### PR TITLE
pghoard: auto-check cronjob

### DIFF
--- a/charts/pghoard/Chart.yaml
+++ b/charts/pghoard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: pghoard
 name: pghoard
-version: 0.6.1
+version: 0.6.2
 maintainers:
 - name: desaintmartin
   email: cdesaintmartin@wiremind.io

--- a/charts/pghoard/Chart.yaml
+++ b/charts/pghoard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: pghoard
 name: pghoard
-version: 0.6.2
+version: 0.7.0
 maintainers:
 - name: desaintmartin
   email: cdesaintmartin@wiremind.io

--- a/charts/pghoard/templates/crontab-restore-autocheck.yaml
+++ b/charts/pghoard/templates/crontab-restore-autocheck.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: restore-autocheck
 spec:
-  schedule: "0 12 * * *"
+  schedule: {{ .Values.restore.schedule }}
   startingDeadlineSeconds: 600
   concurrencyPolicy: "Forbid"
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}

--- a/charts/pghoard/templates/crontab-restore-autocheck.yaml
+++ b/charts/pghoard/templates/crontab-restore-autocheck.yaml
@@ -24,7 +24,7 @@ spec:
             helm.sh/chart: {{ include "pghoard.chart" . }}
             app.kubernetes.io/instance: {{ .Release.Name }}
             app.kubernetes.io/managed-by: {{ .Release.Service }}
-            app.kubernetes.io/component: restore
+            app.kubernetes.io/component: restore-autocheck
             {{ .Release.Name }}-postgresql-client: "true"  # Allows postgresql netpol, from the postgresql helm chart, to accept pghoard
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}

--- a/charts/pghoard/values.yaml
+++ b/charts/pghoard/values.yaml
@@ -38,6 +38,7 @@ successfulJobsHistoryLimit: 1
 failedJobsHistoryLimit: 1
 
 restore:
+  schedule: "0 12 * * *"
   # The number of retries before considering a Job as failed
   retriesNumber: 0
   # after restore, run a query to check that data is here


### PR DESCRIPTION
fix(pghoard): Rectify restore autocheck Pods label to avoid overlapping when selecting by labels, of course no clash was possible between the Job and ReplicaSet controllers, the metadata.ownerReferences field on the Pod and the pod-template-hash label on the ReplicaSet labelselector prevent that.

feat(pghoard): Make it Possible to customize the restore autocheck cronJob schedule