### PR TITLE
[clamav] fix for #22, allowing to set both freshclam and clamav custom configs at same time

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 1.3.1
+version: 1.3.2
 appVersion: "1.8"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/deployment.yaml
+++ b/charts/clamav/templates/deployment.yaml
@@ -26,14 +26,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.freshclamConfig }}
           volumeMounts:
+{{- if .Values.freshclamConfig }}
           - name: freshclam-config-volume
             mountPath: /etc/clamav/freshclam.conf
             subPath: freshclam.conf
 {{- end }}
 {{- if .Values.clamdConfig }}
-          volumeMounts:
           - name: clamd-config-volume
             mountPath: /etc/clamav/clamd.conf
             subPath: clamd.conf
@@ -58,14 +57,13 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.freshclamConfig }}
       volumes:
+{{- if .Values.freshclamConfig }}
         - name: freshclam-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-freshclam
 {{- end }}
 {{- if .Values.clamdConfig }}
-      volumes:
         - name: clamd-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-clamd


### PR DESCRIPTION
This PR will be fix #22 which currently won't allow you to set both the custom config (clamd and freshclam)

**Using the local version for testing:**

```
$ helm template test --namespace test --values https://gist.githubusercontent.com/C123R/c0ae8a5e44205fcd965a9ab70150a7e6/raw/e32f27762afa415486c4e4abff10daef72fe7acc/values.yml  ~/github.com/wiremind-helm-charts/charts/clamav/ | grep volume

volumeMounts:
          - name: freshclam-config-volume
          - name: clamd-config-volume
volumes:
        - name: freshclam-config-volume
        - name: clamd-config-volume
 ```
