### PR TITLE
adding service annotations to support aws nlb

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.0.0
+version: 2.1.0
 appVersion: "1.8"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/service.yaml
+++ b/charts/clamav/templates/service.yaml
@@ -2,11 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "clamav.fullname" . }}
-{{- if .Values.service.annotationsEnabled -}}
 {{- with .Values.service.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
-{{- end }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "clamav.name" . }}

--- a/charts/clamav/templates/service.yaml
+++ b/charts/clamav/templates/service.yaml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "clamav.fullname" . }}
+{{- if .Values.service.annotationsEnabled -}}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "clamav.name" . }}
     helm.sh/chart: {{ include "clamav.chart" . }}

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -21,12 +21,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 3310
-  annotationsEnabled: false
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
-    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
-    external-dns.alpha.kubernetes.io/hostname: chart-example.local
-    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Name=clamav-nlb,product=Core,env=dev,app=kubernetes"
+  annotations: {}
 
 ingress:
   enabled: false

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -21,6 +21,12 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 3310
+  annotationsEnabled: false
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    external-dns.alpha.kubernetes.io/hostname: chart-example.local
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Name=clamav-nlb,product=Core,env=dev,app=kubernetes"
 
 ingress:
   enabled: false


### PR DESCRIPTION
adding service annotations to have more control while defining the service types 

**--dry run**

```
# Source: clamav/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: clamav
  labels:
    app.kubernetes.io/name: clamav
    helm.sh/chart: clamav-2.0.0
    app.kubernetes.io/instance: clamav
    app.kubernetes.io/managed-by: Helm
spec:
  type: LoadBalancer
  ports:
    - port: 3310
      targetPort: 3310
      protocol: TCP
      name: clamavport
  selector:
    app.kubernetes.io/name: clamav
    app.kubernetes.io/instance: clamav
```