### PR TITLE
feat(karma): allow configuration of a ServiceMonitor

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 1.8.3
+version: 1.9.0
 appVersion: "0.91"
 maintainers:
   - name: desaintmartin

--- a/charts/karma/templates/servicemonitor.yaml
+++ b/charts/karma/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "karma.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "karma.name" . }}
+    helm.sh/chart: {{ include "karma.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+{{- end }}
+{{- with .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  jobLabel: app.kubernetes.io/name
+  endpoints:
+  - port: http
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    path: /metrics
+    honorLabels: true
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "karma.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/karma/values.schema.json
+++ b/charts/karma/values.schema.json
@@ -130,6 +130,29 @@
                 }
             }
         },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "additionalLabels": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "metricRelabelings": {
+                    "type": "array"
+                },
+                "relabelings": {
+                    "type": "array"
+                }
+            }
+        },
         "tolerations": {
             "type": "array"
         }

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -52,6 +52,18 @@ ingress:
 deployment:
   annotations: {}
 
+serviceMonitor:
+  enabled: false
+  interval: 15s
+  additionalLabels:
+    {}
+  annotations:
+    {}
+  metricRelabelings:
+    []
+  relabelings:
+    []
+
 resources:
   {}
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This pull request allows to easily enable a [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator) for Karma which is used by the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) to fetch metrics.