### PR TITLE
fix(json): change schema type for env

### DIFF
--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.10.4
+version: 1.10.5
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool to manage ElasticSearch

--- a/charts/cerebro/values.schema.json
+++ b/charts/cerebro/values.schema.json
@@ -59,7 +59,7 @@
             }
         },
         "env": {
-            "type": "null"
+            "type": "object"
         },
         "image": {
             "type": "object",

--- a/charts/cerebro/values.yaml
+++ b/charts/cerebro/values.yaml
@@ -54,7 +54,7 @@ tolerations: []
 
 affinity: {}
 
-env:
+env: {}
   # AUTH_TYPE: "basic"
   # BASIC_AUTH_USER: "admin"
 


### PR DESCRIPTION
Fix env type

```bash
helm diff upgrade dashboard-es-cerebro wiremind/cerebro --namespace monitoring  -f values/elasticsearch/${ENV}/cerebro-values.yaml --version 1.10.4
Error: Failed to render chart: exit status 1: Error: values don't meet the specifications of the schema(s) in the following chart(s):
cerebro:
- env: Invalid type. Expected: null, given: object


Error: plugin "diff" exited with error
```