### PR TITLE
Clamav hpa fix, convert HorizontalPodAutoscaler to reference based on StatefulSet

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.3.0
+version: 2.2.1
 appVersion: "1.8"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.2.0
+version: 2.3.0
 appVersion: "1.8"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/hpa.yaml
+++ b/charts/clamav/templates/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: {{ template "clamav.fullname" . }}
   minReplicas: {{ .Values.replicaCount }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}

--- a/charts/clamav/values.schema.json
+++ b/charts/clamav/values.schema.json
@@ -106,7 +106,7 @@
       ]
     },
     "clamdConfig": {
-      "type": "object"
+      "type": ["object", "string"]
     },
     "freshclamConfig": {
       "type": ["object", "string"]


### PR DESCRIPTION
ClamAV chart
fix HPA, the scaleTargetRef kind should be a StatefulSet, there are no deployments in this chart
allow  clamdConfig to be a String for multi-line strings object mapping