### PR TITLE
cerebro: add Kubernetes ServiceAccount

### DIFF
--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.10.6
+version: 1.11.0
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool to manage ElasticSearch

--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 1.10.5
+version: 1.10.6
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool to manage ElasticSearch

--- a/charts/cerebro/templates/_helpers.tpl
+++ b/charts/cerebro/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "cerebro.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cerebro.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cerebro.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cerebro/templates/deployment.yaml
+++ b/charts/cerebro/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "cerebro.serviceAccountName" . }}
       {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}

--- a/charts/cerebro/templates/serviceaccount.yaml
+++ b/charts/cerebro/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cerebro.serviceAccountName" . }}
+  labels:
+    app: {{ template "cerebro.name" . }}
+    chart: {{ template "cerebro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.serviceAccount.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cerebro/values.schema.json
+++ b/charts/cerebro/values.schema.json
@@ -198,6 +198,24 @@
                 }
             }
         },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "name": {
+                    "type": "string"
+                }
+
+            }
+        },
         "tolerations": {
             "type": "array"
         }

--- a/charts/cerebro/values.yaml
+++ b/charts/cerebro/values.yaml
@@ -88,3 +88,14 @@ config:
 #       defaultMode: 420
 #       optional: false
 #       secretName: cerebro_ca_cert_secret
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # Labels to add to the service account
+  labels: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
Add the ability for the cerebro Helm Chart to manage a Kubernetes ServiceAccount resource. On certain cloud providers, a ServiceAccount can be directly associated with a cloud provider role. For example, see [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) or [AWS IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). This cloud provider feature is enabled by adding an annotation to the ServiceAccount.

@desaintmartin , @machine424 , @francoisminaud you're listed as maintainers of this chart. I thought I'd mention you here so that you can see and review this. Thanks for your help!