### PR TITLE
Cerebro/Ingress

### DIFF
--- a/charts/cerebro/templates/ingress.yaml
+++ b/charts/cerebro/templates/ingress.yaml
@@ -34,8 +34,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/cerebro/templates/ingress.yaml
+++ b/charts/cerebro/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cerebro.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }} extensions/v1beta1 {{- else }} networking.k8s.io/v1 {{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/cerebro/templates/ingress.yaml
+++ b/charts/cerebro/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cerebro.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
+apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }} extensions/v1beta1 {{- else }} networking.k8s.io/v1 {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122