### PR TITLE
feat-kthxbyeSidecar-karma-chart

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.0.5
+version: 2.0.6
 kubeVersion: '>= 1.19-0'
 appVersion: "v0.99"
 maintainers:

--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.0.6
+version: 2.1.0
 kubeVersion: '>= 1.19-0'
 appVersion: "v0.99"
 maintainers:

--- a/charts/karma/README.md
+++ b/charts/karma/README.md
@@ -100,3 +100,29 @@ existingSecretConfig:
 ```
 
 **NOTE:** you can either use `existingSecretConfig` or `configMap`, it cannot be both.
+
+
+### kthxbye sidecar added by streamotion
+kthxbye is a tiny daemon that can help with managing short lived acknowledged silences.
+It will continuously extend short lived acknowledgement silences if there are alerts firing against those silences,
+which means that the user doesn't need to worry about setting proper duration for such silences.
+
+```yml
+# values.yaml
+kthxbyeSidecar:
+  enabled: false
+  image:
+    repository: ghcr.io/prymitive/kthxbye
+    tag:  v0.14
+    pullPolicy: IfNotPresent
+  alertmanagerServiceName: prometheus-alertmanager
+  alertmanagerServicePort: 80
+  extraArgs: {}
+    # alertmanager.timeout: <duration> #Alertmanager request timeout (default 1m0s)
+    # extend-by: <duration> # Extend silences by adding DURATION seconds (default 15m0s)
+    # extend-if-expiring-in: <duration> # Extend silences that are about to expire in the next DURATION seconds (default 5m0s)
+    # extend-with-prefix: <string> # Extend silences with comment starting with PREFIX string (default "ACK!")
+    # interval: <duration> # Silence check interval (default 45s)
+    # max-duration=<duration> # Maximum duration of a silence, it won't be extended anymore after reaching it
+  logJson: false
+```

--- a/charts/karma/README.md
+++ b/charts/karma/README.md
@@ -102,7 +102,7 @@ existingSecretConfig:
 **NOTE:** you can either use `existingSecretConfig` or `configMap`, it cannot be both.
 
 
-### kthxbye sidecar added by streamotion
+### kthxbye sidecar
 kthxbye is a tiny daemon that can help with managing short lived acknowledged silences.
 It will continuously extend short lived acknowledgement silences if there are alerts firing against those silences,
 which means that the user doesn't need to worry about setting proper duration for such silences.

--- a/charts/karma/README.md
+++ b/charts/karma/README.md
@@ -110,19 +110,5 @@ which means that the user doesn't need to worry about setting proper duration fo
 ```yml
 # values.yaml
 kthxbyeSidecar:
-  enabled: false
-  image:
-    repository: ghcr.io/prymitive/kthxbye
-    tag:  v0.14
-    pullPolicy: IfNotPresent
-  alertmanagerServiceName: prometheus-alertmanager
-  alertmanagerServicePort: 80
-  extraArgs: {}
-    # alertmanager.timeout: <duration> #Alertmanager request timeout (default 1m0s)
-    # extend-by: <duration> # Extend silences by adding DURATION seconds (default 15m0s)
-    # extend-if-expiring-in: <duration> # Extend silences that are about to expire in the next DURATION seconds (default 5m0s)
-    # extend-with-prefix: <string> # Extend silences with comment starting with PREFIX string (default "ACK!")
-    # interval: <duration> # Silence check interval (default 45s)
-    # max-duration=<duration> # Maximum duration of a silence, it won't be extended anymore after reaching it
-  logJson: false
+  enabled: true
 ```

--- a/charts/karma/README.md
+++ b/charts/karma/README.md
@@ -112,3 +112,4 @@ which means that the user doesn't need to worry about setting proper duration fo
 kthxbyeSidecar:
   enabled: true
 ```
+**NOTE:** kthxbye-sidecar in karma does not support multiple alertmanager.uri. this means if you have multiple

--- a/charts/karma/ci/test-values.yaml
+++ b/charts/karma/ci/test-values.yaml
@@ -8,3 +8,8 @@ ingress:
   - chart-example.local
   path: /
   pathType: ImplementationSpecific
+
+kthxbyeSidecar:
+  enabled: true
+  alertmanagerServiceName: prometheus-alertmanager
+  alertmanagerServicePort: 80

--- a/charts/karma/templates/deployment.yaml
+++ b/charts/karma/templates/deployment.yaml
@@ -80,6 +80,20 @@ spec:
               mountPath: /etc/certs/{{ . }}
               readOnly: true
           {{- end }}
+        {{- if .Values.kthxbyeSidecar.enabled }}
+        - name: kthxbye-sidecar
+          image: "{{ .Values.kthxbyeSidecar.image.repository }}:{{ .Values.kthxbyeSidecar.image.tag }}"
+          imagePullPolicy: "{{ .Values.kthxbyeSidecar.image.pullPolicy }}"
+          args:
+            - --listen=:80
+            - --alertmanager.uri=http://{{ .Values.kthxbyeSidecar.alertmanagerServiceName }}:{{ .Values.kthxbyeSidecar.alertmanagerServicePort }}
+          {{- range $key, $value := .Values.kthxbyeSidecar.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          {{- if .Values.kthxbyeSidecar.logJson }}
+            - --log-json
+          {{- end }}
+         {{- end }}    
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/karma/templates/deployment.yaml
+++ b/charts/karma/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           image: "{{ .Values.kthxbyeSidecar.image.repository }}:{{ .Values.kthxbyeSidecar.image.tag }}"
           imagePullPolicy: "{{ .Values.kthxbyeSidecar.image.pullPolicy }}"
           args:
-            - --listen=:80
+            - --listen=:8082
             - --alertmanager.uri=http://{{ .Values.kthxbyeSidecar.alertmanagerServiceName }}:{{ .Values.kthxbyeSidecar.alertmanagerServicePort }}
           {{- range $key, $value := .Values.kthxbyeSidecar.extraArgs }}
             - --{{ $key }}={{ $value }}
@@ -93,7 +93,12 @@ spec:
           {{- if .Values.kthxbyeSidecar.logJson }}
             - --log-json
           {{- end }}
-         {{- end }}    
+         {{- end }}
+        {{- if .Values.securityContext }}
+          securityContext:
+            runAsUser: 2000
+            allowPrivilegeEscalation: false
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -193,5 +193,5 @@ kthxbyeSidecar:
     # extend-if-expiring-in: <duration> # Extend silences that are about to expire in the next DURATION seconds (default 5m0s)
     # extend-with-prefix: <string> # Extend silences with comment starting with PREFIX string (default "ACK!")
     # interval: <duration> # Silence check interval (default 45s)
-    # max-duration=<duration> # Maximum duration of a silence, it won't be extended anymore after reaching it
+    # max-duration: <duration> # Maximum duration of a silence, it won't be extended anymore after reaching it
   logJson: false

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -175,3 +175,23 @@ configMap:
 # `configMap.rawConfig.alertmanager.servers[].tls.ca`.
 ## Ref: <https://github.com/prymitive/karma/blob/master/docs/CONFIGURATION.md#alertmanagers>.
 certSecretNames: []
+
+## kthxbye is a tiny daemon that can help with managing short lived acknowledged silences.
+## It will continuously extend short lived acknowledgement silences if there are alerts firing against those silences,
+## which means that the user doesn't need to worry about setting proper duration for such silences.
+kthxbyeSidecar:
+  enabled: false
+  image:
+    repository: ghcr.io/prymitive/kthxbye
+    tag:  v0.14
+    pullPolicy: IfNotPresent
+  alertmanagerServiceName: prometheus-alertmanager
+  alertmanagerServicePort: 80
+  extraArgs: {}
+    # alertmanager.timeout: <duration> #Alertmanager request timeout (default 1m0s)
+    # extend-by: <duration> # Extend silences by adding DURATION seconds (default 15m0s)
+    # extend-if-expiring-in: <duration> # Extend silences that are about to expire in the next DURATION seconds (default 5m0s)
+    # extend-with-prefix: <string> # Extend silences with comment starting with PREFIX string (default "ACK!")
+    # interval: <duration> # Silence check interval (default 45s)
+    # max-duration=<duration> # Maximum duration of a silence, it won't be extended anymore after reaching it
+  logJson: false

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -183,7 +183,7 @@ kthxbyeSidecar:
   enabled: false
   image:
     repository: ghcr.io/prymitive/kthxbye
-    tag:  v0.14
+    tag: v0.14
     pullPolicy: IfNotPresent
   alertmanagerServiceName: prometheus-alertmanager
   alertmanagerServicePort: 80


### PR DESCRIPTION
- instead of add kthxbye sidecar in alertmanager. add the  kthxbyeSidecar in karma chart. 
- point the alertmanager.uri to alertmanager service and port
-  listen to port 80 as 8080 is already used by karma