### PR TITLE
Closes #157 fix typo for configFromSecretRef.

### DIFF
--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 2.0.1
+version: 2.0.2
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool to manage ElasticSearch

--- a/charts/cerebro/values.yaml
+++ b/charts/cerebro/values.yaml
@@ -62,9 +62,10 @@ env: {}
 # Reference to a Secret object with environment variables
 # envFromSecretRef: 'my-secret-ref'
 
-# if config is coming from a k8s secret, give the secret name
-# configFromSecertRef: 'my-secret-config-name'
+# Allows you to add "application.conf" from a kubernetes secret
+# configFromSecretRef: '<secret-with-key-application.conf>'
 
+# "config" will be ignored if "configFromSecretRef" is set.
 config:
   basePath: '/'
   restHistorySize: 50


### PR DESCRIPTION
The `configFromSecretRef` configuration option addressed in #69 had a typo in `values.yaml`.
This PR updates the example configuration.