### PR TITLE
Fixes Kubernetes version comparison in igress API version computation.

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex
-version: 2.15.5
+version: 2.15.6
 appVersion: 2.24.0
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 keywords:

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "dex.fullname" . -}}
 {{- $servicePort := .Values.ports.web.servicePort -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- $use_networking_v1 := semverCompare ">= 1.19.0" .Capabilities.KubeVersion.Version -}}
+{{- $use_networking_v1 := semverCompare ">= 1.19.0" (regexReplaceAll "v?([^+-]*).*" .Capabilities.KubeVersion.Version "${1}") -}}
 apiVersion: {{ $use_networking_v1 | ternary "networking.k8s.io/v1" "extensions/v1beta1" }}
 kind: Ingress
 metadata:


### PR DESCRIPTION
Some cloud-hosted Kubernetes clusters return the version from `.Capabilities.KubeVersion.Version` that is not SemVer compatible (e.g., `v1.22.6-eks-14c7a48` - not the `v` in front). The `semverCompare` function fails on such versions, so this PR strips the leading V and the trailing pre-release label (which also trips `semverCompare`) before comparing. With version 1.22 rolling out, this becomes important, as it no longer accepts `extensions/v1beta1`.