### PR TITLE
Adding startup probe to avoid startup dependency on readiness/liveness probe

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.6.0
+version: 2.6.1
 appVersion: "1.9"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/statefulset.yaml
+++ b/charts/clamav/templates/statefulset.yaml
@@ -55,6 +55,13 @@ spec:
             - name: clamavport
               containerPort: 3310
               protocol: TCP
+          startupProbe:
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            tcpSocket:
+              port: clamavport
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -179,6 +179,12 @@ tolerations: []
 
 affinity: {}
 
+startupProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 3
+  timeoutSeconds: 1
+
 livenessProbe:
   initialDelaySeconds: 300
   periodSeconds: 10


### PR DESCRIPTION
Startup probe is sometime needed to avoid the initial health check going to readiness/liveness probe. Adding it, to be useful for the downstream usage.