### PR TITLE
Add `apiVersion: policy/v1` to the PDB template for Kubernetes 1.25

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex
-version: 2.15.6
+version: 2.15.7
 appVersion: 2.24.0
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 keywords:

--- a/charts/dex/templates/poddisruptionbudget.yaml
+++ b/charts/dex/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "dex.fullname" . }}


### PR DESCRIPTION
This PR adds `apiVersion: policy/v1` to the PDB template.  `policy/v1beta1` is removed in Kubernetes 1.25 - https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125