### PR TITLE
fix(clamav): use github repo instead of docker, bump to 1.9.50

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.7.0
-appVersion: "1.9.43"
+version: 2.7.1
+appVersion: "1.9.50"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 sources:

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   # TODO: Switch to clamav/clamav container
-  repository: mailu/clamav
+  repository: ghcr.io/mailu/clamav
   tag: ""  # If not defined, uses appVersion
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
https://mailu.io/master/releases.html#mailu-2-0-2023-04-03

> The Mailu project has moved to ghcr.io for hosting the docker images. The images on docker.io will be taken down after this release.

Oldest version on their github repo is 1.9.50:
- https://github.com/mailu/Mailu/pkgs/container/clamav/77893510?tag=1.9
- https://github.com/mailu/Mailu/pkgs/container/clamav/77893510?tag=1.9.50