### PR TITLE
Upgrade clamav k8s ingress version

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.7.1
+version: 2.8.0
 appVersion: "1.9.50"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
@@ -13,3 +13,4 @@ sources:
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts
+kubeVersion: ">=1.19.0"

--- a/charts/clamav/README.md
+++ b/charts/clamav/README.md
@@ -18,7 +18,7 @@ This chart bootstraps a ClamAV deployment and service on a Kubernetes cluster us
 
 ## Prerequisites
 
-- Kubernetes 1.9+
+- Kubernetes 1.19+
 
 ## Installing the Chart
 

--- a/charts/clamav/templates/ingress.yaml
+++ b/charts/clamav/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "clamav.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -30,9 +30,12 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: clamavport
-  {{- end }}
+        - backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: clamavport
+          path: {{ $ingressPath }}
+          pathType: Prefix
+  {{- end -}}
 {{- end }}


### PR DESCRIPTION
The code here upgrades k8s version for `clamav` ingress, minimal k8s version to 1.19 per the deprecation guide.