### PR TITLE
chore(buildkitd): version 0.8.1

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: buildkitd
 description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
-appVersion: 0.12.0
+appVersion: 0.12.1
 kubeVersion: ">=1.19.0-0"
-version: 0.8.0
+version: 0.8.1
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: moby/buildkit
   pullPolicy: IfNotPresent
-  tag: "v0.12.0-rootless"
+  tag: "v0.12.1-rootless"
 
 # User 1000 is used in official images
 user:


### PR DESCRIPTION
Use buildkit version 0.12.1-rootless by default.