### PR TITLE
fix(buildkitd): fsGroup is not declared in schema

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
 appVersion: 0.12.2
 kubeVersion: ">=1.19.0-0"
-version: 0.10.1
+version: 0.10.2
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -114,7 +114,6 @@ spec:
             runAsNonRoot: true
             runAsUser: {{ .Values.user.uid }}
             runAsGroup:  {{ .Values.user.gid }}
-            fsGroup: {{ .Values.user.uid }}
             {{- with .Values.extraSecurityContext }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
There is a difference between pod level securitycontext and container level.
fsGroup is not defined on pod level.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core