### PR TITLE
feat(istio): upgrade istio operator crds to 1.18.2

### DIFF
--- a/charts/istio-operator-crds/Chart.yaml
+++ b/charts/istio-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ annotations:
   category: DeveloperTools
 apiVersion: v2
 name: istio-operator-crds
-version: 1.17.5
-appVersion: "1.17.5"
+version: 1.18.2
+appVersion: "1.18.2"
 description: Manage istio-operator CRDs
 keywords:
   - istio


### PR DESCRIPTION
It seems there is no change from 1.17 to 1.18 regarding CRDs.