### PR TITLE
Support container level securityContext values for Cerebro

### DIFF
--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 2.0.3
+version: 2.0.4
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool to manage ElasticSearch

--- a/charts/cerebro/templates/deployment.yaml
+++ b/charts/cerebro/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:
-{{ toYaml .Values.podSecurityContext | indent 12}}
+{{ toYaml .Values.containerSecurityContext | indent 12}}
       volumes:
         - name: db
           emptyDir: {}

--- a/charts/cerebro/templates/deployment.yaml
+++ b/charts/cerebro/templates/deployment.yaml
@@ -98,6 +98,8 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+{{ toYaml .Values.podSecurityContext | indent 12}}
       volumes:
         - name: db
           emptyDir: {}

--- a/charts/cerebro/values.yaml
+++ b/charts/cerebro/values.yaml
@@ -45,6 +45,14 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 1000
 
+podSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+
 priorityClassName: ""
 
 resources: {}

--- a/charts/cerebro/values.yaml
+++ b/charts/cerebro/values.yaml
@@ -45,7 +45,7 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 1000
 
-podSecurityContext:
+containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
I noticed the Cerebro chart supports pod level security context values but not at the container level. This should add support for the latter.