### PR TITLE
fix: sha change detection only on tier's part

### DIFF
--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Apache Druid is a high performance real-time analytics database.
 name: druid
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 26.0.0
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png

--- a/charts/druid/templates/historical/statefulset.yaml
+++ b/charts/druid/templates/historical/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         # This restarts all historicals for now as we use the same file
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
-        checksum/configmap-historicals: {{ include (print $.Template.BasePath "/historical/configmap.yaml") (print "$historical.tiers." $tierName) | sha256sum }}
+        checksum/configmap-historicals: {{ (print $tierValue) | sha256sum }}
         checksum/secret-historicals: {{ include (print $.Template.BasePath "/historical/secret.yaml") $ | sha256sum }}
 {{- with $historicalDefaults.podAnnotations }}
 {{ toYaml . | indent 8 }}

--- a/charts/druid/templates/historical/statefulset.yaml
+++ b/charts/druid/templates/historical/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         # This restarts all historicals for now as we use the same file
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
-        checksum/configmap-historicals: {{ include (print $.Template.BasePath "/historical/configmap.yaml") $(print "historical.tiers." $tierName) | sha256sum }}
+        checksum/configmap-historicals: {{ include (print $.Template.BasePath "/historical/configmap.yaml") (print "$historical.tiers." $tierName) | sha256sum }}
         checksum/secret-historicals: {{ include (print $.Template.BasePath "/historical/secret.yaml") $ | sha256sum }}
 {{- with $historicalDefaults.podAnnotations }}
 {{ toYaml . | indent 8 }}

--- a/charts/druid/templates/historical/statefulset.yaml
+++ b/charts/druid/templates/historical/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         # This restarts all historicals for now as we use the same file
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
-        checksum/configmap-historicals: {{ include (print $.Template.BasePath "/historical/configmap.yaml") $ | sha256sum }}
+        checksum/configmap-historicals: {{ include (print $.Template.BasePath "/historical/configmap.yaml") $(print "historical.tiers." $tierName) | sha256sum }}
         checksum/secret-historicals: {{ include (print $.Template.BasePath "/historical/secret.yaml") $ | sha256sum }}
 {{- with $historicalDefaults.podAnnotations }}
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
Today, change a single tier config makes every tier being redeployed. This is way too costly. I propose to only detection config changes per tier.  
cf doc: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-include-function