### PR TITLE
fix(druid): broker: do not override host if HPA enabled

### DIFF
--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Apache Druid is a high performance real-time analytics database.
 name: druid
 type: application
-version: 1.10.1
+version: 1.10.2
 appVersion: 26.0.0
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png

--- a/charts/druid/templates/broker/deployment.yaml
+++ b/charts/druid/templates/broker/deployment.yaml
@@ -54,8 +54,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- if .Values.service.overrideDruidHost }}
+            {{- if not .Values.broker.autoscaling.enabled }}
             - name: druid_host
               value: {{ include "druid.broker.fullname" $ }}
+            {{- end }}
             {{- end }}
             - name: druid_extensions_loadList
               value: {{ .Values.extensions.loadList | toJson | quote }}


### PR DESCRIPTION
Druid does not handle service loadbalancing
It needs unique pod IP
If we want pod DNS resolution, implement StatefulSet for brokers