### PR TITLE
fix(pythie): use autoscaler/v2 API for kube 1.26+

### DIFF
--- a/charts/pythie/Chart.yaml
+++ b/charts/pythie/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pythie
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.0"
 description: Serve machine learning models with tensorflow and pythie
 keywords:

--- a/charts/pythie/templates/pythie-serving-hpa.yaml
+++ b/charts/pythie/templates/pythie-serving-hpa.yaml
@@ -3,7 +3,13 @@
 {{- if $modelValue.autoscaling }}
 {{- if $modelValue.autoscaling.enabled }}
 
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+# See: autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+,
+# unavailable in v1.26+
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: model-{{ $modelName }}


### PR DESCRIPTION
autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler

See: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/