### PR TITLE
fix: remove hardcoded default storageClassName

### DIFF
--- a/charts/druid/templates/historical/statefulset.yaml
+++ b/charts/druid/templates/historical/statefulset.yaml
@@ -155,7 +155,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        storageClassName: {{ default "standard" $historicalDefaults.persistence.storageClass }}
+        storageClassName: {{ default "" $historicalDefaults.persistence.storageClass }}
         resources:
           requests:
             storage: "{{ $tierValue.persistence.size }}"


### PR DESCRIPTION
Fixes https://github.com/wiremind/wiremind-helm-charts/issues/529