### PR TITLE
fix(clamav): implement ability to specify pod annotations

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.8.1
+version: 2.8.2
 appVersion: "1.9.50"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/statefulset.yaml
+++ b/charts/clamav/templates/statefulset.yaml
@@ -12,6 +12,10 @@ spec:
       {{- include "clamav.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "clamav.selectorLabels" . | nindent 8 }}
         {{- if .Values.podLabels }}

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -175,6 +175,7 @@ resources: {}
 
 # Additional pod labels
 podLabels: {}
+podAnnotations: {}
 
 nodeSelector: {}
 


### PR DESCRIPTION
Implementation of the option to set additional pod annotations with `podAnnotations`. So far only pod labels could be set