### PR TITLE
chore(buildkitd): upgrade to 0.13.0

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: buildkitd
 description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
-appVersion: 0.12.5
+appVersion: 0.13.0
 kubeVersion: ">=1.19.0-0"
-version: 0.11.6
+version: 0.12.0
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/buildkitd/templates/configmap.yaml
+++ b/charts/buildkitd/templates/configmap.yaml
@@ -13,6 +13,15 @@ data:
     # See: https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md
     rootless = true
     debug = {{ .Values.config.debug }}
+    trace = {{ .Values.config.trace }}
+
+    [log]
+      # log formatter: json or text
+      format = {{ .Values.config.logFormat | quote }}
+
+    [otel]
+      # OTEL collector trace socket path
+      socketPath = "/run/{{ .Values.user.name }}/{{ .Values.user.uid }}/buildkit/otel-grpc.sock"
 
     [grpc]
       address = [ "tcp://0.0.0.0:{{ .Values.config.port }}" ]
@@ -84,3 +93,8 @@ data:
   XDG_RUNTIME_DIR: "/run/{{ .Values.user.name }}/{{ .Values.user.uid }}"
   TMPDIR: "/home/{{ .Values.user.name }}/.local/tmp"
   BUILDKIT_HOST: "tcp://localhost:{{ .Values.config.port }}"
+  OTEL_SERVICE_NAME: {{ template "buildkitd.fullname" . }}
+  OTEL_METRICS_EXPORTER: {{ .Values.config.otel.metricsExporter | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.config.otel.otlpEndpoint | quote }}
+  OTEL_EXPORTER_OTLP_COMPRESSION: {{ .Values.config.otel.compression | quote }}
+  OTEL_EXPORTER_OTLP_TIMEOUT: {{ .Values.config.otel.timeout | quote }}

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -41,7 +41,14 @@ affinity: {}
 
 config:
   debug: false
+  trace: false
+  logFormat: "text"
   port: 12345
+  otel:
+    metricsExporter: "none"
+    otlpEndpoint: ""
+    compression: "gzip"
+    timeout: 10
   gc:
     enabled: true
     keepstoragePercentage: 0.90


### PR DESCRIPTION
Changes:
- use 0.13.0-rootless image by default
- log format choice (json or text)
- trace toggle
- opentelemetry metrics & traces export

See: https://github.com/moby/buildkit/releases/tag/v0.13.0