### PR TITLE
fix(clamav): Switch to official clamav image

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 2.8.3
-appVersion: "1.9.50"
+version: 3.0.0
+appVersion: "1.3.0"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 sources:

--- a/charts/clamav/templates/_helpers.tpl
+++ b/charts/clamav/templates/_helpers.tpl
@@ -63,3 +63,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "clamav.entrypoint" -}}
+{{- if .Values.entrypoint -}}
+{{ .Values.entrypoint }}
+{{- else if eq (default 0 .Values.podSecurityContext.runAsUser | int) 0 -}}
+/init
+{{- else -}}
+/init-unprivileged
+{{- end -}}
+{{- end -}}

--- a/charts/clamav/templates/statefulset.yaml
+++ b/charts/clamav/templates/statefulset.yaml
@@ -35,7 +35,9 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s_base" .Chart.AppVersion) }}"
+          command:
+            - {{ include "clamav.entrypoint" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -5,8 +5,7 @@
 replicaCount: 1
 
 image:
-  # TODO: Switch to clamav/clamav container
-  repository: ghcr.io/mailu/clamav
+  repository: clamav/clamav
   tag: ""  # If not defined, uses appVersion
   pullPolicy: IfNotPresent
 
@@ -23,8 +22,9 @@ fullnameOverride: ""
 
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 2000
-  runAsGroup: 2000
+  runAsUser: 100
+  runAsGroup: 101
+  fsGroup: 101
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -73,8 +73,6 @@ clamdConfig: |
   # CUSTOM: Use pid file in tmp
   PidFile /tmp/clamd.pid
   LocalSocket /tmp/clamd.sock
-  # CUSTOM: Set local socket group to defined group id
-  LocalSocketGroup 2000
   TCPSocket 3310
   Foreground yes
 


### PR DESCRIPTION
I chose the _base version of the image because the previously used MailU version didn't include a database either.

Fixes #325
Fixes #432
