### PR TITLE
feat(clamav): Allow specifying extra env vars

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 3.0.0
+version: 3.1.0
 appVersion: "1.3.0"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/statefulset.yaml
+++ b/charts/clamav/templates/statefulset.yaml
@@ -39,6 +39,18 @@ spec:
           command:
             - {{ include "clamav.entrypoint" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraEnvVars }}
+          env: {{- toYaml . | nindent 10 }}
+          {{- end }}
+          envFrom:
+          {{- with .Values.extraEnvVarsCM }}
+          - configMapRef:
+              name: {{ . }}
+          {{- end }}
+          {{- with .Values.extraEnvVarsSecret }}
+          - secretRef:
+              name: {{ . }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -46,6 +46,10 @@ service:
   # nodePort: 30100
   annotations: {}
 
+extraEnvVars: {}
+extraEnvVarsCM: ""
+extraEnvVarsSecret: ""
+
 ingress:
   enabled: false
 # ingressClassName: ""


### PR DESCRIPTION
This is particularly useful for freshclam, since it uses libcurl and can thus use `https_proxy` for the proxy and `CURL_CA_BUNDLE` for additional/alternate CA certificates.

(While there are proxy-related settings in `freshclam.conf`, it is difficult to configure proxy authentication there, since `HTTPProxyPassword` imposes additional security requirements on the config file, which aren't easily satisfied in a Kubernetes context.)