### PR TITLE
feat(buildkitd): lifecycle and terminationGracePeriodSeconds

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
 appVersion: 0.13.2
 kubeVersion: ">=1.19.0-0"
-version: 0.13.3
+version: 0.14.0
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -139,6 +139,10 @@ spec:
             {{- with .Values.extraSecurityContext }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
@@ -154,6 +158,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   volumeClaimTemplates:
     - kind: PersistentVolumeClaim
       apiVersion: v1

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -108,3 +108,7 @@ startupProbe:
   retries: 60
 
 extraSecurityContext: {}
+
+lifecycle: {}
+
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
* add lifecycle to statefulset.yaml and values.yaml

add lifecycle to buildkitd - useful for running a pre-stop hook to make sure all build jobs can run to completion before terminating the pod

* add terminationGracePeriodSeconds to statefulset.yaml and values.yaml

useful for making sure lifestyle pre-stop hook has enough time to complete