### PR TITLE
feat(safety-exporter): do not crash if safety has not produced json yet, add count of vulnerabilities as safety_vulnerabilities_found, add prometheus rule support, be more tolerant for probes.

### DIFF
--- a/charts/prometheus-safety-exporter/Chart.yaml
+++ b/charts/prometheus-safety-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-safety-exporter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.2
+version: 0.3.0
 appVersion: "0.6.0"
 maintainers:
   - name: Wiremind

--- a/charts/prometheus-safety-exporter/templates/configmap.yaml
+++ b/charts/prometheus-safety-exporter/templates/configmap.yaml
@@ -46,3 +46,9 @@ data:
           values:
             severity: '{ .severity.cvssv3.base_score }'
             detected: 1
+        - name: safety_vulnerabilities
+          type: object
+          help: Python Safety Vulnerabilities found
+          path: '{ .report_meta }'
+          values:
+            found: '{ .vulnerabilities_found }'

--- a/charts/prometheus-safety-exporter/templates/prometheusrule.yaml
+++ b/charts/prometheus-safety-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "prometheus-safety-exporter.fullname" . }}
+{{- with .Values.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    {{- include "prometheus-safety-exporter.labels" . | nindent 4 }}
+{{- with .Values.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ include "prometheus-safety-exporter.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-safety-exporter/values.yaml
+++ b/charts/prometheus-safety-exporter/values.yaml
@@ -74,14 +74,14 @@ jsonExporter:
     httpGet:
       path: /probe?target=http://localhost:8000/results.json
       port: http
-    failureThreshold: 10
+    failureThreshold: 50
   livenessProbe:
     timeoutSeconds: 3
-    periodSeconds: 120
+    periodSeconds: 300
     httpGet:
       path: /probe?target=http://localhost:8000/results.json
       port: http
-    failureThreshold: 3
+    failureThreshold: 5
   readinessProbe:
     timeoutSeconds: 3
     periodSeconds: 120
@@ -89,6 +89,25 @@ jsonExporter:
     httpGet:
       path: /probe?target=http://localhost:8000/results.json
       port: http
+
+## Custom PrometheusRules to be defined
+## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+  namespace: ""
+  rules: []
+    ## These are just examples rules, please adapt them to your needs.
+    ## Make sure to constraint the rules to the current service.
+    #  - alert: NoSafetyVulnerabilitieFoundExist
+    #    expr: safety_vulnerabilities_found{job="{{ .Release.Namespace}}"/{{ include "prometheus-memcached-exporter.fullname" . }}"} == 0
+    #    for: 3h
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Safety has not returned any recent value for {{ "{{ $labels.instance }}" }}
+    #      description: Safety has not returned any recent value for {{ "{{ $labels.instance }}" }}
 
 # Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
feat(safety-exporter):
- do not crash if safety has not produced json yet,
- add count of vulnerabilities as safety_vulnerabilities_found
- add prometheus rule support
- be more tolerant for probes.