### PR TITLE
Allow setting custom serviceAccount.name

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.9.0
+version: 2.9.1
 kubeVersion: ">= 1.19-0"
 appVersion: "v0.120"
 maintainers:

--- a/charts/karma/values.schema.json
+++ b/charts/karma/values.schema.json
@@ -129,7 +129,7 @@
                     "type": "boolean"
                 },
                 "name": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "imagePullSecrets": {
                     "type": "array"

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -36,7 +36,7 @@ serviceAccount:
   create: true
   ## The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the fullname template
-  name:
+  name: ""
   # Automount API credentials for the Service Account
   automountServiceAccountToken: false
   # ImagePullSecrets


### PR DESCRIPTION
```
      Helm install failed: values don't meet the specifications of the schema(s) in the following chart(s):
      karma:
      - serviceAccount.name: Invalid type. Expected: null, given: string
```

This error happens if I use the following values:

```yaml
  values:

    serviceAccount:
      create: false
      name: my-service-account
```