### PR TITLE
Cerebro chart: Don't quote username or password elastic host settings begginning with ${?

### DIFF
--- a/charts/cerebro/templates/secret.yaml
+++ b/charts/cerebro/templates/secret.yaml
@@ -70,7 +70,7 @@ stringData:
 
     hosts = [
       {{- range $index, $element := .Values.config.hosts }}
-      {{ if $index }},{{ end }}
+      {{- if $index }},{{- end }}
       {
         host = {{ $element.host | quote }}
         name = {{ $element.name | quote }}
@@ -79,8 +79,16 @@ stringData:
         {{- end }}
         {{- if $element.auth }}
         auth = {
+          {{- if hasPrefix "${?" $element.auth.username }}
+          username = {{ $element.auth.username }}
+          {{- else }}
           username = {{ $element.auth.username | quote }}
+          {{- end }}
+          {{- if hasPrefix "${?" $element.auth.password }}
+          password = {{ $element.auth.password }}
+          {{- else }}
           password = {{ $element.auth.password | quote }}
+          {{- end }}
         }
         {{- end }}
       }


### PR DESCRIPTION
Remove quotes from auth variables beginning with ${?.

This allows username or password secrets to be interpolated from the environment without needing to provide the entire config file as a custom secret. For my usecase, I have a common login for cerebro, so this allows me to inject that password in via a custom secret defined `envFromSecretRef` and reference it from several elastic host config sections.