### PR TITLE
Update ClamAV to 1.4.1

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 3.1.3
-appVersion: "1.3.0"
+version: 3.2.0
+appVersion: "1.4.1"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 sources:

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -133,7 +133,6 @@ freshclamConfig: |
   ###############
 
   DatabaseDirectory /data
-  UpdateLogFile /dev/stdout
   LogTime yes
   # CUSTOM: Use pid file in tmp
   PidFile /tmp/freshclam.pid


### PR DESCRIPTION
Version 1.4.1 fixes [CVE-2024-20506](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-20506) and hence disallows logfiles that are symlinks. Thus we also have to remove that setting.

Luckily, the output is sent to stdout already, meaning we are actually fixing a bug that caused duplicate log lines.