### PR TITLE
feat(clamav): Make config files dict values

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 3.2.0
+version: 3.3.0
 appVersion: "1.4.1"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/README.md
+++ b/charts/clamav/README.md
@@ -48,6 +48,8 @@ The command removes all the Kubernetes components associated with the chart and 
 The configurable parameters of the ClamAV chart and
 their descriptions can be seen in `values.yaml`. The [full documentation](https://www.clamav.net/documents/clam-antivirus-0-101-0-user-manual) contains more information about running ClamAV in docker.
 
+The config files themselves can either be specified as a plain text value or composed from a dict. In case they are specified via dict, if you give one key a list as a value, the option will be repeated for each value in the list.
+
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Memory Usage

--- a/charts/clamav/templates/_helpers.tpl
+++ b/charts/clamav/templates/_helpers.tpl
@@ -72,3 +72,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 /init-unprivileged
 {{- end -}}
 {{- end -}}
+
+{{- define "clamav.dictToConfig" -}}
+{{- range $key, $value := . -}}
+{{- if kindIs "slice" $value -}}
+{{- range $value -}}
+{{ $key }} {{ . }}
+{{ end }}
+{{- else -}}
+{{ $key }} {{ $value }}
+{{ end }}
+{{- end }}
+{{- end -}}

--- a/charts/clamav/templates/clamd-configmap.yaml
+++ b/charts/clamav/templates/clamd-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clamdConfig -}}
+{{- if or .Values.clamdConfig .Values.clamdConfigDict -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  clamd.conf:
-    {{- toYaml .Values.clamdConfig | nindent 4 }}
+  clamd.conf: |
+    {{- if .Values.clamdConfig }}
+    {{- .Values.clamdConfig | nindent 4 }}
+    {{- else }}
+    {{- include "clamav.dictToConfig" .Values.clamdConfigDict | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/clamav/templates/freshclam-configmap.yaml
+++ b/charts/clamav/templates/freshclam-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.freshclamConfig -}}
+{{- if or .Values.freshclamConfig .Values.clamdConfigDict -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  freshclam.conf:
-    {{- toYaml .Values.freshclamConfig | nindent 4 }}
+  freshclam.conf: |
+    {{- if .Values.freshclamConfig }}
+    {{- .Values.freshclamConfig | nindent 4 }}
+    {{- else }}
+    {{- include "clamav.dictToConfig" .Values.freshclamConfigDict | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/clamav/templates/statefulset.yaml
+++ b/charts/clamav/templates/statefulset.yaml
@@ -59,12 +59,12 @@ spec:
           volumeMounts:
             - name: clamav-data
               mountPath: /data
-            {{- if .Values.freshclamConfig }}
+            {{- if or .Values.freshclamConfig .Values.freshclamConfigDict }}
             - name: freshclam-config-volume
               mountPath: /etc/clamav/freshclam.conf
               subPath: freshclam.conf
             {{- end }}
-            {{- if .Values.clamdConfig }}
+            {{- if or .Values.clamdConfig .Values.clamdConfigDict }}
             - name: clamd-config-volume
               mountPath: /etc/clamav/clamd.conf
               subPath: clamd.conf
@@ -116,12 +116,12 @@ spec:
         - name: clamav-data
           emptyDir: {}
         {{- end }}
-        {{- if .Values.freshclamConfig }}
+        {{- if or .Values.freshclamConfig .Values.freshclamConfigDict }}
         - name: freshclam-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-freshclam
         {{- end }}
-        {{- if .Values.clamdConfig }}
+        {{- if or .Values.clamdConfig .Values.clamdConfigDict }}
         - name: clamd-config-volume
           configMap:
             name: {{ include "clamav.fullname" . }}-clamd

--- a/charts/clamav/values.schema.json
+++ b/charts/clamav/values.schema.json
@@ -111,8 +111,40 @@
     "clamdConfig": {
       "type": ["string"]
     },
+    "clamdConfigDict": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "anyOf": [
+            { "type": ["string", "integer" ] },
+            {
+              "type": "array",
+              "items":[
+                { "type": ["string", "integer" ] }
+              ]
+            }
+          ]
+        }
+      }
+    },
     "freshclamConfig": {
       "type": ["string"]
+    },
+    "freshclamConfigDict": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "anyOf": [
+            { "type": ["string", "integer" ] },
+            {
+              "type": "array",
+              "items":[
+                { "type": ["string", "integer" ] }
+              ]
+            }
+          ]
+        }
+      }
     },
     "resources": {
       "type": "object",
@@ -285,8 +317,6 @@
     "fullnameOverride",
     "service",
     "ingress",
-    "clamdConfig",
-    "freshclamConfig",
     "resources",
     "podLabels",
     "nodeSelector",
@@ -299,5 +329,19 @@
     "extraVolumes",
     "extraVolumeMounts",
     "persistentVolume"
+  ],
+  "allOf":[
+    {
+      "anyOf":[
+        { "required": ["clamdConfig"] },
+        { "required": ["clamdConfigDict"] }
+      ]
+    },
+    {
+      "anyOf":[
+        { "required": ["freshclamConfig"] },
+        { "required": ["freshclamConfigDict"] }
+      ]
+    }
   ]
 }

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -66,87 +66,80 @@ ingress:
 
 ## Ref: https://linux.die.net/man/5/clamd.conf
 ## Note: will completely override default clamd.conf file at https://github.com/Mailu/Mailu/tree/master/optional/clamav/conf
-clamdConfig: |
+clamdConfigDict:
   ###############
   # General
   ###############
-
-  DatabaseDirectory /data
-  TemporaryDirectory /tmp
-  LogTime yes
+  DatabaseDirectory: /data
+  TemporaryDirectory: /tmp
+  LogTime: "yes"
   # CUSTOM: Use pid file in tmp
-  PidFile /tmp/clamd.pid
-  LocalSocket /tmp/clamd.sock
-  TCPSocket 3310
-  Foreground yes
+  PidFile: /tmp/clamd.pid
+  LocalSocket: /tmp/clamd.sock
+  TCPSocket: 3310
+  Foreground: "yes"
 
   ###############
   # Results
   ###############
-
-  DetectPUA yes
-  ExcludePUA NetTool
-  ExcludePUA PWTool
-  HeuristicAlerts yes
-  Bytecode yes
-
-  ###############
-  # Scan
-  ###############
-
-  ScanPE yes
-  DisableCertCheck yes
-  ScanELF yes
-  AlertBrokenExecutables yes
-  ScanOLE2 yes
-  ScanPDF yes
-  ScanSWF yes
-  ScanMail yes
-  PhishingSignatures yes
-  PhishingScanURLs yes
-  ScanHTML yes
-  ScanArchive yes
+  DetectPUA: "yes"
+  ExcludePUA:
+    - NetTool
+    - PWTool
+  HeuristicAlerts: "yes"
+  Bytecode: "yes"
 
   ###############
   # Scan
   ###############
+  ScanPE: "yes"
+  DisableCertCheck: "yes"
+  ScanELF: "yes"
+  AlertBrokenExecutables: "yes"
+  ScanOLE2: "yes"
+  ScanPDF: "yes"
+  ScanSWF: "yes"
+  ScanMail: "yes"
+  PhishingSignatures: "yes"
+  PhishingScanURLs: "yes"
+  ScanHTML: "yes"
+  ScanArchive: "yes"
 
-  MaxScanSize 150M
-  MaxFileSize 30M
-  MaxRecursion 10
-  MaxFiles 15000
-  MaxEmbeddedPE 10M
-  MaxHTMLNormalize 10M
-  MaxHTMLNoTags 2M
-  MaxScriptNormalize 5M
-  MaxZipTypeRcg 1M
-  MaxPartitions 128
-  MaxIconsPE 200
-  PCREMatchLimit 10000
-  PCRERecMatchLimit 10000
+  MaxScanSize: 150M
+  MaxFileSize: 30M
+  MaxRecursion: 10
+  MaxFiles: 15000
+  MaxEmbeddedPE: 10M
+  MaxHTMLNormalize: 10M
+  MaxHTMLNoTags: 2M
+  MaxScriptNormalize: 5M
+  MaxZipTypeRcg: 1M
+  MaxPartitions: 128
+  MaxIconsPE: 200
+  PCREMatchLimit: 10000
+  PCRERecMatchLimit: 10000
 
 ## Ref: https://linux.die.net/man/5/freshclam.conf
 ## Note: will completely override default clamd.conf file at https://github.com/Mailu/Mailu/tree/master/optional/clamav/conf
-freshclamConfig: |
+freshclamConfigDict:
   ###############
   # General
   ###############
-
-  DatabaseDirectory /data
-  LogTime yes
+  DatabaseDirectory: /data
+  LogTime: "yes"
   # CUSTOM: Use pid file in tmp
-  PidFile /tmp/freshclam.pid
+  PidFile: /tmp/freshclam.pid
   # CUSTOM: Set defined user
-  DatabaseOwner 2000
+  DatabaseOwner: "2000"
 
   ###############
   # Updates
   ###############
 
-  DatabaseMirror database.clamav.net
-  ScriptedUpdates yes
-  NotifyClamd /etc/clamav/clamd.conf
-  Bytecode yes
+  DatabaseMirror: database.clamav.net
+  ScriptedUpdates: "yes"
+  NotifyClamd: /etc/clamav/clamd.conf
+  Bytecode: "yes"
 
 # Use freshclamConfig to define the content of /etc/clamav/freshclam.conf. Example:
 # freshclamConfig: |


### PR DESCRIPTION
This allows for fine-grained overrides of the default values provided with the Helm chart.

It should fall back gracefully when there are local values of the old string type.