### PR TITLE
buildkitd chart: Added support for some registry config; caCert, insecure, etc.

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: buildkitd
 description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
-appVersion: 0.17.0
+appVersion: 0.17.1
 kubeVersion: ">=1.19.0-0"
 version: 0.18.0
 maintainers:

--- a/charts/buildkitd/templates/configmap.yaml
+++ b/charts/buildkitd/templates/configmap.yaml
@@ -81,6 +81,24 @@ data:
       # maxEntries is the maximum number of history entries to keep.
       maxEntries = {{ .Values.config.history.maxEntries }}
 
+    {{ if eq "slice" (kindOf .Values.config.registries) }}
+      {{- range .Values.config.registries }}
+    [registry."{{ .host }}"]
+      {{- if eq "bool" (kindOf .http) }}
+      http = {{ .http }}
+      {{- end }}
+      {{- if eq "bool" (kindOf .insecure) }}
+      insecure = {{ .insecure }}
+      {{- end }}
+      {{- if eq "slice" (kindOf .mirrors) }}
+      mirrors = {{ toJson .mirrors }}
+      {{- end }}
+      ca = ["/etc/ssl/private/{{ .host }}.crt"]
+
+      {{- end }}
+    {{- end }}
+
+
 ---
 
 # See https://github.com/moby/buildkit/blob/master/Dockerfile
@@ -119,3 +137,20 @@ data:
   OTEL_EXPORTER_OTLP_INSECURE: {{ .Values.config.otel.common.insecure | quote }}
   OTEL_EXPORTER_OTLP_TRACES_INSECURE: {{ .Values.config.otel.traces.insecure | quote }}
   OTEL_EXPORTER_OTLP_METRICS_INSECURE: {{ .Values.config.otel.metrics.insecure | quote }}
+{{- if eq "slice" (kindOf .Values.config.registries) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "buildkitd.fullname" . }}-registry-ca-certs
+  labels:
+    app: {{ template "buildkitd.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  {{- range .Values.config.registries }}
+  "{{ .host }}.crt":
+    {{ toYaml .caCert | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -34,6 +34,12 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
+        {{- if eq "slice" (kindOf .Values.config.registries) }}
+        - name: registry-certs
+          configMap:
+            defaultMode: 420
+            name: {{ include "buildkitd.fullname" . }}-registry-ca-certs
+        {{- end }}
       containers:
         - name: buildkitd
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s-rootless" .Chart.AppVersion) }}
@@ -53,6 +59,10 @@ spec:
               mountPath: /home/{{ .Values.user.name }}/.config/buildkit
             - name: runtime-dir
               mountPath: /run/{{ .Values.user.name }}/{{ .Values.user.uid }}
+            {{- if eq "slice" (kindOf .Values.config.registries) }}
+            - name: registry-certs
+              mountPath: /etc/ssl/private
+            {{- end }}
           args:
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -89,6 +89,15 @@ config:
   history:
     maxAge: 172800
     maxEntries: 50
+  registries:
+  # - host: my-registry.com:5000
+  #   insecure: false
+  #   http: false  # use https only
+  #   mirrors:
+  #   - mirror1.com
+  #   - mirror2.net
+  #   caCert: |-
+  #     ...CA cert goes here...
 
 livenessProbe:
   initialDelaySeconds: 5

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -97,7 +97,7 @@ config:
   #   - mirror1.com
   #   - mirror2.net
   #   caCert: |-
-  #     ...CA cert goes here...
+  #     ...CA cert goes here in PEM format...
 
 livenessProbe:
   initialDelaySeconds: 5


### PR DESCRIPTION
See https://github.com/moby/buildkit/blob/master/util/resolver/config/config.go for schema details - I am implementing RootCAs, PlainHTTP, Insecure and Mirrors in this change.  This makes it easy to adapt a buildkitd for a personal OCI/container registry using a self-signed cert (or self-signed CA).