### PR TITLE
feat(karma): fix containerSecurityContext and add kthxbyeSidecar.securityContext

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.9.1
+version: 2.9.2
 kubeVersion: ">= 1.19-0"
 appVersion: "v0.120"
 maintainers:

--- a/charts/karma/templates/deployment.yaml
+++ b/charts/karma/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- if .Values.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
+        {{- end }}
         {{- if .Values.kthxbyeSidecar.enabled }}
         - name: kthxbye-sidecar
           image: "{{ .Values.kthxbyeSidecar.image.repository }}:{{ .Values.kthxbyeSidecar.image.tag }}"
@@ -111,13 +115,13 @@ spec:
           {{- if .Values.kthxbyeSidecar.logJson }}
             - --log-json
           {{- end }}
-         {{- end }}
+          {{- if .Values.kthxbyeSidecar.securityContext }}
+          securityContext:
+{{ toYaml .Values.kthxbyeSidecar.securityContext | indent 12 }}
+          {{- end }}
+        {{- end }}
         {{- with .Values.sidecarContainers }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- if .Values.containerSecurityContext }}
-          securityContext:
-{{ toYaml .Values.containerSecurityContext | indent 12 }}
         {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -227,6 +227,7 @@ kthxbyeSidecar:
     # interval: <duration> # Silence check interval (default 45s)
     # max-duration: <duration> # Maximum duration of a silence, it won't be extended anymore after reaching it
   logJson: false
+  securityContext: {}
 
 # additional sidecar containers array which will be added to the deployment
 sidecarContainers: []


### PR DESCRIPTION
`containerSecurityContext` was incorrectly rendered in case `kthxbyeSidecar.enabled` was `true` or `sidecarContainers` were specified. In this case it became part of the sidecar definition.

This change also adds `kthxbyeSidecar.securityContext` as a way to specify securityContext for the kthxbye sidecar container.