### PR TITLE
feat(clamav): Add Deployment alternative

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 3.4.0
+version: 3.5.0
 appVersion: "1.4.1"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
 name: clamav
-version: 3.3.0
+version: 3.4.0
 appVersion: "1.4.1"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/workload.yaml
+++ b/charts/clamav/templates/workload.yaml
@@ -1,5 +1,11 @@
+{{- if not (has .Values.kind (list "StatefulSet" "Deployment")) -}}
+{{- fail "Invalid value for .Values.kind, only StatefulSet and Deployment are supported" -}}
+{{- end -}}
+{{- if and .Values.persistentVolume.enabled (ne .Values.kind "StatefulSet")  -}}
+{{- fail "If .Values.persistentVolume.enabled is set to true, then .Values.kind has to be set to \"StatefulSet\"" -}}
+{{- end -}}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: {{ .Values.kind }}
 metadata:
   name: {{ include "clamav.fullname" . }}
   labels:
@@ -8,10 +14,20 @@ spec:
   {{- if not .Values.hpa.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if eq .Values.kind "StatefulSet" }}
   serviceName: {{ include "clamav.fullname" . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "clamav.selectorLabels" . | nindent 6 }}
+  {{- with .Values.updateStrategy }}
+  {{- if eq $.Values.kind "StatefulSet" }}
+  updateStrategy:
+  {{- else }}
+  strategy:
+  {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/clamav/values.schema.json
+++ b/charts/clamav/values.schema.json
@@ -36,6 +36,13 @@
     "fullnameOverride": {
       "type": "string"
     },
+    "kind": {
+      "type": "string",
+      "enum": ["Deployment", "StatefulSet"]
+    },
+    "updateStrategy": {
+      "type": "string"
+    },
     "service": {
       "type": "object",
       "properties": {

--- a/charts/clamav/values.schema.json
+++ b/charts/clamav/values.schema.json
@@ -42,9 +42,27 @@
     },
     "updateStrategy": {
       "type": [
-        "string",
+        "object",
         "null"
-      ]
+      ],
+      "properties": {
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rollingUpdate": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
     },
     "service": {
       "type": "object",

--- a/charts/clamav/values.schema.json
+++ b/charts/clamav/values.schema.json
@@ -41,7 +41,10 @@
       "enum": ["Deployment", "StatefulSet"]
     },
     "updateStrategy": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "service": {
       "type": "object",

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -21,6 +21,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 kind: StatefulSet
+updateStrategy: null
 
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -20,6 +20,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+kind: StatefulSet
+
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 100


### PR DESCRIPTION
Currently, ClamAV is always deployed as StatefulSet.

This doesn't make sense when not using a PersistentVolume (which isn't even the deafult) and has the disadvantage of less flexible rollingUpdate.

This commit adds the possibility to use a Deployment instead of a StatefulSet when the persistentVolume is not enabled.

It also adds the possibility to set updateStrategy options via Values.