### PR TITLE
chore(clamav): Update docs to refer to official image

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
-description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using Mailu docker image.
+description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using official docker image.
 name: clamav
-version: 3.3.0
+version: 3.4.0
 appVersion: "1.4.1"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/clamav
-  - https://github.com/Mailu/Mailu/tree/master/optional/clamav
-  - https://hub.docker.com/r/mailu/clamav
-  - https://github.com/Cisco-Talos/clamav-devel
+  - https://hub.docker.com/r/clamav/clamav
+  - https://github.com/Cisco-Talos/clamav-docker
+  - https://github.com/Cisco-Talos/clamav
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/clamav/README.md
+++ b/charts/clamav/README.md
@@ -3,7 +3,7 @@
 ##  An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 
 [ClamAV](https://www.clamav.net/) is the open source standard for mail gateway scanning software.
- Developed by [Cisco Talos](https://github.com/Cisco-Talos/clamav-devel). This Helm Chart uses the [MailU](https://github.com/Mailu/Mailu) Docker image. `appVersion` shows the Mailu/clamav container image version.
+ Developed by [Cisco Talos](https://github.com/Cisco-Talos/clamav-devel). This Helm Chart uses the [official ClamAV Docker image](https://hub.docker.com/r/clamav/clamav). `appVersion` shows the container image version.
 
 ## QuickStart
 

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -65,7 +65,7 @@ ingress:
   #      - chart-example.local
 
 ## Ref: https://linux.die.net/man/5/clamd.conf
-## Note: will completely override default clamd.conf file at https://github.com/Mailu/Mailu/tree/master/optional/clamav/conf
+## Note: will completely override default clamd.conf file at https://github.com/Cisco-Talos/clamav/blob/main/etc/clamd.conf.sample
 clamdConfigDict:
   ###############
   # General
@@ -120,7 +120,7 @@ clamdConfigDict:
   PCRERecMatchLimit: 10000
 
 ## Ref: https://linux.die.net/man/5/freshclam.conf
-## Note: will completely override default clamd.conf file at https://github.com/Mailu/Mailu/tree/master/optional/clamav/conf
+## Note: will completely override default clamd.conf file at https://github.com/Cisco-Talos/clamav/blob/main/etc/freshclam.conf.sample
 freshclamConfigDict:
   ###############
   # General


### PR DESCRIPTION
In #456 I forgot to update the docs to reflect that the container image is now sourced from the official repo, not from MailU.

I didn't update the Chart version on purpose because this PR only updates the docs.