### PR TITLE
chore(buildkitd): use version 0.18.2 by default

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: buildkitd
 description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
-appVersion: 0.18.1
+appVersion: 0.18.2
 kubeVersion: ">=1.19.0-0"
-version: 0.18.1
+version: 0.18.2
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts


### PR DESCRIPTION
See: https://github.com/moby/buildkit/releases/tag/v0.18.2