### PR TITLE
fix(chartreuse): fix version bump to patch only

### DIFF
--- a/charts/chartreuse/Chart.yaml
+++ b/charts/chartreuse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: chartreuse
 # NOTE: when setting a development version, please explicitly specify it in e2e test helm chart, otherwise just put *.
 appVersion: 4.3.5
-version: 4.4.1
+version: 4.3.8
 description: Automate Alembic SQL schema migrations.
 maintainers:
   - name: Wiremind


### PR DESCRIPTION
Chartreus check if the Python package minor version is equal to the Chart version. So we must have the same version.