### PR TITLE
feat(clamav): Add DaemonSet alternative

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using official docker image.
 name: clamav
-version: 3.5.0
+version: 3.6.0
 appVersion: "1.4.1"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/workload.yaml
+++ b/charts/clamav/templates/workload.yaml
@@ -1,8 +1,11 @@
-{{- if not (has .Values.kind (list "StatefulSet" "Deployment")) -}}
-{{- fail "Invalid value for .Values.kind, only StatefulSet and Deployment are supported" -}}
+{{- if not (has .Values.kind (list "StatefulSet" "Deployment" "DaemonSet")) -}}
+{{- fail "Invalid value for .Values.kind, only StatefulSet, Deployment and DaemonSet are supported" -}}
 {{- end -}}
 {{- if and .Values.persistentVolume.enabled (ne .Values.kind "StatefulSet")  -}}
 {{- fail "If .Values.persistentVolume.enabled is set to true, then .Values.kind has to be set to \"StatefulSet\"" -}}
+{{- end -}}
+{{- if and .Values.hpa.enabled (eq .Values.kind "DaemonSet")  -}}
+{{- fail "If .Values.hpa.enabled is set to true, then .Values.kind has to be set to \"StatefulSet\" or \"Deployment\"" -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: {{ .Values.kind }}
@@ -11,7 +14,7 @@ metadata:
   labels:
     {{- include "clamav.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.hpa.enabled }}
+  {{- if and (ne .Values.kind "DaemonSet") (not .Values.hpa.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- if eq .Values.kind "StatefulSet" }}
@@ -21,10 +24,10 @@ spec:
     matchLabels:
       {{- include "clamav.selectorLabels" . | nindent 6 }}
   {{- with .Values.updateStrategy }}
-  {{- if eq $.Values.kind "StatefulSet" }}
-  updateStrategy:
-  {{- else }}
+  {{- if eq $.Values.kind "Deployment" }}
   strategy:
+  {{- else }}
+  updateStrategy:
   {{- end }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/clamav/values.schema.json
+++ b/charts/clamav/values.schema.json
@@ -38,7 +38,7 @@
     },
     "kind": {
       "type": "string",
-      "enum": ["Deployment", "StatefulSet"]
+      "enum": ["DaemonSet", "Deployment", "StatefulSet"]
     },
     "updateStrategy": {
       "type": [

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -49,7 +49,12 @@ service:
   # nodePort: 30100
   annotations: {}
 
-extraEnvVars: {}
+## Extra environment variables to be set on the container
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+extraEnvVars: []
 extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 


### PR DESCRIPTION
Currently, ClamAV can be deployed as a StatefulSet or a Deployment. This PR introduces the option to deploy ClamAV as a DaemonSet.

Adding a DaemonSet alternative allows ClamAV to run on every Kubernetes node. This can be useful in scenarios where you want to ensure that virus definitions are updated locally on each node, or when node-level scanning is required.