### PR TITLE
Add nginx-vts Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+charts
+scripts

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,20 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "regex"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    extractors:
+      - files: ["Containerfile"]
+        regex: "VTS_VERSION=(?<current_value>[0-9.]+)"
+        datasource: "github-releases"
+        url: "https://github.com/vozlt/nginx-module-vts"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,60 @@
+name: Build and publish nginx-vts image
+
+on:
+  push:
+    paths:
+      - 'Containerfile'
+      - '.github/workflows/docker-image.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Containerfile
+
+      - name: Build image for test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          load: true
+          tags: local/nginx-vts:test
+
+      - name: Test module loading
+        run: |
+          docker run --rm local/nginx-vts:test nginx -V 2>&1 | grep -q vhost_traffic_status
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/nginx-vts:latest
+          platforms: linux/amd64,linux/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 charts/*/charts/
 .venv
 venv
-.idea/*
+.idea/
+.vscode/
+*.tgz
+tmp/
+*.swp
+*.pyc
+__pycache__/
+dist/

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+ARG NGINX_VERSION=1.25.3
+ARG VTS_VERSION=0.1.0
+FROM nginx:${NGINX_VERSION}-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache --virtual .build-deps \
+        git build-base openssl-dev pcre2-dev zlib-dev linux-headers curl \
+    && curl -fSL https://github.com/vozlt/nginx-module-vts/archive/refs/tags/v${VTS_VERSION}.tar.gz | tar -xz -C /tmp \
+    && mv /tmp/nginx-module-vts-* /tmp/nginx-module-vts \
+    && curl -fSL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -xz -C /tmp \
+    && cd /tmp/nginx-${NGINX_VERSION} \
+    && ./configure --with-compat --add-dynamic-module=/tmp/nginx-module-vts \
+    && make modules
+
+FROM nginx:${NGINX_VERSION}-alpine
+COPY --from=builder /tmp/nginx-${NGINX_VERSION}/objs/ngx_http_vhost_traffic_status_module.so /etc/nginx/modules/
+RUN mkdir -p /etc/nginx/modules-enabled \
+    && echo 'load_module modules/ngx_http_vhost_traffic_status_module.so;' > /etc/nginx/modules-enabled/50-mod-http-vts.conf
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- create Containerfile to compile and package nginx with the vts module
- add dockerignore
- add workflow to build, test and publish the image to GHCR
- extend dependabot to track Docker base image updates
- pin vts module to v0.1.0 and remove stray script
- configure dependabot regex manager for vts releases
- expand gitignore patterns

## Testing
- `git status --short`
