### PR TITLE
fix(clamav): do not use sidecar container for metrics

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,10 +1,8 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using official docker image.
 name: clamav
-version: 3.7.0
+version: 3.7.1
 appVersion: "1.4.3"
-# XXX if you want to use metrics, you need to use kubeVersion >=1.29.0
-# kubeVersion: ">=1.29.0"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png
 sources:

--- a/charts/clamav/templates/workload.yaml
+++ b/charts/clamav/templates/workload.yaml
@@ -122,12 +122,10 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if .Values.metrics.enabled }}
-      initContainers:
+        {{- if .Values.metrics.enabled }}
         - name: clamav-exporter
           image: {{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
-          restartPolicy: Always
           args:
             - --clamav.address=tcp://localhost:3310
             - --web.listen-address=0.0.0.0:{{ .Values.metrics.port }}
@@ -167,7 +165,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Service discovery does not take into account ports from native sidecar containers, so no metrics.

Go back to traditional container for our metrics.