### PR TITLE
feat(karma): add toggle for using fullname for configmap

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.9.6
+version: 2.10.0
 kubeVersion: ">= 1.19-0"
 appVersion: "v0.121"
 maintainers:

--- a/charts/karma/templates/configmap.yaml
+++ b/charts/karma/templates/configmap.yaml
@@ -11,7 +11,11 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{ if .Values.configMap.useFullname }}
+  name: {{ include "karma.fullname" . }}-config
+{{ else }}
   name: "{{ .Release.Name }}-config"
+{{- end}}
   namespace: {{ .Release.Namespace }}
 data:
 {{- with .Values.configMap.aclsConfig }}

--- a/charts/karma/templates/deployment.yaml
+++ b/charts/karma/templates/deployment.yaml
@@ -146,7 +146,11 @@ spec:
       {{- if .Values.configMap.enabled }}
       - name: karma-config
         configMap:
-          name: {{ .Release.Name }}-config
+        {{ if .Values.configMap.useFullname }}
+          name: {{ include "karma.fullname" . }}-config
+        {{ else }}
+          name: "{{ .Release.Name }}-config"
+        {{- end}}
       {{- end }}
       {{- if .Values.existingSecretConfig.enabled }}
       - name: karma-config

--- a/charts/karma/values.schema.json
+++ b/charts/karma/values.schema.json
@@ -16,6 +16,9 @@
                 },
                 "enabled": {
                     "type": "boolean"
+                },
+                "useFullname": {
+                    "type": "boolean"
                 }
             }
         },

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -123,6 +123,7 @@ existingSecretConfig:
 ## to provide advanced configuration. NOTE, you must use port 8080!
 configMap:
   enabled: false
+  useFullname: false
   annotations: {}
   ## karma compatible YAML configuration
   # rawConfig:


### PR DESCRIPTION
# Description
This PR introduces a toggle called `.configMap.useFullname` for selecting if the fullname is supposed to be used or not.

# Current behaviour
ConfigMap is the only resource not respecting the fullname logic which is especially useful if you use the Karma chart as a subchart of a monitoring stack

# Expected behaviour and fix
ConfigMap resource should respect the fullname logic as well. The new toggle `.configMap.useFullname` has been introduced for backwards compatibility.
