### PR TITLE
fix(karma): allow setting of revisionHistoryLimit in karma

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.12.0
+version: 2.12.1
 kubeVersion: ">= 1.19-0"
 appVersion: "v0.121"
 maintainers:

--- a/charts/karma/templates/deployment.yaml
+++ b/charts/karma/templates/deployment.yaml
@@ -14,6 +14,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "karma.name" . }}

--- a/charts/karma/values.schema.json
+++ b/charts/karma/values.schema.json
@@ -102,6 +102,11 @@
         "replicaCount": {
             "type": "integer"
         },
+        "revisionHistoryLimit": {
+            "type": "number",
+            "description": "The number of old history to retain to allow rollback",
+            "default": 3
+        },
         "resources": {
             "type": "object"
         },

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -4,6 +4,7 @@
 
 # Number of replicas
 replicaCount: 1
+revisionHistoryLimit: 3
 
 image:
   ## The image to run


### PR DESCRIPTION
hi!

I quite like your helm charts, but noticed that the `revisionHistoryLimit` could not be set for karma, so I added it.

One could also update the app version for karma, the latest one is `v0.128`