### PR TITLE
feat(chartreuse): emit ArgoCD Sync hook when deploymentMethod=argocd (6.3.0)

### DIFF
--- a/charts/chartreuse/Chart.yaml
+++ b/charts/chartreuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chartreuse
 appVersion: 6.2.0
-version: 6.2.0
+version: 6.3.0
 description: Automate Alembic SQL schema migrations.
 maintainers:
   - name: Wiremind

--- a/charts/chartreuse/README.md
+++ b/charts/chartreuse/README.md
@@ -5,3 +5,65 @@
 Chartreuse is an Automated Alembic migrations within kubernetes.
 
 Please refer to https://github.com/wiremind/chartreuse.
+
+## Using this chart under ArgoCD
+
+The chart ships an opt-in ArgoCD-native mode that replaces the Helm hook
+machinery with ArgoCD Sync hooks. Enable it by setting:
+
+```yaml
+argocd:
+  enabled: true
+  # Sync-wave applied to the migration Job.
+  # Default: -50 (runs before consumer Deployments at the default wave 0).
+  syncWave: -50
+```
+
+### What it does
+
+When `argocd.enabled: true`:
+
+- The chartreuse migration `Job` is rendered with the following annotations:
+  - `argocd.argoproj.io/hook: Sync`
+  - `argocd.argoproj.io/hook-delete-policy: BeforeHookCreation`
+  - `argocd.argoproj.io/sync-wave: "<argocd.syncWave>"`
+- The Helm `-ephemeral` upgrade-hook resource set (ConfigMap, Role/RoleBinding,
+  ServiceAccount, ExternalSecret) is **not rendered**. ArgoCD does not run
+  Helm's `pre-upgrade`/`post-upgrade` hooks, so these resources serve no
+  purpose under ArgoCD. The single unsuffixed resource set is used instead.
+- The `HELM_IS_INSTALL` ConfigMap key is always emitted as `""` because
+  ArgoCD does not have a notion of install-vs-upgrade.
+
+### Why
+
+Kubernetes `Job.spec.template` is immutable. ArgoCD applies resources via
+`kubectl apply` by default, which fails on any image bump with:
+
+```
+Job.batch "<name>" is invalid: spec.template: Invalid value: ...:
+  field is immutable
+```
+
+Declaring the Job as an ArgoCD Sync hook with `BeforeHookCreation` instructs
+ArgoCD to **delete and recreate** the Job on every sync, sidestepping the
+immutability constraint.
+
+### Sync-wave model
+
+The default `argocd.syncWave: -50` is designed to slot between database
+resources (lower waves) and application Deployments (default wave `0` or
+higher). Recommended ordering:
+
+| Resource | Sync wave |
+|----------|-----------|
+| Database / database operator resources | `< -50` (e.g. `-100`) |
+| Chartreuse migration Job | `-50` (default) |
+| Application Deployments | `0` (default) |
+
+Override `argocd.syncWave` if your deployment uses a different wave scheme.
+
+### Backward compatibility
+
+This mode is **opt-in**. With `argocd.enabled: false` (the default), the
+chart renders exactly the same resources with the same annotations and
+naming as previous versions; pure-Helm consumers are not affected.

--- a/charts/chartreuse/README.md
+++ b/charts/chartreuse/README.md
@@ -12,16 +12,21 @@ The chart ships an opt-in ArgoCD-native mode that replaces the Helm hook
 machinery with ArgoCD Sync hooks. Enable it by setting:
 
 ```yaml
+deploymentMethod: argocd
+
 argocd:
-  enabled: true
   # Sync-wave applied to the migration Job.
   # Default: -50 (runs before consumer Deployments at the default wave 0).
   syncWave: -50
 ```
 
+The `deploymentMethod` value matches the umbrella `wiremind` chart and
+`overwhelm`'s `--cd-version` derivation, so the same toggle propagates
+end-to-end across overwhelm → wiremind → chartreuse.
+
 ### What it does
 
-When `argocd.enabled: true`:
+When `deploymentMethod: argocd`:
 
 - The chartreuse migration `Job` is rendered with the following annotations:
   - `argocd.argoproj.io/hook: Sync`
@@ -64,6 +69,6 @@ Override `argocd.syncWave` if your deployment uses a different wave scheme.
 
 ### Backward compatibility
 
-This mode is **opt-in**. With `argocd.enabled: false` (the default), the
+This mode is **opt-in**. With `deploymentMethod: helm` (the default), the
 chart renders exactly the same resources with the same annotations and
 naming as previous versions; pure-Helm consumers are not affected.

--- a/charts/chartreuse/templates/_helpers.tpl
+++ b/charts/chartreuse/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "chartreuse.upgradeJobAnnotations" -}}
-{{- if .Values.argocd.enabled -}}
+{{- if eq .Values.deploymentMethod "argocd" -}}
 "argocd.argoproj.io/hook": Sync
 "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation
 "argocd.argoproj.io/sync-wave": {{ .Values.argocd.syncWave | quote }}
@@ -92,7 +92,7 @@ Create the name of the service account to use
 
 # Adds suffix -ephemeral if it is a helm hook
 {{- define "chartreuse.hook.suffix" -}}
-{{- if .Values.argocd.enabled -}}
+{{- if eq .Values.deploymentMethod "argocd" -}}
 {{/* No suffix in ArgoCD mode - single unsuffixed resource set, with the Job as a Sync hook. */}}
 {{- else -}}
 {{- if .Values.upgradeBeforeDeployment -}}

--- a/charts/chartreuse/templates/_helpers.tpl
+++ b/charts/chartreuse/templates/_helpers.tpl
@@ -56,6 +56,11 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "chartreuse.upgradeJobAnnotations" -}}
+{{- if .Values.argocd.enabled -}}
+"argocd.argoproj.io/hook": Sync
+"argocd.argoproj.io/hook-delete-policy": BeforeHookCreation
+"argocd.argoproj.io/sync-wave": {{ .Values.argocd.syncWave | quote }}
+{{- else -}}
 {{- if .Values.upgradeBeforeDeployment -}}
 {{- if .Release.IsInstall }}
 # No hook: we deploy this job during the initial install, as part of the Helm Release
@@ -73,6 +78,7 @@ Create the name of the service account to use
 "helm.sh/hook-delete-policy": "before-hook-creation"
 {{- end }}
 {{- end -}}
+{{- end -}}
 
 {{- define "chartreuse.annotations.ephemeral" -}}
 {{- if .Values.upgradeBeforeDeployment -}}
@@ -86,11 +92,15 @@ Create the name of the service account to use
 
 # Adds suffix -ephemeral if it is a helm hook
 {{- define "chartreuse.hook.suffix" -}}
+{{- if .Values.argocd.enabled -}}
+{{/* No suffix in ArgoCD mode - single unsuffixed resource set, with the Job as a Sync hook. */}}
+{{- else -}}
 {{- if .Values.upgradeBeforeDeployment -}}
 {{- if .Release.IsUpgrade -}}
 -ephemeral
 {{- end -}}
 {{- else -}}
 -ephemeral
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/chartreuse/templates/confimap-ephemeral.yaml
+++ b/charts/chartreuse/templates/confimap-ephemeral.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.argocd.enabled -}}
+{{- if ne .Values.deploymentMethod "argocd" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/chartreuse/templates/confimap-ephemeral.yaml
+++ b/charts/chartreuse/templates/confimap-ephemeral.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.argocd.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -47,3 +48,4 @@ data:
   {{- range $key, $value := .Values.additionalEnvironmentVariables }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+{{- end -}}

--- a/charts/chartreuse/templates/confimap.yaml
+++ b/charts/chartreuse/templates/confimap.yaml
@@ -12,8 +12,12 @@ data:
   CHARTREUSE_ALEMBIC_ALLOW_MIGRATION_FOR_EMPTY_DATABASE: ""
 {{- end }}
 
+{{- if not .Values.argocd.enabled }}
 {{- if .Release.IsInstall }}
   HELM_IS_INSTALL: "1"
+{{- else }}
+  HELM_IS_INSTALL: ""
+{{- end }}
 {{- else }}
   HELM_IS_INSTALL: ""
 {{- end }}

--- a/charts/chartreuse/templates/confimap.yaml
+++ b/charts/chartreuse/templates/confimap.yaml
@@ -12,7 +12,7 @@ data:
   CHARTREUSE_ALEMBIC_ALLOW_MIGRATION_FOR_EMPTY_DATABASE: ""
 {{- end }}
 
-{{- if not .Values.argocd.enabled }}
+{{- if ne .Values.deploymentMethod "argocd" }}
 {{- if .Release.IsInstall }}
   HELM_IS_INSTALL: "1"
 {{- else }}

--- a/charts/chartreuse/templates/externalsecrets/externalsecret-ephemeral.yaml
+++ b/charts/chartreuse/templates/externalsecrets/externalsecret-ephemeral.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.argocd.enabled -}}
+{{- if ne .Values.deploymentMethod "argocd" -}}
 {{- if .Values.alembic.enabled -}}
 ---
 apiVersion: external-secrets.io/v1

--- a/charts/chartreuse/templates/externalsecrets/externalsecret-ephemeral.yaml
+++ b/charts/chartreuse/templates/externalsecrets/externalsecret-ephemeral.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.argocd.enabled -}}
 {{- if .Values.alembic.enabled -}}
 ---
 apiVersion: external-secrets.io/v1
@@ -65,4 +66,5 @@ spec:
         key: {{ $remoteKey }}
         metadataPolicy: None
   {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/chartreuse/templates/role-ephemeral.yaml
+++ b/charts/chartreuse/templates/role-ephemeral.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.argocd.enabled -}}
+{{- if ne .Values.deploymentMethod "argocd" -}}
 {{- if .Values.rbac.create -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/chartreuse/templates/role-ephemeral.yaml
+++ b/charts/chartreuse/templates/role-ephemeral.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.argocd.enabled -}}
 {{- if .Values.rbac.create -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -54,4 +55,5 @@ subjects:
     name: {{ template "chartreuse.fullname" . }}-ephemeral
     namespace: {{ .Release.Namespace }}
 
+{{- end -}}
 {{- end -}}

--- a/charts/chartreuse/templates/serviceaccount-ephemeral.yaml
+++ b/charts/chartreuse/templates/serviceaccount-ephemeral.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.argocd.enabled -}}
+{{- if ne .Values.deploymentMethod "argocd" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/chartreuse/templates/serviceaccount-ephemeral.yaml
+++ b/charts/chartreuse/templates/serviceaccount-ephemeral.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.argocd.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "chartreuse.labels" . | nindent 4 }}
   annotations:
     {{- include "chartreuse.annotations.ephemeral" . | nindent 4 }}
+{{- end -}}

--- a/charts/chartreuse/values.schema.json
+++ b/charts/chartreuse/values.schema.json
@@ -11,15 +11,16 @@
         "argocd": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false
-                },
                 "syncWave": {
                     "type": "integer",
                     "default": -50
                 }
             }
+        },
+        "deploymentMethod": {
+            "type": "string",
+            "enum": ["helm", "argocd"],
+            "default": "helm"
         },
         "alembic": {
             "type": "object",

--- a/charts/chartreuse/values.schema.json
+++ b/charts/chartreuse/values.schema.json
@@ -8,6 +8,19 @@
         "affinity": {
             "type": "object"
         },
+        "argocd": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "syncWave": {
+                    "type": "integer",
+                    "default": -50
+                }
+            }
+        },
         "alembic": {
             "type": "object",
             "properties": {

--- a/charts/chartreuse/values.yaml
+++ b/charts/chartreuse/values.yaml
@@ -90,3 +90,15 @@ tolerations: []
 affinity: {}
 
 podAnnotations: {}
+
+## ArgoCD-native mode. When enabled, the chart renders the migration Job as an
+## ArgoCD Sync hook with delete-and-recreate semantics (fixing the immutable
+## Job.spec.template error on image bumps) and skips the `-ephemeral` upgrade-hook
+## resource set entirely (the Helm-only mechanism for pre-upgrade migrations).
+## Default false to preserve existing Helm-install/upgrade behavior unchanged.
+argocd:
+  enabled: false
+  ## Sync-wave for the chartreuse Job. Consumers should place their app Deployments
+  ## at a higher wave (default 0) and their database resources at a lower wave so
+  ## ordering is DB -> chartreuse -> app.
+  syncWave: -50

--- a/charts/chartreuse/values.yaml
+++ b/charts/chartreuse/values.yaml
@@ -91,13 +91,17 @@ affinity: {}
 
 podAnnotations: {}
 
-## ArgoCD-native mode. When enabled, the chart renders the migration Job as an
-## ArgoCD Sync hook with delete-and-recreate semantics (fixing the immutable
-## Job.spec.template error on image bumps) and skips the `-ephemeral` upgrade-hook
-## resource set entirely (the Helm-only mechanism for pre-upgrade migrations).
-## Default false to preserve existing Helm-install/upgrade behavior unchanged.
+## Deployment surface. `helm` (default) keeps existing Helm install/upgrade
+## hook semantics. `argocd` renders the migration Job as an ArgoCD Sync hook
+## with delete-and-recreate (fixing the immutable Job.spec.template error on
+## image bumps) and skips the `-ephemeral` upgrade-hook resource set entirely
+## (the Helm-only mechanism for pre-upgrade migrations). Matches the umbrella
+## wiremind chart and overwhelm's `--cd-version` derivation so the same toggle
+## propagates end-to-end.
+deploymentMethod: helm
+
 argocd:
-  enabled: false
+  ## Used only when `deploymentMethod: argocd`.
   ## Sync-wave for the chartreuse Job. Consumers should place their app Deployments
   ## at a higher wave (default 0) and their database resources at a lower wave so
   ## ordering is DB -> chartreuse -> app.


### PR DESCRIPTION
## Summary
- Adds a top-level `deploymentMethod: helm | argocd` value (default `helm`).
- When `deploymentMethod: argocd`, renders the migration Job as an ArgoCD `Sync` hook with `BeforeHookCreation` + `sync-wave: "-50"` (configurable via `argocd.syncWave`) instead of as a plain Sync resource.
- When `deploymentMethod: argocd`, skips the `-ephemeral` upgrade-hook resource set (those exist only to support Helm's pre-upgrade hook mechanism, which ArgoCD does not use).
- `HELM_IS_INSTALL` ConfigMap key is always emitted as `""` in ArgoCD mode so the Python tool can drop the env var independently (see sister PR in wiremind/chartreuse).
- Bumps chart `version: 6.3.0` (minor — additive value, default behaviour unchanged).

## Why
Under ArgoCD the rendered chartreuse Job has been failing every image bump with `Job.batch invalid: spec.template field is immutable`. ArgoCD was applying it as a plain Sync resource and Kubernetes Jobs have immutable pod templates, so any image-tag change broke the sync. Making the Job an ArgoCD Sync hook with `BeforeHookCreation` makes ArgoCD delete-and-recreate instead of patching.

`deploymentMethod` is named to match the value contract already in place upstream: `overwhelm` emits `deployment_method` derived from `--cd-version` (`v1 -> helm`, `v2 -> argocd`), and the `wiremind` umbrella chart forwards it under `chartreuse.deploymentMethod`. Same toggle name end-to-end → single source of truth.

Backward-compat: `deploymentMethod: helm` (the default) produces byte-identical output to chart 6.2.0 for pure-Helm consumers — verified by diffing renders against `origin/main`.

## Test plan
- [x] Diff `helm template` with defaults against chart 6.2.0 → only version-string and `helm.sh/release-time` deltas, no structural changes.
- [x] Render with `deploymentMethod=argocd upgradeBeforeDeployment=true` → Job has `argocd.argoproj.io/hook: Sync`, `BeforeHookCreation`, `sync-wave: "-50"`, `HELM_IS_INSTALL: ""`, no `*-ephemeral` resources.
- [ ] Reviewer to confirm `helm lint charts/chartreuse` and run their own `helm template` smoke tests.

## Coordinated with
- #860 — `feat/postgres-operator/wiremind-fork-1.14.0` in this repo: vendors zalando postgres-operator 1.14.0 as `1.14.0-wiremind0` with `deploymentAnnotations` so the umbrella can wave-order the operator Pod.
- https://github.com/wiremind/chartreuse/pull/52 — drops `HELM_IS_INSTALL` from the Python tool; lands independently of this PR.
- https://gitlab.wiremind.io/wiremind/devops/helm-charts-private/-/merge_requests/1563 — umbrella consumer change, blocked on this PR + #860 publishing.
- https://gitlab.wiremind.io/wiremind/devops/overwhelm/-/merge_requests/418 — overwhelm mirrors `deployment_method` into the chartreuse subchart block.

## Supersedes
Closed #861, which proposed the same goal with a slightly different design (`PreSync`/`PostSync` based on `upgradeBeforeDeployment`, keeping ephemeral resources). The current design (Sync hook + delete-and-recreate + drop ephemeral) was kept because it directly addresses the immutable-pod-template bug and removes redundant Helm-only plumbing under ArgoCD. The value key now matches the rest of the contract (`deploymentMethod`) thanks to the rename in 79c337b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)