### PR TITLE
fix(postgres-operator): add operatorConfigurationAnnotations values key (1.14.0-wiremind1)

### DIFF
--- a/charts/postgres-operator/Chart.yaml
+++ b/charts/postgres-operator/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: postgres-operator
-version: 1.14.0-wiremind0
+version: 1.14.0-wiremind1
 appVersion: 1.14.0
 home: https://github.com/zalando/postgres-operator
-description: Zalando PostgreSQL operator (wiremind fork, adds deploymentAnnotations)
+description: Zalando PostgreSQL operator (wiremind fork, adds deploymentAnnotations and operatorConfigurationAnnotations)
 icon: https://www.wiremind.io/assets/logo.png
 keywords:
 - postgres

--- a/charts/postgres-operator/FORK.md
+++ b/charts/postgres-operator/FORK.md
@@ -2,13 +2,18 @@
 
 This chart is a vendored fork of the upstream
 [zalando/postgres-operator](https://github.com/zalando/postgres-operator/tree/v1.14.0/charts/postgres-operator)
-Helm chart at tag `v1.14.0`. The only functional change is the addition of a
-`deploymentAnnotations` values key that renders annotations onto the operator
-`Deployment`'s `metadata.annotations` (upstream only exposes `podAnnotations`,
-which annotates the pod template — that does not let ArgoCD pin a sync-wave on
-the controller resource). Without this, ArgoCD applies `Postgresql` CRs at
-sync-wave `-80` before any controller exists at default sync-wave `0`, which
-deadlocks first-install. Our wiremind fork is versioned `1.14.0-wiremind0`;
-on each upstream bump, sync the new release into this directory and re-apply
-the four-file patch (`Chart.yaml`, `FORK.md`, `values.yaml`,
-`templates/deployment.yaml`).
+Helm chart at tag `v1.14.0`. The functional changes are:
+
+- `deploymentAnnotations` values key that renders annotations onto the operator
+  `Deployment`'s `metadata.annotations` (upstream only exposes `podAnnotations`,
+  which annotates the pod template).
+- `operatorConfigurationAnnotations` values key that renders annotations onto
+  the `OperatorConfiguration` CR's `metadata.annotations`.
+
+These let GitOps tooling pin per-resource ordering metadata (e.g. sync waves)
+on the controller resources, which upstream does not expose.
+
+Our wiremind fork is versioned `1.14.0-wiremind1`; on each upstream bump, sync
+the new release into this directory and re-apply the five-file patch
+(`Chart.yaml`, `FORK.md`, `values.yaml`, `templates/deployment.yaml`,
+`templates/operatorconfiguration.yaml`).

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/chart: {{ template "postgres-operator.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.operatorConfigurationAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 configuration:
 {{ tpl (toYaml .Values.configGeneral) . | indent 2 }}
   users:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -14,6 +14,11 @@ image:
 ## Wiremind extension: not present in upstream zalando chart at v1.14.0.
 deploymentAnnotations: {}
 
+## Annotations to add to the OperatorConfiguration CR's metadata.annotations.
+## Only honored when configTarget == "OperatorConfigurationCRD".
+## Wiremind extension: not present in upstream zalando chart at v1.14.0.
+operatorConfigurationAnnotations: {}
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Summary
- Bumps the wiremind postgres-operator fork `1.14.0-wiremind0 → 1.14.0-wiremind1`.
- Adds `operatorConfigurationAnnotations` values key (default `{}`) wired through the OperatorConfiguration CR template, mirroring the existing `deploymentAnnotations` pattern on the Deployment.
- Updates `FORK.md` to document the new key and bump the five-file patch list.

## Why
Under ArgoCD, the operator `Deployment` is pinned at sync-wave `-90` via `deploymentAnnotations` so it rolls out before the `Postgresql` CRs it manages at wave `-80`. But the `OperatorConfiguration` CR the operator reads at startup has no annotation passthrough — it lands at default wave `0`. On a fresh install, ArgoCD applies wave `-90` (operator Deployment) and the Pod crashloops with:

```
{"level":"fatal","msg":"unable to read operator configuration: could not get operator configuration object \"...-postgres-operator\": operatorconfigurations.acid.zalan.do \"...-postgres-operator\" not found"}
```

ArgoCD then deadlocks at wave `-90` waiting for a Pod that can never become Healthy, so wave `0` (where the OperatorConfiguration lives) is never reached.

With this PR, downstream consumers can set `operatorConfigurationAnnotations.argocd.argoproj.io/sync-wave: "-91"` so the CR lands strictly before the operator Deployment in the same sync cycle.

## Test plan
- [x] `helm template` with no overrides → no `annotations:` block on OperatorConfiguration (byte-identical to `1.14.0-wiremind0` default render).
- [x] `helm template` with `operatorConfigurationAnnotations.argocd.argoproj.io/sync-wave: "-91"` → CR carries the annotation.
- [ ] Downstream umbrella bump in `wiremind/devops/helm-charts-private` setting the value to `-91` and refreshing `Chart.lock`.

## Coordinated with
- https://gitlab.wiremind.io/wiremind/devops/helm-charts-private/-/merge_requests/1563 — umbrella will consume this once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)