### PR TITLE
fix(wiremind-baremetal): allow overriding raid device

### DIFF
--- a/charts/wiremind-baremetal/CHANGELOG.md
+++ b/charts/wiremind-baremetal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v2.0.1 (2026-05-29)
+## Fix
+- Allow configuring the RAID device path with the `raidDevice` value and try `/dev/md/md0` then `/dev/md127` by default
+
 # v1.4.0 (2022-06-13)
 ## Feat
 - Support resources, containerSecurityContext, readinessProbe, livenessProbe, image, hostPID

--- a/charts/wiremind-baremetal/Chart.yaml
+++ b/charts/wiremind-baremetal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wiremind-baremetal
 description: Helm chart to use BareMetal Encrypted at Rest disks
 icon: https://www.wiremind.io/assets/logo.png
-version: 2.0.0
+version: 2.0.1
 appVersion: "3.18.0"
 maintainers:
   - name: platform

--- a/charts/wiremind-baremetal/baremetal-scripts/decrypt-and-mount.sh
+++ b/charts/wiremind-baremetal/baremetal-scripts/decrypt-and-mount.sh
@@ -2,66 +2,76 @@
 set -x
 set -e
 
-RAID_DEVICE="/dev/md/md0"
+: "${RAID_DEVICE_CANDIDATES:?RAID_DEVICE_CANDIDATES must be set}"
+RAID_DEVICE=""
 DECRYPTED_LUKS_DEVICE_NAME="md0crypt"
 DECRYPTED_LUKS_DEVICE="/dev/mapper/md0crypt"
 LVM_PARTITION_DEVICES="/dev/md0cryptlvm/persistentvolume*"
 
-# Check if raid device exists
+wmb_find_raid_device() {
+	for candidate in $RAID_DEVICE_CANDIDATES; do
+		if mdadm -D "$candidate" >/dev/null 2>&1; then
+			RAID_DEVICE="$candidate"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+# Check if one of the configured md devices exists.
 set +e
 
-device_details=$(mdadm -D "$RAID_DEVICE")
+wmb_find_raid_device
 if [[ "$?" != "0" ]]; then
-    echo "Raid device <${RAID_DEVICE}> not found, skipping"
-    exit 0
+	echo "No raid device found in <${RAID_DEVICE_CANDIDATES}>, skipping"
+	exit 0
 fi
 
 set -e
 
 wmb_decrypt_device() {
-  if ! cryptsetup status $DECRYPTED_LUKS_DEVICE_NAME; then
-      echo "Decrypting the device $DECRYPTED_LUKS_DEVICE_NAME."
-      set +x  # Do not log password, please.
-      # XXX: this will actually hang (even if successfully opening) when run like this.
-      # When run locally, even from a script, it works.
-      # It will anyway get killed by the livenessprobe.
-      echo -n "$password" | cryptsetup luksOpen --verbose $RAID_DEVICE $DECRYPTED_LUKS_DEVICE_NAME --verbose --debug --allow-discards --key-file -
-      echo "Done decrypting the device $DECRYPTED_LUKS_DEVICE_NAME."
-      set -x
-  fi
+	if ! cryptsetup status $DECRYPTED_LUKS_DEVICE_NAME; then
+		echo "Decrypting the device $DECRYPTED_LUKS_DEVICE_NAME."
+		set +x # Do not log password, please.
+		# XXX: this will actually hang (even if successfully opening) when run like this.
+		# When run locally, even from a script, it works.
+		# It will anyway get killed by the livenessprobe.
+		echo -n "$password" | cryptsetup luksOpen --verbose $RAID_DEVICE $DECRYPTED_LUKS_DEVICE_NAME --verbose --debug --allow-discards --key-file -
+		echo "Done decrypting the device $DECRYPTED_LUKS_DEVICE_NAME."
+		set -x
+	fi
 
-  # Check, will exit non-0 if failed
-  cryptsetup status $DECRYPTED_LUKS_DEVICE
-  pvscan
-  vgscan
+	# Check, will exit non-0 if failed
+	cryptsetup status $DECRYPTED_LUKS_DEVICE
+	pvscan
+	vgscan
 }
-
 
 wmb_mount_partition_devices() {
-  # Mount every /dev/md0cryptlvm/persistentvolumeX to /mnt/persistentvolumeX
-  for PARTITION_DEVICE in $LVM_PARTITION_DEVICES; do
-      # When there is no matching device
-      if [ "$PARTITION_DEVICE" = "$LVM_PARTITION_DEVICES" ]; then
-        echo "No lvm partition found"
-        continue
-      fi
-      if ! findmnt "$PARTITION_DEVICE"; then
-          mount -t ext4 "$PARTITION_DEVICE" /mnt/$(basename "$PARTITION_DEVICE")
-      fi
-  done
+	# Mount every /dev/md0cryptlvm/persistentvolumeX to /mnt/persistentvolumeX
+	for PARTITION_DEVICE in $LVM_PARTITION_DEVICES; do
+		# When there is no matching device
+		if [ "$PARTITION_DEVICE" = "$LVM_PARTITION_DEVICES" ]; then
+			echo "No lvm partition found"
+			continue
+		fi
+		if ! findmnt "$PARTITION_DEVICE"; then
+			mount -t ext4 "$PARTITION_DEVICE" /mnt/$(basename "$PARTITION_DEVICE")
+		fi
+	done
 }
 
-
 wmb_check_partition_devices_mounts() {
-  for PARTITION_DEVICE in $LVM_PARTITION_DEVICES; do
-      # When there is no matching device
-      if [ "$PARTITION_DEVICE" = "$LVM_PARTITION_DEVICES" ]; then
-        echo "No lvm partition found"
-        continue
-      fi
-      echo "Checking $PARTITION_DEVICE mount point..."
-      findmnt "$PARTITION_DEVICE"
-  done
+	for PARTITION_DEVICE in $LVM_PARTITION_DEVICES; do
+		# When there is no matching device
+		if [ "$PARTITION_DEVICE" = "$LVM_PARTITION_DEVICES" ]; then
+			echo "No lvm partition found"
+			continue
+		fi
+		echo "Checking $PARTITION_DEVICE mount point..."
+		findmnt "$PARTITION_DEVICE"
+	done
 }
 
 # Decrypt
@@ -69,6 +79,6 @@ wmb_decrypt_device
 
 # Topolvm manages the mounts/checks on its own.
 if [[ -z "$TOPOLVM_ENABLED" ]]; then
-    wmb_mount_partition_devices
-    wmb_check_partition_devices_mounts
+	wmb_mount_partition_devices
+	wmb_check_partition_devices_mounts
 fi

--- a/charts/wiremind-baremetal/templates/baremetal-daemonset.yaml
+++ b/charts/wiremind-baremetal/templates/baremetal-daemonset.yaml
@@ -28,8 +28,10 @@ spec:
               {{- else }}
               name: {{ .Release.Name }}-installer
               {{- end }}
-        {{- with .Values.extraEnv }}
         env:
+          - name: RAID_DEVICE_CANDIDATES
+            value: {{ .Values.raidDevice | quote }}
+        {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:

--- a/charts/wiremind-baremetal/values.yaml
+++ b/charts/wiremind-baremetal/values.yaml
@@ -10,6 +10,11 @@ secret:
 
 extraEnv: []
 
+# Space-separated md device candidates checked in order.
+# We /dev/md127 because we did a mistake on creating /dev/md/md0_0 instead of /dev/md/md0 
+# with symbolic link: /dev/md/md0_0 -> ../md127)
+raidDevice: "/dev/md/md0 /dev/md127"
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
## Summary
- add a `raidDevice` chart value to configure the md device used by the baremetal installer
- pass `RAID_DEVICE` to the daemonset container so bare-metal hosts using `/dev/md127` can override the default
- document the new value and bump the chart to `2.0.1`

## Verification
- `helm lint ./charts/wiremind-baremetal`
- `helm template test ./charts/wiremind-baremetal`
- `helm template test ./charts/wiremind-baremetal --set raidDevice=/dev/md127`