### PR TITLE
fix(baremetal): add md0 device fallback

### DIFF
--- a/charts/wiremind-baremetal/Chart.yaml
+++ b/charts/wiremind-baremetal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wiremind-baremetal
 description: Helm chart to use BareMetal Encrypted at Rest disks
 icon: https://www.wiremind.io/assets/logo.png
-version: 2.0.0
+version: 2.0.1
 appVersion: "3.18.0"
 maintainers:
   - name: platform

--- a/charts/wiremind-baremetal/baremetal-scripts/decrypt-and-mount.sh
+++ b/charts/wiremind-baremetal/baremetal-scripts/decrypt-and-mount.sh
@@ -3,20 +3,26 @@ set -x
 set -e
 
 RAID_DEVICE="/dev/md/md0"
+FALLBACK_RAID_DEVICE="/dev/md/md0_0"
 DECRYPTED_LUKS_DEVICE_NAME="md0crypt"
 DECRYPTED_LUKS_DEVICE="/dev/mapper/md0crypt"
 LVM_PARTITION_DEVICES="/dev/md0cryptlvm/persistentvolume*"
 
-# Check if raid device exists
-set +e
+resolve_raid_device() {
+  for CANDIDATE_RAID_DEVICE in "$RAID_DEVICE" "$FALLBACK_RAID_DEVICE"; do
+    if mdadm -D "$CANDIDATE_RAID_DEVICE" >/dev/null 2>&1; then
+      RAID_DEVICE="$CANDIDATE_RAID_DEVICE"
+      return 0
+    fi
+  done
 
-device_details=$(mdadm -D "$RAID_DEVICE")
-if [[ "$?" != "0" ]]; then
-    echo "Raid device <${RAID_DEVICE}> not found, skipping"
-    exit 0
+  return 1
+}
+
+if ! resolve_raid_device; then
+  echo "Raid devices <${RAID_DEVICE}> and <${FALLBACK_RAID_DEVICE}> not found, skipping"
+  exit 0
 fi
-
-set -e
 
 wmb_decrypt_device() {
   if ! cryptsetup status $DECRYPTED_LUKS_DEVICE_NAME; then


### PR DESCRIPTION
## Summary
- add /dev/md/md0_0 fallback support in decrypt-and-mount.sh
- resolve the first available md device before luksOpen
- bump wiremind-baremetal chart version to 2.0.1

## Validation
- bash -n charts/wiremind-baremetal/baremetal-scripts/decrypt-and-mount.sh
- helm lint charts/wiremind-baremetal