### PR TITLE
fix(wiremind-baremetal): render extraEnv entries correctly

### DIFF
--- a/charts/wiremind-baremetal/CHANGELOG.md
+++ b/charts/wiremind-baremetal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v2.0.2 (2026-05-29)
+## Fix
+- Keep `extraEnv` entries under the container `env` list so the chart still renders when custom environment variables are set
+
 # v2.0.1 (2026-05-29)
 ## Fix
 - Allow configuring the RAID device path with the `raidDevice` value and try `/dev/md/md0` then `/dev/md127` by default

--- a/charts/wiremind-baremetal/Chart.yaml
+++ b/charts/wiremind-baremetal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wiremind-baremetal
 description: Helm chart to use BareMetal Encrypted at Rest disks
 icon: https://www.wiremind.io/assets/logo.png
-version: 2.0.1
+version: 2.0.2
 appVersion: "3.18.0"
 maintainers:
   - name: platform

--- a/charts/wiremind-baremetal/templates/baremetal-daemonset.yaml
+++ b/charts/wiremind-baremetal/templates/baremetal-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
           - name: RAID_DEVICE_CANDIDATES
             value: {{ .Values.raidDevice | quote }}
         {{- with .Values.extraEnv }}
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: {{ .Release.Name }}-install-script

--- a/charts/wiremind-baremetal/values.yaml
+++ b/charts/wiremind-baremetal/values.yaml
@@ -11,7 +11,7 @@ secret:
 extraEnv: []
 
 # Space-separated md device candidates checked in order.
-# We /dev/md127 because we did a mistake on creating /dev/md/md0_0 instead of /dev/md/md0 
+# We /dev/md127 because we did a mistake on creating /dev/md/md0_0 instead of /dev/md/md0
 # with symbolic link: /dev/md/md0_0 -> ../md127)
 raidDevice: "/dev/md/md0 /dev/md127"
 


### PR DESCRIPTION
## Summary
- fix the `wiremind-baremetal` daemonset template so `extraEnv` entries render inside the container `env` list
- bump the chart version to `2.0.2` and record the regression fix in the changelog
- address the regression introduced in #866 when `extraEnv` is non-empty

## Verification
- `helm template test ./charts/wiremind-baremetal --debug`
- `helm template test ./charts/wiremind-baremetal --debug --set-json 'extraEnv=[{\"name\":\"FOO\",\"value\":\"bar\"}]'`
- `helm template test ./charts/wiremind-baremetal --debug --set secret.existingSecret=foo --set-json 'extraEnv=[{\"name\":\"FOO\",\"value\":\"bar\"}]'`