### PR TITLE
fix(chartreuse): ArgoCD idempotency — dep sync-waves + ExternalSecret refresh annotation (6.3.4)

### DIFF
--- a/charts/chartreuse/Chart.yaml
+++ b/charts/chartreuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chartreuse
 appVersion: 6.2.1
-version: 6.3.3
+version: 6.3.4
 description: Automate Alembic SQL schema migrations.
 maintainers:
   - name: Wiremind

--- a/charts/chartreuse/templates/_helpers.tpl
+++ b/charts/chartreuse/templates/_helpers.tpl
@@ -80,6 +80,19 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+{{/*
+ArgoCD sync-wave for the Job's dependency resources (ServiceAccount, ConfigMap,
+RBAC, ExternalSecret). In ArgoCD mode the Job is a Sync hook at `argocd.syncWave`;
+ArgoCD applies (and health-gates) lower waves first, so these dependencies must sit
+one wave earlier than the Job or the hook deadlocks creating its pod (missing SA /
+ConfigMap / Secret). Empty under Helm, where they ship as part of the Release.
+*/}}
+{{- define "chartreuse.dependencyAnnotations" -}}
+{{- if eq .Values.deploymentMethod "argocd" -}}
+"argocd.argoproj.io/sync-wave": {{ sub (int .Values.argocd.syncWave) 1 | quote }}
+{{- end -}}
+{{- end -}}
+
 {{- define "chartreuse.annotations.ephemeral" -}}
 {{- if .Values.upgradeBeforeDeployment -}}
 "helm.sh/hook": pre-upgrade

--- a/charts/chartreuse/templates/_helpers.tpl
+++ b/charts/chartreuse/templates/_helpers.tpl
@@ -95,18 +95,19 @@ ConfigMap / Secret). Empty under Helm, where they ship as part of the Release.
 
 {{/*
 Annotations for the chartreuse-config ExternalSecret.
+- argocd mode: a sync-wave only (NO render-time timestamp — manifests are committed to
+  git, so `now` would break idempotency). Defaults to the dependency wave
+  (`syncWave - 1`) but is overridable via `argocd.externalSecretSyncWave` so an umbrella
+  can place it in its early "secrets" band, where a shared force-sync refresh Job
+  re-pulls it at deploy time. That refresh path relies on `refreshPolicy: OnChange`
+  (set in the ExternalSecret spec below), so a force-sync annotation triggers a pull.
 - helm mode: a render-time timestamp (moved here from a label) bumps the object on
-  every `helm upgrade`, forcing external-secrets to re-pull while `refreshInterval`
-  is intentionally long.
-- argocd mode: only the dependency sync-wave; NO timestamp. Manifests are committed
-  to git, so a per-render `now` would churn the diff and break idempotency. A config
-  change already mutates the ExternalSecret spec (bumping .metadata.generation), which
-  triggers an immediate re-sync; tune `refreshInterval` to catch store-side rotation.
-The two branches are mutually exclusive, so they never need joining.
+  every `helm upgrade`, forcing a re-pull while `refreshInterval` is intentionally long.
 */}}
 {{- define "chartreuse.externalSecretAnnotations" -}}
-{{- include "chartreuse.dependencyAnnotations" . -}}
-{{- if ne .Values.deploymentMethod "argocd" -}}
+{{- if eq .Values.deploymentMethod "argocd" -}}
+"argocd.argoproj.io/sync-wave": {{ .Values.argocd.externalSecretSyncWave | default (sub (int .Values.argocd.syncWave) 1) | quote }}
+{{- else -}}
 helm.sh/release-time: {{ now | unixEpoch | quote }}
 {{- end -}}
 {{- end -}}

--- a/charts/chartreuse/templates/_helpers.tpl
+++ b/charts/chartreuse/templates/_helpers.tpl
@@ -93,6 +93,24 @@ ConfigMap / Secret). Empty under Helm, where they ship as part of the Release.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Annotations for the chartreuse-config ExternalSecret.
+- helm mode: a render-time timestamp (moved here from a label) bumps the object on
+  every `helm upgrade`, forcing external-secrets to re-pull while `refreshInterval`
+  is intentionally long.
+- argocd mode: only the dependency sync-wave; NO timestamp. Manifests are committed
+  to git, so a per-render `now` would churn the diff and break idempotency. A config
+  change already mutates the ExternalSecret spec (bumping .metadata.generation), which
+  triggers an immediate re-sync; tune `refreshInterval` to catch store-side rotation.
+The two branches are mutually exclusive, so they never need joining.
+*/}}
+{{- define "chartreuse.externalSecretAnnotations" -}}
+{{- include "chartreuse.dependencyAnnotations" . -}}
+{{- if ne .Values.deploymentMethod "argocd" -}}
+helm.sh/release-time: {{ now | unixEpoch | quote }}
+{{- end -}}
+{{- end -}}
+
 {{- define "chartreuse.annotations.ephemeral" -}}
 {{- if .Values.upgradeBeforeDeployment -}}
 "helm.sh/hook": pre-upgrade

--- a/charts/chartreuse/templates/confimap.yaml
+++ b/charts/chartreuse/templates/confimap.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "chartreuse.fullname" . }}
   labels:
     {{- include "chartreuse.labels" . | nindent 4 }}
+  {{- with (include "chartreuse.dependencyAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   # Note: Chartreuse expects false values to be empty string (falsy value) and true values to be non-empty string.
 {{- if .Values.alembic.allowMigrationFromEmptyDatabase }}

--- a/charts/chartreuse/templates/externalsecrets/externalsecret-ephemeral.yaml
+++ b/charts/chartreuse/templates/externalsecrets/externalsecret-ephemeral.yaml
@@ -10,10 +10,10 @@ metadata:
     chart: {{ template "chartreuse.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    helm.sh/release-time: {{ now | unixEpoch | quote }}
     {{- include "chartreuse.labels" . | nindent 4 }}
   annotations:
     {{- include "chartreuse.annotations.ephemeral" . | nindent 4 }}
+    helm.sh/release-time: {{ now | unixEpoch | quote }}
 spec:
   refreshInterval: {{ .Values.alembic.externalSecrets.refreshInterval }}
   secretStoreRef:

--- a/charts/chartreuse/templates/externalsecrets/externalsecret.yaml
+++ b/charts/chartreuse/templates/externalsecrets/externalsecret.yaml
@@ -11,6 +11,10 @@ metadata:
     heritage: {{ .Release.Service }}
     helm.sh/release-time: {{ now | unixEpoch | quote }}
     {{- include "chartreuse.labels" . | nindent 4 }}
+  {{- with (include "chartreuse.dependencyAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   refreshInterval: {{ .Values.alembic.externalSecrets.refreshInterval }}
   secretStoreRef:

--- a/charts/chartreuse/templates/externalsecrets/externalsecret.yaml
+++ b/charts/chartreuse/templates/externalsecrets/externalsecret.yaml
@@ -15,6 +15,11 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if eq .Values.deploymentMethod "argocd" }}
+  # OnChange (not Periodic) so the committed manifest is idempotent and a force-sync
+  # annotation (applied at deploy time by the umbrella's refresh Job) triggers a re-pull.
+  refreshPolicy: OnChange
+  {{- end }}
   refreshInterval: {{ .Values.alembic.externalSecrets.refreshInterval }}
   secretStoreRef:
     kind: {{ .Values.alembic.externalSecrets.storeRef.kind }}

--- a/charts/chartreuse/templates/externalsecrets/externalsecret.yaml
+++ b/charts/chartreuse/templates/externalsecrets/externalsecret.yaml
@@ -9,9 +9,8 @@ metadata:
     chart: {{ template "chartreuse.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    helm.sh/release-time: {{ now | unixEpoch | quote }}
     {{- include "chartreuse.labels" . | nindent 4 }}
-  {{- with (include "chartreuse.dependencyAnnotations" .) }}
+  {{- with (include "chartreuse.externalSecretAnnotations" .) }}
   annotations:
     {{- . | nindent 4 }}
   {{- end }}

--- a/charts/chartreuse/templates/role.yaml
+++ b/charts/chartreuse/templates/role.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "chartreuse.fullname" . }}
   labels:
     {{- include "chartreuse.labels" . | nindent 4 }}
+  {{- with (include "chartreuse.dependencyAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
@@ -42,6 +46,10 @@ metadata:
   name: {{ template "chartreuse.fullname" . }}
   labels:
     {{- include "chartreuse.labels" . | nindent 4 }}
+  {{- with (include "chartreuse.dependencyAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/chartreuse/templates/serviceaccount.yaml
+++ b/charts/chartreuse/templates/serviceaccount.yaml
@@ -4,3 +4,7 @@ metadata:
   name: {{ template "chartreuse.serviceAccountName" . }}
   labels:
     {{- include "chartreuse.labels" . | nindent 4 }}
+  {{- with (include "chartreuse.dependencyAnnotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}

--- a/charts/chartreuse/values.yaml
+++ b/charts/chartreuse/values.yaml
@@ -105,4 +105,7 @@ argocd:
   ## Sync-wave for the chartreuse Job. Consumers should place their app Deployments
   ## at a higher wave (default 0) and their database resources at a lower wave so
   ## ordering is DB -> chartreuse -> app.
+  ## The Job's own dependencies (ServiceAccount, ConfigMap, RBAC, ExternalSecret)
+  ## are automatically placed one wave earlier (`syncWave - 1`) so they exist before
+  ## the Job hook runs.
   syncWave: -50

--- a/charts/chartreuse/values.yaml
+++ b/charts/chartreuse/values.yaml
@@ -109,3 +109,9 @@ argocd:
   ## are automatically placed one wave earlier (`syncWave - 1`) so they exist before
   ## the Job hook runs.
   syncWave: -50
+  ## Sync-wave for the chartreuse-config ExternalSecret specifically. Defaults to the
+  ## dependency wave (`syncWave - 1`). Override this to an umbrella's early "secrets"
+  ## wave (well before the Job) when a shared force-sync refresh Job is responsible for
+  ## re-pulling it at deploy time — that path also requires `refreshPolicy: OnChange`,
+  ## which this chart sets automatically in ArgoCD mode. null = use `syncWave - 1`.
+  externalSecretSyncWave: null


### PR DESCRIPTION
Three related changes that make the chartreuse chart deploy cleanly, idempotently, and with fresh credentials under `deploymentMethod=argocd`. Bumps chart `6.3.3 → 6.3.4`.

## 1. Sync-wave deadlock on the migration Job's dependencies
In ArgoCD mode the migration Job is a `Sync` hook at `argocd.syncWave` (-50), but its ServiceAccount/ConfigMap/RBAC/ExternalSecret had no sync-wave (default 0). ArgoCD applies lower waves first, so it created the Job before its dependencies and deadlocked (`serviceaccount … not found`, sync never reached wave 0). Fix: `chartreuse.dependencyAnnotations` stamps those resources at `syncWave - 1` (-51).

## 2. ExternalSecret `release-time` → annotation, dropped in ArgoCD mode
The chartreuse-config ExternalSecret used `helm.sh/release-time: {{ now }}` as a **label** to force re-pulls. It's now an **annotation**, and omitted in ArgoCD mode (a `now` baked into committed manifests breaks GitOps idempotency).

## 3. Refreshable by an umbrella force-sync Job (latest store value at migration time)
So a shared umbrella `refresh-external-secrets` Job can re-pull this secret at deploy time, in ArgoCD mode the ExternalSecret now:
- sets `refreshPolicy: OnChange` — a `force-sync` annotation (metadata change) triggers a re-pull, while the committed manifest stays idempotent (no periodic poll);
- takes its sync-wave from a new, overridable `argocd.externalSecretSyncWave` (default `syncWave - 1`). The umbrella sets this to its early "secrets" wave so the secret exists and is force-synced before the migration Job.

SA/ConfigMap/RBAC stay at `syncWave - 1`. Helm mode unchanged throughout.

## Verification
- chartreuse `helm template --set deploymentMethod=argocd`: deps `-51`, Job `-50`, ES `refreshPolicy: OnChange`; ES wave `-51` by default and `-109` when `argocd.externalSecretSyncWave=-109`; two renders byte-identical (idempotent).
- End-to-end through the wiremind umbrella (local render): chartreuse ES → wave `-109` + `OnChange`; refresh Job selector → `name in (wiremind,chartreuse)`.
- `helm template --set deploymentMethod=helm`: `release-time` annotation only; no sync-wave/refreshPolicy.
- `helm lint` passes in both modes.

> Companion umbrella change (broaden refresh-Job selector + set `chartreuse.argocd.externalSecretSyncWave: -109`) lives in helm-charts-private and requires this chart `>= 6.3.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)