### PR TITLE
chore(clickhouse-crds): upgrade to 0.27.0

### DIFF
--- a/charts/clickhouse-operator-crds/Chart.yaml
+++ b/charts/clickhouse-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: clickhouse-operator-crds
-version: 0.25.6
-appVersion: "0.25.6"
+version: 0.27.0
+appVersion: "0.27.0"
 description: Manage clickhouse-operator CRDs
 keywords:
   - clickhouse-operator

--- a/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -4,14 +4,14 @@
 # SINGULAR=clickhouseinstallation
 # PLURAL=clickhouseinstallations
 # SHORT=chi
-# OPERATOR_VERSION=0.25.6
+# OPERATOR_VERSION=0.27.0
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.25.6
+    clickhouse.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -26,6 +26,10 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+        - name: status
+          type: string
+          description: Resource status
+          jsonPath: .status.status
         - name: version
           type: string
           description: Operator version
@@ -49,10 +53,6 @@ spec:
           description: TaskID
           priority: 1 # show in wide view
           jsonPath: .status.taskID
-        - name: status
-          type: string
-          description: Resource status
-          jsonPath: .status.status
         - name: hosts-completed
           type: integer
           description: Completed hosts count
@@ -497,6 +497,80 @@ spec:
                           minimum: 0
                           maximum: 100
                           description: "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                    statefulSet: &TypeReconcileStatefulSet
+                      type: object
+                      description: "Optional, StatefulSet reconcile behavior tuning"
+                      properties:
+                        create:
+                          type: object
+                          description: "Behavior during create StatefulSet"
+                          properties:
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "delete"
+                                - "ignore"
+                        update:
+                          type: object
+                          description: "Behavior during update StatefulSet"
+                          properties:
+                            timeout:
+                              type: integer
+                              description: "How many seconds to wait for StatefulSet to be 'Ready' during update"
+                              minimum: 0
+                              maximum: 3600
+                            pollInterval:
+                              type: integer
+                              description: "How many seconds to wait between checks for StatefulSet status during update"
+                              minimum: 1
+                              maximum: 600
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "rollback"
+                                - "ignore"
+                        recreate:
+                          type: object
+                          description: "Behavior during recreate StatefulSet"
+                          properties:
+                            onDataLoss:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
+                            onUpdateFailure:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
                     host: &TypeReconcileHost
                       type: object
                       description: |
@@ -566,6 +640,228 @@ spec:
                                   !!merge <<: *TypeStringBool
                                   description: |
                                     Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated
+                        hooks: &TypeReconcileHooks
+                          type: object
+                          description: "hooks to execute before and after host reconcile"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before reconcile"
+                              nullable: true
+                              items: &TypeHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Reconcile lifecycle events that trigger this hook. Required, must be non-empty.
+                                      The hook is skipped on any reconcile whose classifier does not emit at least one
+                                      of the listed events. Supported values:
+                                        Any               - wildcard match: fires on every hook-evaluation point,
+                                                            including the pre-delete sweep on the dying host
+                                        HostCreate        - first reconcile that creates a host (no ancestor); best
+                                                            paired with POST hooks because PRE hooks on first creation
+                                                            are skipped (no live pod yet)
+                                        HostUpdate        - reconcile that has prior state for the host; catch-all
+                                                            for ongoing reconciles
+                                        HostStart         - host transitions from stopped to running
+                                        HostStop          - host is being stopped (current spec marks it stopped)
+                                        HostConfigRestart - in-place software restart for a configuration change
+                                        HostRollout       - pod-template change forces a StatefulSet rollout
+                                        HostShutdown      - aggregate: fires whenever the pod is going down for any
+                                                            reason (Stop, ConfigRestart, Rollout, or Delete)
+                                        HostDelete        - host is being removed from the cluster (downsize); fires
+                                                            on the dying host before tear-down. Always emitted
+                                                            alongside HostShutdown.
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "HostCreate"
+                                        - "hostcreate"
+                                        - "HostDelete"
+                                        - "hostdelete"
+                                        - "HostUpdate"
+                                        - "hostupdate"
+                                        - "HostStart"
+                                        - "hoststart"
+                                        - "HostStop"
+                                        - "hoststop"
+                                        - "HostConfigRestart"
+                                        - "hostconfigrestart"
+                                        - "HostRollout"
+                                        - "hostrollout"
+                                        - "HostShutdown"
+                                        - "hostshutdown"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default): error propagates — pre-hook aborts reconcile / host deletion.
+                                      Ignore: error is logged and the reconcile continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeHookAction
+                    cluster:
+                      type: object
+                      description: |
+                        CHI-level cluster reconcile defaults inherited by every cluster's
+                        spec.configuration.clusters[N].reconcile section. Use this as a single
+                        place to define cluster-level hooks that should apply to all clusters
+                        in this CHI; per-cluster hooks (under clusters[N].reconcile.hooks)
+                        are appended to (and dedup'd against) the inherited set.
+                      properties:
+                        hooks:
+                          type: object
+                          description: "cluster-level hooks inherited by every cluster"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before each cluster reconcile"
+                              nullable: true
+                              items: &TypeClusterHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Cluster-scope reconcile lifecycle events. Required, non-empty.
+                                        Any              - wildcard match: fires on every cluster reconcile pass
+                                                           and the cluster delete sweep
+                                        ClusterCreate    - all hosts in the cluster are new (no ancestor); fires
+                                                           only on the first reconcile of a brand-new cluster
+                                        ClusterReconcile - ongoing reconcile pass over an existing cluster (at
+                                                           least one host has prior state). Fires on every
+                                                           operator reconcile cycle the upstream gates allow,
+                                                           including taskID-only force-reconciles. NOT a "spec
+                                                           changed" signal.
+                                        ClusterDelete    - cluster is being removed (delete sweep — wiring follow-up)
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "ClusterCreate"
+                                        - "clustercreate"
+                                        - "ClusterDelete"
+                                        - "clusterdelete"
+                                        - "ClusterReconcile"
+                                        - "clusterreconcile"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default) propagates the error; Ignore logs a warning and continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after each cluster reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeClusterHookAction
                 reconcile:
                   !!merge <<: *TypeReconcile
                   description: "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
@@ -687,6 +983,30 @@ spec:
                               availabilityZone:
                                 type: string
                                 description: "availability zone for Zookeeper node"
+                        keeper:
+                          type: object
+                          description: |
+                            reference to a ClickHouseKeeperInstallation (CHK) resource.
+                            The operator resolves this to ZooKeeper node addresses automatically.
+                          properties:
+                            name:
+                              type: string
+                              description: "name of the ClickHouseKeeperInstallation custom resource"
+                            namespace:
+                              type: string
+                              description: "namespace of the CHK resource, defaults to the CHI namespace if omitted"
+                            serviceType:
+                              type: string
+                              description: |
+                                how to discover keeper endpoints:
+                                  replicas (default) — enumerate per-host services, one ZK node per keeper replica
+                                  service — use the CR-level headless service as a single ZK node entry
+                              enum:
+                                - ""
+                                - "Replicas"
+                                - "replicas"
+                                - "Service"
+                                - "service"
                         session_timeout_ms:
                           type: integer
                           description: "session timeout during connect to Zookeeper"
@@ -903,6 +1223,26 @@ spec:
                                 !!merge <<: *TypeReconcileRuntime
                               host:
                                 !!merge <<: *TypeReconcileHost
+                              hooks:
+                                # Per-cluster cluster-scope hooks. The schema (TypeClusterHookAction) is
+                                # defined once at spec.reconcile.cluster.hooks above; this block just
+                                # references it. Hooks defined here are merged with any inherited from
+                                # CHI-level spec.reconcile.cluster.hooks via dedup'd MergeFrom.
+                                type: object
+                                description: "cluster-level hooks to execute before and after cluster reconcile"
+                                properties:
+                                  pre:
+                                    type: array
+                                    description: "actions to execute before cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
+                                  post:
+                                    type: array
+                                    description: "actions to execute after cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
                           layout:
                             type: object
                             description: |

--- a/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -4,14 +4,14 @@
 # SINGULAR=clickhouseinstallationtemplate
 # PLURAL=clickhouseinstallationtemplates
 # SHORT=chit
-# OPERATOR_VERSION=0.25.6
+# OPERATOR_VERSION=0.27.0
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.25.6
+    clickhouse.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -26,6 +26,10 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+        - name: status
+          type: string
+          description: Resource status
+          jsonPath: .status.status
         - name: version
           type: string
           description: Operator version
@@ -49,10 +53,6 @@ spec:
           description: TaskID
           priority: 1 # show in wide view
           jsonPath: .status.taskID
-        - name: status
-          type: string
-          description: Resource status
-          jsonPath: .status.status
         - name: hosts-completed
           type: integer
           description: Completed hosts count
@@ -497,6 +497,80 @@ spec:
                           minimum: 0
                           maximum: 100
                           description: "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                    statefulSet: &TypeReconcileStatefulSet
+                      type: object
+                      description: "Optional, StatefulSet reconcile behavior tuning"
+                      properties:
+                        create:
+                          type: object
+                          description: "Behavior during create StatefulSet"
+                          properties:
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "delete"
+                                - "ignore"
+                        update:
+                          type: object
+                          description: "Behavior during update StatefulSet"
+                          properties:
+                            timeout:
+                              type: integer
+                              description: "How many seconds to wait for StatefulSet to be 'Ready' during update"
+                              minimum: 0
+                              maximum: 3600
+                            pollInterval:
+                              type: integer
+                              description: "How many seconds to wait between checks for StatefulSet status during update"
+                              minimum: 1
+                              maximum: 600
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "rollback"
+                                - "ignore"
+                        recreate:
+                          type: object
+                          description: "Behavior during recreate StatefulSet"
+                          properties:
+                            onDataLoss:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
+                            onUpdateFailure:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
                     host: &TypeReconcileHost
                       type: object
                       description: |
@@ -566,6 +640,228 @@ spec:
                                   !!merge <<: *TypeStringBool
                                   description: |
                                     Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated
+                        hooks: &TypeReconcileHooks
+                          type: object
+                          description: "hooks to execute before and after host reconcile"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before reconcile"
+                              nullable: true
+                              items: &TypeHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Reconcile lifecycle events that trigger this hook. Required, must be non-empty.
+                                      The hook is skipped on any reconcile whose classifier does not emit at least one
+                                      of the listed events. Supported values:
+                                        Any               - wildcard match: fires on every hook-evaluation point,
+                                                            including the pre-delete sweep on the dying host
+                                        HostCreate        - first reconcile that creates a host (no ancestor); best
+                                                            paired with POST hooks because PRE hooks on first creation
+                                                            are skipped (no live pod yet)
+                                        HostUpdate        - reconcile that has prior state for the host; catch-all
+                                                            for ongoing reconciles
+                                        HostStart         - host transitions from stopped to running
+                                        HostStop          - host is being stopped (current spec marks it stopped)
+                                        HostConfigRestart - in-place software restart for a configuration change
+                                        HostRollout       - pod-template change forces a StatefulSet rollout
+                                        HostShutdown      - aggregate: fires whenever the pod is going down for any
+                                                            reason (Stop, ConfigRestart, Rollout, or Delete)
+                                        HostDelete        - host is being removed from the cluster (downsize); fires
+                                                            on the dying host before tear-down. Always emitted
+                                                            alongside HostShutdown.
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "HostCreate"
+                                        - "hostcreate"
+                                        - "HostDelete"
+                                        - "hostdelete"
+                                        - "HostUpdate"
+                                        - "hostupdate"
+                                        - "HostStart"
+                                        - "hoststart"
+                                        - "HostStop"
+                                        - "hoststop"
+                                        - "HostConfigRestart"
+                                        - "hostconfigrestart"
+                                        - "HostRollout"
+                                        - "hostrollout"
+                                        - "HostShutdown"
+                                        - "hostshutdown"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default): error propagates — pre-hook aborts reconcile / host deletion.
+                                      Ignore: error is logged and the reconcile continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeHookAction
+                    cluster:
+                      type: object
+                      description: |
+                        CHI-level cluster reconcile defaults inherited by every cluster's
+                        spec.configuration.clusters[N].reconcile section. Use this as a single
+                        place to define cluster-level hooks that should apply to all clusters
+                        in this CHI; per-cluster hooks (under clusters[N].reconcile.hooks)
+                        are appended to (and dedup'd against) the inherited set.
+                      properties:
+                        hooks:
+                          type: object
+                          description: "cluster-level hooks inherited by every cluster"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before each cluster reconcile"
+                              nullable: true
+                              items: &TypeClusterHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Cluster-scope reconcile lifecycle events. Required, non-empty.
+                                        Any              - wildcard match: fires on every cluster reconcile pass
+                                                           and the cluster delete sweep
+                                        ClusterCreate    - all hosts in the cluster are new (no ancestor); fires
+                                                           only on the first reconcile of a brand-new cluster
+                                        ClusterReconcile - ongoing reconcile pass over an existing cluster (at
+                                                           least one host has prior state). Fires on every
+                                                           operator reconcile cycle the upstream gates allow,
+                                                           including taskID-only force-reconciles. NOT a "spec
+                                                           changed" signal.
+                                        ClusterDelete    - cluster is being removed (delete sweep — wiring follow-up)
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "ClusterCreate"
+                                        - "clustercreate"
+                                        - "ClusterDelete"
+                                        - "clusterdelete"
+                                        - "ClusterReconcile"
+                                        - "clusterreconcile"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default) propagates the error; Ignore logs a warning and continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after each cluster reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeClusterHookAction
                 reconcile:
                   !!merge <<: *TypeReconcile
                   description: "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
@@ -687,6 +983,30 @@ spec:
                               availabilityZone:
                                 type: string
                                 description: "availability zone for Zookeeper node"
+                        keeper:
+                          type: object
+                          description: |
+                            reference to a ClickHouseKeeperInstallation (CHK) resource.
+                            The operator resolves this to ZooKeeper node addresses automatically.
+                          properties:
+                            name:
+                              type: string
+                              description: "name of the ClickHouseKeeperInstallation custom resource"
+                            namespace:
+                              type: string
+                              description: "namespace of the CHK resource, defaults to the CHI namespace if omitted"
+                            serviceType:
+                              type: string
+                              description: |
+                                how to discover keeper endpoints:
+                                  replicas (default) — enumerate per-host services, one ZK node per keeper replica
+                                  service — use the CR-level headless service as a single ZK node entry
+                              enum:
+                                - ""
+                                - "Replicas"
+                                - "replicas"
+                                - "Service"
+                                - "service"
                         session_timeout_ms:
                           type: integer
                           description: "session timeout during connect to Zookeeper"
@@ -903,6 +1223,26 @@ spec:
                                 !!merge <<: *TypeReconcileRuntime
                               host:
                                 !!merge <<: *TypeReconcileHost
+                              hooks:
+                                # Per-cluster cluster-scope hooks. The schema (TypeClusterHookAction) is
+                                # defined once at spec.reconcile.cluster.hooks above; this block just
+                                # references it. Hooks defined here are merged with any inherited from
+                                # CHI-level spec.reconcile.cluster.hooks via dedup'd MergeFrom.
+                                type: object
+                                description: "cluster-level hooks to execute before and after cluster reconcile"
+                                properties:
+                                  pre:
+                                    type: array
+                                    description: "actions to execute before cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
+                                  post:
+                                    type: array
+                                    description: "actions to execute after cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
                           layout:
                             type: object
                             description: |

--- a/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
+++ b/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
@@ -1,13 +1,13 @@
 # Template Parameters:
 #
-# OPERATOR_VERSION=0.25.6
+# OPERATOR_VERSION=0.27.0
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhousekeeperinstallations.clickhouse-keeper.altinity.com
   labels:
-    clickhouse-keeper.altinity.com/chop: 0.25.6
+    clickhouse-keeper.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse-keeper.altinity.com
   scope: Namespaced
@@ -22,6 +22,10 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+        - name: status
+          type: string
+          description: Resource status
+          jsonPath: .status.status
         - name: version
           type: string
           description: Operator version
@@ -45,15 +49,10 @@ spec:
           description: TaskID
           priority: 1 # show in wide view
           jsonPath: .status.taskID
-        - name: status
-          type: string
-          description: Resource status
-          jsonPath: .status.status
-        - name: hosts-unchanged
+        - name: hosts-completed
           type: integer
-          description: Unchanged hosts count
-          priority: 1 # show in wide view
-          jsonPath: .status.hostsUnchanged
+          description: Completed hosts count
+          jsonPath: .status.hostsCompleted
         - name: hosts-updated
           type: integer
           description: Updated hosts count
@@ -64,20 +63,11 @@ spec:
           description: Added hosts count
           priority: 1 # show in wide view
           jsonPath: .status.hostsAdded
-        - name: hosts-completed
-          type: integer
-          description: Completed hosts count
-          jsonPath: .status.hostsCompleted
         - name: hosts-deleted
           type: integer
           description: Hosts deleted count
           priority: 1 # show in wide view
           jsonPath: .status.hostsDeleted
-        - name: hosts-delete
-          type: integer
-          description: Hosts to be deleted count
-          priority: 1 # show in wide view
-          jsonPath: .status.hostsDelete
         - name: endpoint
           type: string
           description: Client access endpoint
@@ -243,10 +233,12 @@ spec:
                 normalized:
                   type: object
                   description: "Normalized resource requested"
+                  nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 normalizedCompleted:
                   type: object
                   description: "Normalized resource completed"
+                  nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 hostsWithTablesCreated:
                   type: array
@@ -284,7 +276,7 @@ spec:
                 stop: &TypeStringBool
                   type: string
                   description: |
-                    Allows to stop all ClickHouse clusters defined in a CHI.
+                    Allows to stop all ClickHouse Keeper clusters defined in a CHK.
                     Works as the following:
                      - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.
                      - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.
@@ -527,6 +519,11 @@ spec:
                             description: |
                               optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`
                               override top-level `chi.spec.configuration.files`
+                          templates:
+                            !!merge <<: *TypeTemplateNames
+                            description: |
+                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
+                              override top-level `chi.spec.configuration.templates`
                           pdbManaged:
                             !!merge <<: *TypeStringBool
                             description: |
@@ -544,11 +541,6 @@ spec:
                               by specifying 0. This is a mutually exclusive setting with "minAvailable".
                             minimum: 0
                             maximum: 65535
-                          templates:
-                            !!merge <<: *TypeTemplateNames
-                            description: |
-                              optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster
-                              override top-level `chi.spec.configuration.templates`
                           layout:
                             type: object
                             description: |

--- a/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/charts/clickhouse-operator-crds/templates/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -7,7 +7,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.25.6
+    clickhouse.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -56,6 +56,20 @@ spec:
                       type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
                       x-kubernetes-preserve-unknown-fields: true
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - None
+                            - ignore
+                            - Ignore
+                            - restart
+                            - Restart
+                          description: "none/ignore — do nothing; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"
@@ -240,6 +254,19 @@ spec:
                                 Timeout used to limit metrics collection request. In seconds.
                                 Upon reaching this timeout metrics collection is aborted and no more metrics are collected in this cycle.
                                 All collected metrics are returned.
+                        tablesRegexp:
+                          type: string
+                          description: |
+                            Regexp to match tables in system database to fetch metrics from.
+                            Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
+                            Default is "^(metrics|custom_metrics)$".
+                        excludeRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -318,6 +345,24 @@ spec:
                                 1. abort - do nothing, just break the process and wait for admin.
                                 2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
                                 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
+                        recreate:
+                          type: object
+                          description: "Behavior during recreate StatefulSet"
+                          properties:
+                            onDataLoss:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate (default) - proceed and recreate StatefulSet.
+                            onUpdateFailure:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate (default) - proceed and recreate StatefulSet.
                     host:
                       type: object
                       description: |
@@ -413,6 +458,109 @@ spec:
                                   !!merge <<: *TypeStringBool
                                   description: |
                                     Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated
+                        hooks:
+                          type: object
+                          description: "default host-level hooks to execute before and after host reconcile"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before host reconcile"
+                              nullable: true
+                              items: &TypeHookActionChop
+                                type: object
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook: FirstHost (default), AllHosts, AllShards"
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                            post:
+                              type: array
+                              description: "actions to execute after host reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeHookActionChop
+                    coordination:
+                      type: object
+                      description: "Coordination with external systems during reconcile"
+                      properties:
+                        keeper:
+                          type: object
+                          description: "Keeper-related coordination settings"
+                          properties:
+                            readyTimeout:
+                              type: integer
+                              minimum: 1
+                              description: |
+                                How long the operator waits for a referenced ClickHouseKeeper to become ready
+                                before aborting CHI reconcile. In seconds. Default is 120.
+                            onKeeperResourceUpdate:
+                              type: string
+                              description: |
+                                Reaction when a referenced CHK resource changes.
+                                  none (default) — do nothing
+                                  reconcile — trigger CHI reconcile
+                              enum:
+                                - ""
+                                - "None"
+                                - "none"
+                                - "Reconcile"
+                                - "reconcile"
+                    recovery:
+                      type: object
+                      description: "Auto-recovery from reconcile failures, scoped by CHI state"
+                      properties:
+                        from:
+                          type: object
+                          description: "Recovery scopes keyed by CHI state being recovered from"
+                          properties:
+                            aborted:
+                              type: object
+                              description: "Recovery from Status=Aborted"
+                              properties:
+                                onPodReady:
+                                  type: string
+                                  description: |
+                                    Reaction when a pod belonging to an Aborted CHI transitions to Ready.
+                                      retry (default) — re-enqueue the CHI for reconcile
+                                      none — do nothing, CHI stays Aborted
+                                  enum:
+                                    - ""
+                                    - "None"
+                                    - "none"
+                                    - "Retry"
+                                    - "retry"
                 annotation:
                   type: object
                   description: "defines which metadata.annotations items will include or exclude during render StatefulSet, Pod, PVC resources"


### PR DESCRIPTION
This upgrade is needed to fix a nul pointer dereference when polling CR during rolling updates.

Since argoCD introduces sync-waves to idempotent resources like volumeClaimsTemplates rolling updates are needed.

Fix: https://github.com/Altinity/clickhouse-operator/pull/1974