### PR TITLE
chore(velero-crds): upgrade to 12.0.3

### DIFF
--- a/charts/velero-crds/Chart.yaml
+++ b/charts/velero-crds/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: velero-crds
 description: A Helm chart to manage velero CRDs
 # Set it velero's Chart version.
-appVersion: 1.17.0
+appVersion: 1.18.1
 kubeVersion: ">=1.16.0-0"
-version: 11.1.1
+version: 12.0.3
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/velero-crds/README.md
+++ b/charts/velero-crds/README.md
@@ -11,7 +11,7 @@ If the version of the CRDs changes, aka breaking changes (this doesn't happen ev
 ```
 cd charts/velero-crds
 repo="vmware-tanzu/helm-charts"
-branch="velero-10.0.4"
+branch="velero-12.0.3"
 folder="charts/velero/crds"
 files=$(curl -s "https://api.github.com/repos/$repo/contents/$folder?ref=$branch" | jq -r '.[].download_url')
 for file in $files

--- a/charts/velero-crds/templates/backuprepositories.yaml
+++ b/charts/velero-crds/templates/backuprepositories.yaml
@@ -116,8 +116,8 @@ spec:
                       nullable: true
                       type: string
                     message:
-                      description: Message is a message about the current status
-                        of the repo maintenance.
+                      description: Message is a message about the current status of
+                        the repo maintenance.
                       type: string
                     result:
                       description: Result is the result of the repo maintenance.
@@ -126,8 +126,7 @@ spec:
                       - Failed
                       type: string
                     startTimestamp:
-                      description: StartTimestamp is the start time of the repo
-                        maintenance.
+                      description: StartTimestamp is the start time of the repo maintenance.
                       format: date-time
                       nullable: true
                       type: string

--- a/charts/velero-crds/templates/backups.yaml
+++ b/charts/velero-crds/templates/backups.yaml
@@ -124,8 +124,8 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources
-                            to which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
@@ -147,8 +147,8 @@ spec:
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the
-                            resources to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -202,8 +202,7 @@ spec:
                             PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
                             These are executed after all "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a
-                              resource.
+                            description: BackupResourceHook defines a hook for a resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -222,8 +221,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -245,8 +244,7 @@ spec:
                             PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
                             These are executed before any "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a
-                              resource.
+                            description: BackupResourceHook defines a hook for a resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -265,8 +263,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -407,16 +405,16 @@ spec:
                     label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector
-                        requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
                         description: |-
                           A label selector requirement is a selector that contains values, a key, and an operator that
                           relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector
-                              applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
                             description: |-
@@ -494,8 +492,8 @@ spec:
                 nullable: true
                 type: boolean
               storageLocation:
-                description: StorageLocation is a string containing the name of
-                  a BackupStorageLocation where the backup should be stored.
+                description: StorageLocation is a string containing the name of a
+                  BackupStorageLocation where the backup should be stored.
                 type: string
               ttl:
                 description: |-
@@ -503,8 +501,7 @@ spec:
                   the Backup should be retained for.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the
-                  uploader.
+                description: UploaderConfig specifies the configuration for the uploader.
                 nullable: true
                 properties:
                   parallelFilesUpload:
@@ -513,12 +510,12 @@ spec:
                     type: integer
                 type: object
               volumeGroupSnapshotLabelKey:
-                description: VolumeGroupSnapshotLabelKey specifies the label key
-                  to group PVCs under a VGS.
+                description: VolumeGroupSnapshotLabelKey specifies the label key to
+                  group PVCs under a VGS.
                 type: string
               volumeSnapshotLocations:
-                description: VolumeSnapshotLocations is a list containing names
-                  of VolumeSnapshotLocations associated with this backup.
+                description: VolumeSnapshotLocations is a list containing names of
+                  VolumeSnapshotLocations associated with this backup.
                 items:
                   type: string
                 type: array
@@ -580,8 +577,8 @@ spec:
                   major, minor, and patch version.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of
-                  the hooks.
+                description: HookStatus contains information about the status of the
+                  hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
@@ -591,14 +588,16 @@ spec:
                       and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which
-                      ended with an error
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
                     type: integer
                 type: object
               phase:
                 description: Phase is the current state of the Backup.
                 enum:
                 - New
+                - Queued
+                - ReadyToStart
                 - FailedValidation
                 - InProgress
                 - WaitingForPluginOperations
@@ -630,6 +629,11 @@ spec:
                       filters that happen as items are processed.
                     type: integer
                 type: object
+              queuePosition:
+                description: |-
+                  QueuePosition is the position of the backup in the queue.
+                  Only relevant when Phase is "Queued"
+                type: integer
               startTimestamp:
                 description: |-
                   StartTimestamp records the time a backup was started.

--- a/charts/velero-crds/templates/backupstoragelocations.yaml
+++ b/charts/velero-crds/templates/backupstoragelocations.yaml
@@ -23,8 +23,8 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: LastValidationTime is the last time the backup store location
-        was validated
+    - description: LastValidationTime is the last time the backup store location was
+        validated
       jsonPath: .status.lastValidationTime
       name: Last Validated
       type: date
@@ -59,8 +59,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupStorageLocationSpec defines the desired state of
-              a Velero BackupStorageLocation
+            description: BackupStorageLocationSpec defines the desired state of a
+              Velero BackupStorageLocation
             properties:
               accessMode:
                 description: AccessMode defines the permissions for the backup storage
@@ -84,8 +84,8 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be
-                      a valid secret key.
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
                   name:
                     default: ""
@@ -115,10 +115,38 @@ spec:
                     description: Bucket is the bucket to use for object storage.
                     type: string
                   caCert:
-                    description: CACert defines a CA bundle to use when verifying
-                      TLS connections to the provider.
+                    description: |-
+                      CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                      Deprecated: Use CACertRef instead.
                     format: byte
                     type: string
+                  caCertRef:
+                    description: |-
+                      CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                      when verifying TLS connections to the provider. The Secret must be in the same
+                      namespace as the BackupStorageLocation.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   prefix:
                     description: Prefix is the path inside a bucket to use for Velero
                       storage. Optional.
@@ -139,8 +167,8 @@ spec:
             - provider
             type: object
           status:
-            description: BackupStorageLocationStatus defines the observed state
-              of BackupStorageLocation
+            description: BackupStorageLocationStatus defines the observed state of
+              BackupStorageLocation
             properties:
               accessMode:
                 description: |-

--- a/charts/velero-crds/templates/datadownloads.yaml
+++ b/charts/velero-crds/templates/datadownloads.yaml
@@ -35,8 +35,7 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is
-        stored
+    - description: Name of the Backup Storage Location where the backup data is stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -96,8 +95,7 @@ spec:
                   If DataMover is "" or "velero", the built-in data mover will be used.
                 type: string
               nodeOS:
-                description: NodeOS is OS of the node where the DataDownload is
-                  processed.
+                description: NodeOS is OS of the node where the DataDownload is processed.
                 enum:
                 - auto
                 - linux
@@ -109,9 +107,13 @@ spec:
                   before returning error as timeout.
                 type: string
               snapshotID:
-                description: SnapshotID is the ID of the Velero backup snapshot
-                  to be restored from.
+                description: SnapshotID is the ID of the Velero backup snapshot to
+                  be restored from.
                 type: string
+              snapshotSize:
+                description: SnapshotSize is the logical size in Bytes of the snapshot.
+                format: int64
+                type: integer
               sourceNamespace:
                 description: |-
                   SourceNamespace is the original namespace where the volume is backed up from.
@@ -125,8 +127,8 @@ spec:
                     description: Namespace is the target namespace
                     type: string
                   pv:
-                    description: PV is the name of the target PV that is created
-                      by Velero restore
+                    description: PV is the name of the target PV that is created by
+                      Velero restore
                     type: string
                   pvc:
                     description: PVC is the name of the target PVC that is created
@@ -169,8 +171,7 @@ spec:
                 description: Message is a message about the DataDownload's status.
                 type: string
               node:
-                description: Node is name of the node where the DataDownload is
-                  processed.
+                description: Node is name of the node where the DataDownload is processed.
                 type: string
               phase:
                 description: Phase is the current state of the DataDownload.

--- a/charts/velero-crds/templates/datauploads.yaml
+++ b/charts/velero-crds/templates/datauploads.yaml
@@ -35,8 +35,14 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should
-        be stored
+    - description: Incremental bytes
+      format: int64
+      jsonPath: .status.incrementalBytes
+      name: Incremental Bytes
+      priority: 10
+      type: integer
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -51,8 +57,8 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: DataUpload acts as the protocol between data mover plugins
-          and data mover controller for the datamover backup operation
+        description: DataUpload acts as the protocol between data mover plugins and
+          data mover controller for the datamover backup operation
         properties:
           apiVersion:
             description: |-
@@ -93,8 +99,8 @@ spec:
                     description: Driver is the driver used by the VolumeSnapshotContent
                     type: string
                   snapshotClass:
-                    description: SnapshotClass is the name of the snapshot class
-                      that the volume snapshot is created with
+                    description: SnapshotClass is the name of the snapshot class that
+                      the volume snapshot is created with
                     type: string
                   storageClass:
                     description: StorageClass is the name of the storage class of
@@ -135,8 +141,8 @@ spec:
                   It is the same namespace for SourcePVC and CSI namespaced objects.
                 type: string
               sourcePVC:
-                description: SourcePVC is the name of the PVC which the snapshot
-                  is taken for.
+                description: SourcePVC is the name of the PVC which the snapshot is
+                  taken for.
                 type: string
             required:
             - backupStorageLocation
@@ -175,6 +181,11 @@ spec:
                   as a result of the DataUpload.
                 nullable: true
                 type: object
+              incrementalBytes:
+                description: IncrementalBytes holds the number of bytes new or changed
+                  since the last backup
+                format: int64
+                type: integer
               message:
                 description: Message is a message about the DataUpload's status.
                 type: string
@@ -189,8 +200,8 @@ spec:
                 - windows
                 type: string
               path:
-                description: Path is the full path of the snapshot volume being
-                  backed up.
+                description: Path is the full path of the snapshot volume being backed
+                  up.
                 type: string
               phase:
                 description: Phase is the current state of the DataUpload.

--- a/charts/velero-crds/templates/deletebackuprequests.yaml
+++ b/charts/velero-crds/templates/deletebackuprequests.yaml
@@ -48,8 +48,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: DeleteBackupRequestSpec is the specification for which
-              backups to delete.
+            description: DeleteBackupRequestSpec is the specification for which backups
+              to delete.
             properties:
               backupName:
                 type: string

--- a/charts/velero-crds/templates/downloadrequests.yaml
+++ b/charts/velero-crds/templates/downloadrequests.yaml
@@ -41,8 +41,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DownloadRequestSpec is the specification for a download
-              request.
+            description: DownloadRequestSpec is the specification for a download request.
             properties:
               target:
                 description: Target is what to download (e.g. logs for a backup).
@@ -84,8 +83,8 @@ spec:
                   file.
                 type: string
               expiration:
-                description: Expiration is when this DownloadRequest expires and
-                  can be deleted by the system.
+                description: Expiration is when this DownloadRequest expires and can
+                  be deleted by the system.
                 format: date-time
                 nullable: true
                 type: string

--- a/charts/velero-crds/templates/podvolumebackups.yaml
+++ b/charts/velero-crds/templates/podvolumebackups.yaml
@@ -35,8 +35,14 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should
-        be stored
+    - description: Incremental bytes
+      format: int64
+      jsonPath: .status.incrementalBytes
+      name: Incremental Bytes
+      priority: 10
+      type: integer
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -91,8 +97,8 @@ spec:
                   on.
                 type: string
               pod:
-                description: Pod is a reference to the pod containing the volume
-                  to be backed up.
+                description: Pod is a reference to the pod containing the volume to
+                  be backed up.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -153,8 +159,8 @@ spec:
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle
-                  the data transfer.
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
                 enum:
                 - kopia
                 - restic
@@ -191,9 +197,13 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              incrementalBytes:
+                description: IncrementalBytes holds the number of bytes new or changed
+                  since the last backup
+                format: int64
+                type: integer
               message:
-                description: Message is a message about the pod volume backup's
-                  status.
+                description: Message is a message about the pod volume backup's status.
                 type: string
               path:
                 description: Path is the full path within the controller pod being

--- a/charts/velero-crds/templates/podvolumerestores.yaml
+++ b/charts/velero-crds/templates/podvolumerestores.yaml
@@ -35,8 +35,7 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is
-        stored
+    - description: Name of the Backup Storage Location where the backup data is stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -87,8 +86,8 @@ spec:
                   when the PodVolumeRestore is in InProgress phase
                 type: boolean
               pod:
-                description: Pod is a reference to the pod containing the volume
-                  to be restored.
+                description: Pod is a reference to the pod containing the volume to
+                  be restored.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -136,6 +135,10 @@ spec:
               snapshotID:
                 description: SnapshotID is the ID of the volume snapshot to be restored.
                 type: string
+              snapshotSize:
+                description: SnapshotSize is the logical size in Bytes of the snapshot.
+                format: int64
+                type: integer
               sourceNamespace:
                 description: SourceNamespace is the original namespace for namaspace
                   mapping.
@@ -149,16 +152,16 @@ spec:
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle
-                  the data transfer.
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
                 enum:
                 - kopia
                 - restic
                 - ""
                 type: string
               volume:
-                description: Volume is the name of the volume within the Pod to
-                  be restored.
+                description: Volume is the name of the volume within the Pod to be
+                  restored.
                 type: string
             required:
             - backupStorageLocation
@@ -187,8 +190,7 @@ spec:
                 nullable: true
                 type: string
               message:
-                description: Message is a message about the pod volume restore's
-                  status.
+                description: Message is a message about the pod volume restore's status.
                 type: string
               node:
                 description: Node is name of the node where the pod volume restore

--- a/charts/velero-crds/templates/restores.yaml
+++ b/charts/velero-crds/templates/restores.yaml
@@ -87,8 +87,8 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources
-                            to which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
@@ -110,8 +110,8 @@ spec:
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the
-                            resources to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -172,8 +172,8 @@ spec:
                                 properties:
                                   command:
                                     description: Command is the command and arguments
-                                      to execute from within a container after a
-                                      pod has been restored.
+                                      to execute from within a container after a pod
+                                      has been restored.
                                     items:
                                       type: string
                                     minItems: 1
@@ -190,8 +190,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -214,9 +214,8 @@ spec:
                                 description: Init defines an init restore hook.
                                 properties:
                                   initContainers:
-                                    description: InitContainers is list of init
-                                      containers to be added to a pod during its
-                                      restore.
+                                    description: InitContainers is list of init containers
+                                      to be added to a pod during its restore.
                                     items:
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
@@ -336,16 +335,16 @@ spec:
                     label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector
-                        requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
                         description: |-
                           A label selector requirement is a selector that contains values, a key, and an operator that
                           relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector
-                              applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
                             description: |-
@@ -381,8 +380,8 @@ spec:
                 nullable: true
                 type: array
               preserveNodePorts:
-                description: PreserveNodePorts specifies whether to restore old
-                  nodePorts from backup.
+                description: PreserveNodePorts specifies whether to restore old nodePorts
+                  from backup.
                 nullable: true
                 type: boolean
               resourceModifier:
@@ -442,17 +441,16 @@ spec:
                   from the most recent successful backup created from this schedule.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the
-                  restore.
+                description: UploaderConfig specifies the configuration for the restore.
                 nullable: true
                 properties:
                   parallelFilesDownload:
-                    description: ParallelFilesDownload is the concurrency number
-                      setting for restore.
+                    description: ParallelFilesDownload is the concurrency number setting
+                      for restore.
                     type: integer
                   writeSparseFiles:
-                    description: WriteSparseFiles is a flag to indicate whether
-                      write files sparsely or not.
+                    description: WriteSparseFiles is a flag to indicate whether write
+                      files sparsely or not.
                     nullable: true
                     type: boolean
                 type: object
@@ -478,8 +476,8 @@ spec:
                   to fail.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of
-                  the hooks.
+                description: HookStatus contains information about the status of the
+                  hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
@@ -489,8 +487,8 @@ spec:
                       and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which
-                      ended with an error
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
                     type: integer
                 type: object
               phase:
@@ -515,8 +513,8 @@ spec:
                 nullable: true
                 properties:
                   itemsRestored:
-                    description: ItemsRestored is the number of items that have
-                      actually been restored so far
+                    description: ItemsRestored is the number of items that have actually
+                      been restored so far
                     type: integer
                   totalItems:
                     description: |-

--- a/charts/velero-crds/templates/schedules.yaml
+++ b/charts/velero-crds/templates/schedules.yaml
@@ -63,8 +63,7 @@ spec:
             description: ScheduleSpec defines the specification for a Velero schedule
             properties:
               paused:
-                description: Paused specifies whether the schedule is paused or
-                  not
+                description: Paused specifies whether the schedule is paused or not
                 type: boolean
               schedule:
                 description: |-
@@ -145,12 +144,12 @@ spec:
                     nullable: true
                     type: array
                   hooks:
-                    description: Hooks represent custom behaviors that should be
-                      executed at different phases of the backup.
+                    description: Hooks represent custom behaviors that should be executed
+                      at different phases of the backup.
                     properties:
                       resources:
-                        description: Resources are hooks that should be executed
-                          when backing up individual instances of a resource.
+                        description: Resources are hooks that should be executed when
+                          backing up individual instances of a resource.
                         items:
                           description: |-
                             BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
@@ -187,14 +186,13 @@ spec:
                               nullable: true
                               type: array
                             labelSelector:
-                              description: LabelSelector, if specified, filters
-                                the resources to which this hook spec applies.
+                              description: LabelSelector, if specified, filters the
+                                resources to which this hook spec applies.
                               nullable: true
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
-                                    selector requirements. The requirements are
-                                    ANDed.
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
@@ -250,8 +248,8 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and
-                                          arguments to execute.
+                                        description: Command is the command and arguments
+                                          to execute.
                                         items:
                                           type: string
                                         minItems: 1
@@ -293,8 +291,8 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and
-                                          arguments to execute.
+                                        description: Command is the command and arguments
+                                          to execute.
                                         items:
                                           type: string
                                         minItems: 1
@@ -535,8 +533,8 @@ spec:
                     nullable: true
                     type: boolean
                   storageLocation:
-                    description: StorageLocation is a string containing the name
-                      of a BackupStorageLocation where the backup should be stored.
+                    description: StorageLocation is a string containing the name of
+                      a BackupStorageLocation where the backup should be stored.
                     type: string
                   ttl:
                     description: |-
@@ -544,18 +542,18 @@ spec:
                       the Backup should be retained for.
                     type: string
                   uploaderConfig:
-                    description: UploaderConfig specifies the configuration for
-                      the uploader.
+                    description: UploaderConfig specifies the configuration for the
+                      uploader.
                     nullable: true
                     properties:
                       parallelFilesUpload:
-                        description: ParallelFilesUpload is the number of files
-                          parallel uploads to perform when using the uploader.
+                        description: ParallelFilesUpload is the number of files parallel
+                          uploads to perform when using the uploader.
                         type: integer
                     type: object
                   volumeGroupSnapshotLabelKey:
-                    description: VolumeGroupSnapshotLabelKey specifies the label
-                      key to group PVCs under a VGS.
+                    description: VolumeGroupSnapshotLabelKey specifies the label key
+                      to group PVCs under a VGS.
                     type: string
                   volumeSnapshotLocations:
                     description: VolumeSnapshotLocations is a list containing names

--- a/charts/velero-crds/templates/serverstatusrequests.yaml
+++ b/charts/velero-crds/templates/serverstatusrequests.yaml
@@ -55,8 +55,8 @@ spec:
                 - Processed
                 type: string
               plugins:
-                description: Plugins list information about the plugins running
-                  on the Velero server
+                description: Plugins list information about the plugins running on
+                  the Velero server
                 items:
                   description: PluginInfo contains attributes of a Velero plugin
                   properties:

--- a/charts/velero-crds/templates/volumesnapshotlocations.yaml
+++ b/charts/velero-crds/templates/volumesnapshotlocations.yaml
@@ -55,8 +55,8 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be
-                      a valid secret key.
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
                   name:
                     default: ""
@@ -85,8 +85,8 @@ spec:
               of a Velero VolumeSnapshotLocation.
             properties:
               phase:
-                description: VolumeSnapshotLocationPhase is the lifecycle phase
-                  of a Velero VolumeSnapshotLocation.
+                description: VolumeSnapshotLocationPhase is the lifecycle phase of
+                  a Velero VolumeSnapshotLocation.
                 enum:
                 - Available
                 - Unavailable


### PR DESCRIPTION
## Summary
- refresh `velero-crds` from `vmware-tanzu/helm-charts` tag `velero-12.0.3`
- bump the chart version to `12.0.3` and align `appVersion` with upstream `1.18.1`
- update the README refresh snippet and keep generated `creationTimestamp: null` lines commented for validation compatibility

## Validation
- `helm lint charts/velero-crds`
- `helm template test-release charts/velero-crds > /tmp/velero-crds-rendered.yaml`