### PR TITLE
chore(external-dns-crds): upgrade to 1.21.1

### DIFF
--- a/charts/external-dns-crds/Chart.yaml
+++ b/charts/external-dns-crds/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: external-dns-crds
 description: A Helm chart to manage external-dns CRDs
-version: 1.17.0
-appVersion: 0.17.0
+version: 1.21.1
+appVersion: 0.21.0
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts


### PR DESCRIPTION
## Summary
- Bump `external-dns-crds` chart version 1.17.0 → 1.21.1 (appVersion 0.17.0 → 0.21.0) to track upstream `external-dns` chart releases.
- No CRD content changes between upstream tags `external-dns-helm-chart-1.17.0` and `external-dns-helm-chart-1.21.1` (verified `dnsendpoints.externaldns.k8s.io.yaml` is byte-identical).

## Test plan
- [x] Diffed upstream CRD manifest between the two tags — no changes
- [ ] CI passes