### PR TITLE
fix(clamav): freshclam configmap should use freshclamConfigDict

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An Open-Source antivirus engine for detecting trojans, viruses, malware & other malicious threats. Using official docker image.
 name: clamav
-version: 3.7.1
+version: 3.7.2
 appVersion: "1.4.3"
 home: https://www.clamav.net
 icon: https://www.clamav.net/assets/clamav-trademark.png

--- a/charts/clamav/templates/freshclam-configmap.yaml
+++ b/charts/clamav/templates/freshclam-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.freshclamConfig .Values.clamdConfigDict -}}
+{{- if or .Values.freshclamConfig .Values.freshclamConfigDict -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Currently, the freshclam-configmap of the clamav chart is rendered if either `freshclamConfig` or `clamdConfigDict` is populated in the Values.
However, it should use the `freshclamConfigDict` instead of `clamdConfigDict`.