### PR TITLE
fix(chartreuse): render the restore Job in Helm mode as a post-upgrade hook (6.5.0)

### DIFF
--- a/charts/chartreuse/Chart.yaml
+++ b/charts/chartreuse/Chart.yaml
@@ -3,7 +3,7 @@ name: chartreuse
 # appVersion must track the chartreuse package release that ships the `chartreuse-restore`
 # entrypoint (ensure_safe_run aborts on a major.minor mismatch with the image's package).
 appVersion: 7.0.0
-version: 6.4.1
+version: 6.5.0
 description: Automate Alembic SQL schema migrations.
 maintainers:
   - name: Wiremind

--- a/charts/chartreuse/README.md
+++ b/charts/chartreuse/README.md
@@ -6,6 +6,28 @@ Chartreuse is an Automated Alembic migrations within kubernetes.
 
 Please refer to https://github.com/wiremind/chartreuse.
 
+## Post-deployment restore Job (`restorePods`)
+
+On the `upgradeBeforeDeployment` path the migration Job stops the tracked
+Deployments (scale to 0 + HPA pause via `spec.behavior.scaleUp.selectPolicy:
+Disabled`) and intentionally skips `start_pods()`, relying on the deployment
+that follows to restore replicas. That deployment restores `spec.replicas`
+only where the chart sets it — HPA-managed Deployments omit it — and never
+touches the paused HPAs (`spec.behavior` is not chart-owned): without a
+restore step they stay stranded at 0 / unable to scale up forever.
+
+With `restorePods: true` (default) and `upgradeBeforeDeployment` + `stopPods`
+enabled, the chart renders a `chartreuse-restore` Job that runs
+`restore_stopped_pods()` after the deployment:
+
+- `deploymentMethod: argocd` → ArgoCD `PostSync` hook.
+- `deploymentMethod: helm` → `helm.sh/hook: post-upgrade`.
+
+The Job is idempotent and annotation-gated (`wiremind.io/stopped-by`,
+`wiremind.io/pre-pause-scale-behavior`), so it also heals leftovers from a
+previous run that crashed or predates the restore Job. It requires chartreuse
+package >= 7.0 in the image (the `chartreuse-restore` entrypoint).
+
 ## Using this chart under ArgoCD
 
 The chart ships an opt-in ArgoCD-native mode that replaces the Helm hook
@@ -70,5 +92,7 @@ Override `argocd.syncWave` if your deployment uses a different wave scheme.
 ### Backward compatibility
 
 This mode is **opt-in**. With `deploymentMethod: helm` (the default), the
-chart renders exactly the same resources with the same annotations and
-naming as previous versions; pure-Helm consumers are not affected.
+chart renders the same resources with the same annotations and naming as
+previous versions; the only Helm-mode addition since 6.5.0 is the
+`chartreuse-restore` post-upgrade hook Job described above (disable with
+`restorePods: false` to get the pre-6.5.0 rendering).

--- a/charts/chartreuse/templates/job-restore.yaml
+++ b/charts/chartreuse/templates/job-restore.yaml
@@ -7,12 +7,19 @@ for Deployments whose chart sets spec.replicas, but HPA-managed ones omit it and
 target is at 0 replicas with minReplicas >= 1 is ScalingDisabled: without this Job they stay
 stranded at 0 after every migration.
 
-ArgoCD mode only: as a PostSync hook it runs once the new pod template is applied, so it only
-ever starts new-version pods. In Helm mode the pre-upgrade `-ephemeral` resource set (SA,
-RBAC, ConfigMap) is deleted as soon as the migration hook succeeds, so this Job has nothing
-to run with there; Helm-mode users of upgradeBeforeDeployment keep the pre-existing behavior.
+Worse since chartreuse 7.0.1: the migration pauses the HPAs themselves
+(spec.behavior.scaleUp.selectPolicy: Disabled), and that field is not chart-owned, so no
+later apply ever resumes them — every paused HPA (minReplicas 0 included) stays unable to
+scale up until restore_stopped_pods() runs.
+
+ArgoCD mode: PostSync hook — runs once the new pod template is applied, so it only ever
+starts new-version pods. Helm mode: post-upgrade hook, the same placement (post-install is
+not needed: at install the migration Job runs in-release with HELM_IS_INSTALL=1 and calls
+start_pods() itself). In both modes the Job uses the persistent unsuffixed
+SA/RBAC/ConfigMap — regular release resources in Helm mode too — not the pre-upgrade
+`-ephemeral` set that Helm deletes as soon as the migration hook succeeds.
 */ -}}
-{{- if and .Values.alembic.enabled .Values.stopPods .Values.upgradeBeforeDeployment .Values.restorePods (eq .Values.deploymentMethod "argocd") -}}
+{{- if and .Values.alembic.enabled .Values.stopPods .Values.upgradeBeforeDeployment .Values.restorePods -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -22,8 +29,14 @@ metadata:
     {{- include "chartreuse.labels" . | nindent 4 }}
     app.kubernetes.io/component: "chartreuse-restore"
   annotations:
+    {{- if eq .Values.deploymentMethod "argocd" }}
     "argocd.argoproj.io/hook": PostSync
     "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation
+    {{- else }}
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": {{ .Values.upgradeJobWeight | quote }}
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    {{- end }}
 spec:
   # The restore is idempotent and annotation-gated: retrying on transient API errors is safe.
   backoffLimit: 3

--- a/charts/chartreuse/values.yaml
+++ b/charts/chartreuse/values.yaml
@@ -18,12 +18,14 @@ upgradeBeforeDeployment: false
 ## Whether or not to scale down deployments with ExpectedDeploymentScale before migrating (if migration is needed)
 stopPods: true
 
-## Whether to run a post-deployment (ArgoCD PostSync) Job restoring the Deployments that the
-## migration stopped and that the deployment itself could not scale back up. Without it,
-## HPA-managed Deployments (which omit spec.replicas in their chart) stay stranded at 0
-## replicas after every upgrade-before-deployment migration: an HPA whose target is at 0
-## replicas with minReplicas >= 1 is ScalingDisabled and never recovers on its own.
-## Only effective with upgradeBeforeDeployment + stopPods + deploymentMethod argocd.
+## Whether to run a post-deployment Job (ArgoCD PostSync hook / Helm post-upgrade hook)
+## restoring the Deployments that the migration stopped and that the deployment itself could
+## not scale back up. Without it, HPA-managed Deployments (which omit spec.replicas in their
+## chart) stay stranded at 0 replicas after every upgrade-before-deployment migration: the
+## HPAs are paused during the migration (spec.behavior.scaleUp.selectPolicy: Disabled, a
+## field charts don't own so no apply reverts it) and an HPA whose target is at 0 replicas
+## with minReplicas >= 1 is ScalingDisabled — neither recovers on its own.
+## Only effective with upgradeBeforeDeployment + stopPods.
 restorePods: true
 
 ## Additional environment variables injected within chartreuse Pods


### PR DESCRIPTION
## Problem

The `chartreuse-restore` Job introduced in #885 is gated on `deploymentMethod: argocd`, on the assumption that Helm-mode `upgradeBeforeDeployment` users "keep the pre-existing behavior".

That assumption was broken by chartreuse 7.0.1 (wiremind/chartreuse#56): `stop_pods()` now pauses HPAs via `spec.behavior.scaleUp.selectPolicy: Disabled` instead of renaming `scaleTargetRef`. The old rename touched a chart-owned field, so the next `helm upgrade` apply reverted it (accidentally self-healing). `spec.behavior` is NOT chart-owned, so in Helm mode nothing ever resumes the HPAs: after every migration, all EDS-tracked worker HPAs stay permanently unable to scale up, and scale-to-zero workers stay stranded at 0 replicas.

Observed in production-like envs on `eu-paxone-hermes` (2026-07-17..20): all worker HPAs of `paxone-preprod-gite`, `paxone-acc-demo` and `paxone-acc-gite` paused (`selectPolicy: Disabled` + empty `wiremind.io/pre-pause-scale-behavior` annotation), queue consumers stranded at 0 with `wiremind.io/stopped-by` still set — e.g. the preprod `static` queue unconsumed since 2026-07-20 13:54 UTC.

## Fix

Render the restore Job in both deployment methods:

- `deploymentMethod: argocd` → ArgoCD `PostSync` hook (unchanged).
- `deploymentMethod: helm` → `helm.sh/hook: post-upgrade` (weight `upgradeJobWeight`, `before-hook-creation` delete policy).

The Job references the persistent unsuffixed SA/RBAC/ConfigMap, which exist as regular release resources in Helm mode too — unlike the pre-upgrade `-ephemeral` set that Helm deletes as soon as the migration hook succeeds (the original reason for the argocd-only gate). No `post-install` hook is needed: at install the migration Job runs in-release with `HELM_IS_INSTALL=1` and calls `start_pods()` itself.

Since `restore_stopped_pods()` is idempotent and annotation-gated, the first deploy carrying this chart also heals HPAs/Deployments stranded by previous migrations.

Chart `6.4.1` → `6.5.0`; `restorePods: false` restores the pre-6.5.0 Helm-mode rendering.

## Validation

- `helm lint` clean.
- `helm template --is-upgrade --set upgradeBeforeDeployment=true`: restore Job rendered with `post-upgrade` hook annotations, referencing unsuffixed ConfigMap/SA.
- `--set deploymentMethod=argocd`: PostSync annotations unchanged vs 6.4.1.
- `--set restorePods=false` or `upgradeBeforeDeployment=false`: Job not rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)