### PR TITLE
feat(ovh-exporter): support deploymentAnnotations, bump app to v2.3.1

### DIFF
--- a/charts/ovh-exporter/Chart.yaml
+++ b/charts/ovh-exporter/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - api
   - exporter
 type: application
-version: 1.0.0
-appVersion: "v2.0.0"
+version: 1.1.0
+appVersion: "v2.3.1"
 kubeVersion: ">=1.19.0-0"
 maintainers:
   - name: Wiremind

--- a/charts/ovh-exporter/templates/deployment.yaml
+++ b/charts/ovh-exporter/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ovh-exporter.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ovh-exporter.labels" . | nindent 4 }}
 spec:

--- a/charts/ovh-exporter/values.yaml
+++ b/charts/ovh-exporter/values.yaml
@@ -36,6 +36,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+deploymentAnnotations: {}
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## What

- New `deploymentAnnotations` value (same convention as prometheus-safety-exporter / postgres-operator), rendered on the Deployment metadata. Motivation: setting `reloader.stakater.com/auto: "true"` so that a rotated OVH consumer key in the chart-managed Secret restarts the exporter — today the new token only takes effect on the next unrelated rollout (bitten by this during the token-scope fix for `ovh_exporter_cloud_project_info`).
- Chart `1.0.0` → `1.1.0`, `appVersion` `v2.0.0` → `v2.3.1` (project info metric, volume/LB/floating-IP inventory metrics, `ovh_exporter_api_errors_total`).

## Validation

`helm template --set 'deploymentAnnotations.reloader\.stakater\.com/auto=true'` renders the annotation on the Deployment; `helm lint` passes.