### PR TITLE
chore(karma): upgrade karma to v0.131

### DIFF
--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -6,9 +6,9 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 2.13.0
+version: 2.13.1
 kubeVersion: ">= 1.19-0"
-appVersion: "v0.129"
+appVersion: "v0.131"
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts


### PR DESCRIPTION
Upgrade karma from v0.129 to v0.131 (chart 2.13.1).

Upstream changes (bugfixes only, no breaking changes):
- v0.130 / v0.131: calendar now uses Monday as the first day of the week (prymitive/karma#6715)

Release notes: https://github.com/prymitive/karma/releases/tag/v0.131