### PR TITLE
feat(ack-controllers-crds): update s3, iam and commons CRDs (s3 v1.8.2, iam v1.7.3)

### DIFF
--- a/charts/ack-controllers-crds/Chart.yaml
+++ b/charts/ack-controllers-crds/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: ack-controllers-crds
 description: Manage some CRDs of the ACK controllers
-version: 1.0.0
+version: 1.1.0
 appVersion: v1.0.0
-home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/ack-controllers-crdss
+home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/ack-controllers-crds
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/ack-controllers-crds

--- a/charts/ack-controllers-crds/README.md
+++ b/charts/ack-controllers-crds/README.md
@@ -20,3 +20,21 @@ This script will:
 This makes it easier to avoid Helm conflicts when installing multiple ACK controllers.
 
 You can add additional controller charts as sources to the script if needed.
+
+### CRD sources
+
+| CRD | Upstream | Version |
+| --- | --- | --- |
+| `buckets.s3.services.k8s.aws` | [aws-controllers-k8s/s3-controller](https://github.com/aws-controllers-k8s/s3-controller/tree/v1.8.2/helm/crds) | v1.8.2 |
+| `*.iam.services.k8s.aws` | [aws-controllers-k8s/iam-controller](https://github.com/aws-controllers-k8s/iam-controller/tree/v1.7.3/helm/crds) | v1.7.3 |
+| `fieldexports.services.k8s.aws`, `iamroleselectors.services.k8s.aws` | ACK runtime commons, shipped identically by both controller charts above | v1.7.3 (iam) |
+| `adoptedresources.services.k8s.aws` | ACK runtime commons, no longer shipped upstream | v1.4.2 (iam) |
+
+CRDs are vendored from the upstream `helm/crds` folder of the matching controller
+release, with `creationTimestamp: null` stripped. Keep the deployed controller
+chart versions in sync with the table above.
+
+`adoptedresources` was dropped from the upstream controller charts, but is kept
+here on purpose: removing a CRD template deletes the CRD on upgrade, which would
+cascade to every `AdoptedResource` object in the cluster. Remove it only after
+confirming none are left.

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_groups.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_groups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: groups.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -131,6 +131,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_instanceprofiles.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_instanceprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instanceprofiles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -150,6 +150,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_openidconnectproviders.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_openidconnectproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: openidconnectproviders.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -148,6 +148,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_policies.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_policies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: policies.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -172,6 +172,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_roles.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: roles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -233,6 +233,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_servicelinkedroles.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_servicelinkedroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicelinkedroles.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -106,6 +106,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/iam.services.k8s.aws_users.yaml
+++ b/charts/ack-controllers-crds/templates/iam.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.iam.services.k8s.aws
 spec:
   group: iam.services.k8s.aws
@@ -185,6 +185,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/s3.services.k8s.aws_buckets.yaml
+++ b/charts/ack-controllers-crds/templates/s3.services.k8s.aws_buckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: buckets.s3.services.k8s.aws
 spec:
   group: s3.services.k8s.aws
@@ -171,6 +171,35 @@ spec:
               createBucketConfiguration:
                 description: The configuration information for the bucket.
                 properties:
+                  bucket:
+                    description: |-
+                      Specifies the information about the bucket that will be created. For more
+                      information about directory buckets, see Directory buckets (https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-overview.html)
+                      in the Amazon S3 User Guide.
+
+                      This functionality is only supported by directory buckets.
+                    properties:
+                      dataRedundancy:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  location:
+                    description: |-
+                      Specifies the location where the bucket will be created.
+
+                      For directory buckets, the location type is Availability Zone or Local Zone.
+                      For more information about directory buckets, see Working with directory
+                      buckets (https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-overview.html)
+                      in the Amazon S3 User Guide.
+
+                      This functionality is only supported by directory buckets.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    type: object
                   locationConstraint:
                     type: string
                 type: object
@@ -207,8 +236,7 @@ spec:
 
                                * Directory buckets - Your SSE-KMS configuration can only support 1 customer
                                managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
-                               per directory bucket for the lifetime of the bucket. The Amazon Web Services
-                               managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
+                               per directory bucket's lifetime. The Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk)
                                (aws/s3) isn't supported.
 
                                * Directory buckets - For directory buckets, there are only two supported
@@ -324,18 +352,18 @@ spec:
               inventory:
                 items:
                   description: |-
-                    Specifies the inventory configuration for an Amazon S3 bucket. For more information,
-                    see GET Bucket inventory (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETInventoryConfig.html)
+                    Specifies the S3 Inventory configuration for an Amazon S3 bucket. For more
+                    information, see GET Bucket inventory (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETInventoryConfig.html)
                     in the Amazon S3 API Reference.
                   properties:
                     destination:
-                      description: Specifies the inventory configuration for an Amazon
-                        S3 bucket.
+                      description: Specifies the S3 Inventory configuration for an
+                        Amazon S3 bucket.
                       properties:
                         s3BucketDestination:
                           description: |-
                             Contains the bucket name, file format, bucket owner (optional), and prefix
-                            (optional) where inventory results are published.
+                            (optional) where S3 Inventory results are published.
                           properties:
                             accountID:
                               type: string
@@ -343,7 +371,7 @@ spec:
                               type: string
                             encryption:
                               description: |-
-                                Contains the type of server-side encryption used to encrypt the inventory
+                                Contains the type of server-side encryption used to encrypt the S3 Inventory
                                 results.
                               properties:
                                 sseKMS:
@@ -362,8 +390,8 @@ spec:
                       type: object
                     filter:
                       description: |-
-                        Specifies an inventory filter. The inventory only includes objects that meet
-                        the filter's criteria.
+                        Specifies an S3 Inventory filter. The inventory only includes objects that
+                        meet the filter's criteria.
                       properties:
                         prefix:
                           type: string
@@ -379,7 +407,7 @@ spec:
                         type: string
                       type: array
                     schedule:
-                      description: Specifies the schedule for generating inventory
+                      description: Specifies the schedule for generating S3 Inventory
                         results.
                       properties:
                         frequency:
@@ -662,6 +690,31 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              namespace:
+                description: |-
+                  Specifies the namespace where you want to create your general purpose bucket.
+                  When you create a general purpose bucket, you can choose to create a bucket
+                  in the shared global namespace or you can choose to create a bucket in your
+                  account regional namespace. Your account regional namespace is a subdivision
+                  of the global namespace that only your account can create buckets in. For
+                  more information on bucket namespaces, see Namespaces for general purpose
+                  buckets (https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html).
+
+                  General purpose buckets in your account regional namespace must follow a
+                  specific naming convention. These buckets consist of a bucket name prefix
+                  that you create, and a suffix that contains your 12-digit Amazon Web Services
+                  Account ID, the Amazon Web Services Region code, and ends with -an. Bucket
+                  names must follow the format bucket-name-prefix-accountId-region-an (for
+                  example, amzn-s3-demo-bucket-111122223333-us-west-2-an). For information
+                  about bucket naming restrictions, see Account regional namespace naming rules
+                  (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html#account-regional-naming-rules)
+                  in the Amazon S3 User Guide.
+
+                  This functionality is not supported for directory buckets.
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               notification:
                 description: |-
                   A container for specifying the notification configuration of the bucket.
@@ -830,6 +883,34 @@ spec:
                       type: object
                     type: array
                 type: object
+              objectLockConfiguration:
+                description: The Object Lock configuration that you want to apply
+                  to the specified bucket.
+                properties:
+                  rule:
+                    description: The container element for an Object Lock rule.
+                    properties:
+                      defaultRetention:
+                        description: |-
+                          The container element for optionally specifying the default Object Lock retention
+                          settings for new objects placed in the specified bucket.
+
+                             * The DefaultRetention settings require both a mode and a period.
+
+                             * The DefaultRetention period can be either Days or Years but you must
+                             select one. You cannot specify Days and Years at the same time.
+                        properties:
+                          days:
+                            format: int64
+                            type: integer
+                          mode:
+                            type: string
+                          years:
+                            format: int64
+                            type: integer
+                        type: object
+                    type: object
+                type: object
               objectLockEnabledForBucket:
                 description: |-
                   Specifies whether you want S3 Object Lock to be enabled for the new bucket.
@@ -910,6 +991,20 @@ spec:
                 properties:
                   role:
                     type: string
+                  roleRef:
+                    description: Reference field for Role
+                    properties:
+                      from:
+                        description: |-
+                          AWSResourceReference provides all the values necessary to reference another
+                          k8s resource for finding the identifier(Id/ARN/Name)
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                    type: object
                   rules:
                     items:
                       description: Specifies which Amazon S3 objects to replicate
@@ -1218,6 +1313,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/charts/ack-controllers-crds/templates/services.k8s.aws_fieldexports.yaml
+++ b/charts/ack-controllers-crds/templates/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/charts/ack-controllers-crds/templates/services.k8s.aws_iamroleselectors.yaml
+++ b/charts/ack-controllers-crds/templates/services.k8s.aws_iamroleselectors.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: iamroleselectors.services.k8s.aws
+spec:
+  group: services.k8s.aws
+  names:
+    kind: IAMRoleSelector
+    listKind: IAMRoleSelectorList
+    plural: iamroleselectors
+    singular: iamroleselector
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IAMRoleSelector is the schema for the IAMRoleSelector API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              arn:
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
+              namespaceSelector:
+                description: IAMRoleSelectorSpec defines the desired state of IAMRoleSelector
+                properties:
+                  labelSelector:
+                    description: LabelSelector is a label query over a set of resources.
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - matchLabels
+                    type: object
+                  names:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - names
+                type: object
+              resourceLabelSelector:
+                description: LabelSelector is a label query over a set of resources.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
+              resourceTypeSelector:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - version
+                  type: object
+                type: array
+            required:
+            - arn
+            type: object
+          status:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Why

Every CRD in this chart was stale, and the two ACK controllers we deploy are being upgraded together, so this bumps all of them in one release rather than staging s3 and iam separately.

- The `buckets.s3.services.k8s.aws` CRD was byte-identical to s3-controller **v1.0.32**, predating `objectLockConfiguration` (added upstream in v1.8.0, [#225](https://github.com/aws-controllers-k8s/s3-controller/pull/225)) and the directory-bucket fields.
- The iam CRDs tracked iam-controller **v1.4.2**, while upstream is at **v1.7.3** (deployed `iam-chart` pin is 1.4.1).

The s3 driver for this is [s3-controller#238](https://github.com/aws-controllers-k8s/s3-controller/pull/238), released in v1.8.2: it makes adopted buckets actually reconcile Object Lock instead of reporting `ResourceSynced=True` while Object Lock stays disabled. Deploying that controller against the old CRD would let the API server prune the spec fields it now reads and writes.

## What

- `buckets.s3.services.k8s.aws` re-vendored from s3-controller `v1.8.2`.
- All seven `*.iam.services.k8s.aws` CRDs re-vendored from iam-controller `v1.7.3`.
- `fieldexports.services.k8s.aws` refreshed, and **`iamroleselectors.services.k8s.aws` added** — a commons CRD both controller charts now ship, used by the CARM role-selector path that is enabled by default from these versions on. Both are byte-identical between the two controllers, so there is no ambiguity about which one to vendor.
- Chart `1.0.0` → `1.1.0`; CRD sources and their upstream versions documented in the chart README.

All vendored from the upstream `helm/crds` folders with `creationTimestamp: null` stripped per the repo convention.

### `adoptedresources` is intentionally not touched

Upstream dropped `services.k8s.aws_adoptedresources.yaml` from **both** controller charts. It is kept here at its v1.4.2 copy (hence the older `controller-gen` stamp): removing the template would delete the CRD on upgrade, which cascades to every `AdoptedResource` object in the cluster. It should only be removed after confirming none are left — that is a separate, deliberate change.

`appVersion` stays `v1.0.0`: it has no single meaning for a chart aggregating CRDs from two controllers, and the README table now carries the real per-CRD versions.

### Chart metadata fix

`home:` pointed at `charts/ack-controllers-crdss` (double "s"), which 404s — it broke the chart metadata links on Artifact Hub and in Helm UIs. Corrected to the real path; verified the fixed URL returns 200 and the old one 404.

## Testing

- `helm lint charts/ack-controllers-crds` passes.
- All 11 templates parse as exactly one valid `CustomResourceDefinition` each; `objectLockConfiguration` and `objectLockEnabledForBucket` both present in the Bucket v1alpha1 spec schema.
- No `creationTimestamp: null` left anywhere in the chart; largest CRD is 70 KB, well under the 256 KB server-side-apply threshold.
- Verified the values schemas of both controller charts across the jumps: every key `wiremind-services-configuration` overrides still exists at the same path. The only new top-level keys are `enableCARM` and `enableCrossNamespace`, both defaulting to `true`.

## Follow-up

`wiremind-services-configuration` needs `ack-controllers-crds` `1.0.0` → `1.1.0`, `s3-chart` `1.0.32` → `1.8.2` and `iam-chart` `1.4.1` → `1.7.3`; that MR is held until this is merged and released.

Ref: https://app.notion.com/p/wiremind/ack-s3-controller-enable-Object-Lock-on-adopted-buckets-by-reconciling-ObjectLockEnabledForBucket-3a3dcbda9c3581bc8886f42a701e21d6
