### PR TITLE
feat(elasticsearch): allow overriding the volumeClaimTemplate release…

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts
 name: elasticsearch
-version: 8.17.1
+version: 8.17.2
 appVersion: 8.19.12
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch

--- a/charts/elasticsearch/templates/statefulset.yaml
+++ b/charts/elasticsearch/templates/statefulset.yaml
@@ -33,10 +33,10 @@ spec:
       name: {{ template "elasticsearch.uname" . }}
       {{- if .Values.persistence.labels.enabled }}
       labels:
-        release: {{ .Release.Name | quote }}
+        release: {{ .Values.persistence.labels.release | default .Release.Name | quote }}
         chart: "{{ .Chart.Name }}"
         app: "{{ template "elasticsearch.uname" . }}"
-        {{- range $key, $value := .Values.labels }}
+        {{- range $key, $value := omit .Values.labels "release" }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -149,6 +149,8 @@ persistence:
   labels:
     # Add default labels for the volumeClaimTemplate of the StatefulSet
     enabled: false
+    # Override the immutable `release` label. Defaults to .Release.Name.
+    release: ""
   annotations: {}
 
 extraVolumes: []


### PR DESCRIPTION
… label

A StatefulSet's volumeClaimTemplates are immutable, so the release label stamped there can never be updated in place. Renaming a Helm release therefore leaves the StatefulSet permanently unable to converge, even though the label is only decoration copied onto new PVCs.

Allow pinning it independently of .Release.Name. Defaults to .Release.Name, so existing installs render unchanged.

The range over .Values.labels now omits 'release' for this block: it previously emitted a duplicate YAML key that took precedence, which would have silently defeated the new override.