### PR TITLE
feat(node-local-dns): fork chart with serve_stale and health_check fixes

### DIFF
--- a/charts/node-local-dns/Chart.yaml
+++ b/charts/node-local-dns/Chart.yaml
@@ -1,0 +1,25 @@
+annotations:
+  artifacthub.io/changes: |
+    - Fork of lablabs/node-local-dns 2.4.0
+    - Fix cache.serve_stale being read as cache.server_stale, and support its duration and refresh mode
+    - Fix forward.health_check being rendered as expire, which silently disabled upstream health checking
+apiVersion: v2
+appVersion: 1.23.1
+description: NodeLocal DNS Cache helm chart
+home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/node-local-dns
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+keywords:
+  - node
+  - dns
+  - cache
+  - kubernetes
+maintainers:
+  - name: Wiremind
+    url: https://github.com/wiremind/wiremind-helm-charts
+name: node-local-dns
+sources:
+  - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/node-local-dns
+  - https://github.com/lablabs/k8s-nodelocaldns-helm
+  - https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/nodelocaldns
+type: application
+version: 2.4.1

--- a/charts/node-local-dns/LICENSE
+++ b/charts/node-local-dns/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2021] [Labyrinth Labs]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/node-local-dns/README.md
+++ b/charts/node-local-dns/README.md
@@ -1,0 +1,142 @@
+# node-local-dns
+
+NodeLocal DNS Cache helm chart
+
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.23.1](https://img.shields.io/badge/AppVersion-1.23.1-informational?style=flat-square)
+
+[<img src="https://lablabs.io/static/ll-logo.png" width=350px>](https://lablabs.io/)
+
+## Installing the Chart
+
+This chart deploys NodeLocal DNSCache Daemon set according to <https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/>.
+
+It is designed to work both with iptables and IPVS setup.
+
+Latest available `node-local-dns` image can be found at [node-local-dns google container repository](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/k8s-dns-node-cache)
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.localDnsIp | string | `"169.254.20.11"` |  |
+| config.zones.".:53".plugins.cache.denial | object | `{}` |  |
+| config.zones.".:53".plugins.cache.parameters | int | `30` |  |
+| config.zones.".:53".plugins.cache.prefetch | object | `{}` |  |
+| config.zones.".:53".plugins.cache.serve_stale | object | `{}` | Set to `{duration: 10m, refresh_mode: immediate}` to serve expired answers when the upstream is unreachable. Defaults to CoreDNS' `1h immediate` when set to a non-empty map without keys. |
+| config.zones.".:53".plugins.cache.success | object | `{}` |  |
+| config.zones.".:53".plugins.debug | bool | `false` |  |
+| config.zones.".:53".plugins.errors | bool | `true` |  |
+| config.zones.".:53".plugins.forward.except | string | `""` |  |
+| config.zones.".:53".plugins.forward.expire | string | `""` |  |
+| config.zones.".:53".plugins.forward.force_tcp | bool | `false` |  |
+| config.zones.".:53".plugins.forward.health_check | string | `""` |  |
+| config.zones.".:53".plugins.forward.max_fails | string | `""` |  |
+| config.zones.".:53".plugins.forward.parameters | string | `"__PILLAR__UPSTREAM__SERVERS__"` |  |
+| config.zones.".:53".plugins.forward.policy | string | `""` |  |
+| config.zones.".:53".plugins.forward.prefer_udp | bool | `false` |  |
+| config.zones.".:53".plugins.health.port | int | `8080` |  |
+| config.zones.".:53".plugins.log.classes | string | `"all"` |  |
+| config.zones.".:53".plugins.log.format | string | `"combined"` |  |
+| config.zones.".:53".plugins.prometheus | bool | `true` |  |
+| config.zones.".:53".plugins.reload | bool | `true` |  |
+| config.zones.".:53".plugins.template | object | `{}` |  |
+| config.zones."in-addr.arpa:53".plugins.cache.parameters | int | `30` |  |
+| config.zones."in-addr.arpa:53".plugins.debug | bool | `false` |  |
+| config.zones."in-addr.arpa:53".plugins.errors | bool | `true` |  |
+| config.zones."in-addr.arpa:53".plugins.forward.force_tcp | bool | `false` |  |
+| config.zones."in-addr.arpa:53".plugins.forward.parameters | string | `"__PILLAR__UPSTREAM__SERVERS__"` |  |
+| config.zones."in-addr.arpa:53".plugins.health.port | int | `8080` |  |
+| config.zones."in-addr.arpa:53".plugins.log.classes | string | `"all"` |  |
+| config.zones."in-addr.arpa:53".plugins.log.format | string | `"combined"` |  |
+| config.zones."in-addr.arpa:53".plugins.prometheus | bool | `true` |  |
+| config.zones."in-addr.arpa:53".plugins.reload | bool | `true` |  |
+| config.zones."ip6.arpa:53".plugins.cache.parameters | int | `30` |  |
+| config.zones."ip6.arpa:53".plugins.debug | bool | `false` |  |
+| config.zones."ip6.arpa:53".plugins.errors | bool | `true` |  |
+| config.zones."ip6.arpa:53".plugins.forward.force_tcp | bool | `false` |  |
+| config.zones."ip6.arpa:53".plugins.forward.parameters | string | `"__PILLAR__UPSTREAM__SERVERS__"` |  |
+| config.zones."ip6.arpa:53".plugins.health.port | int | `8080` |  |
+| config.zones."ip6.arpa:53".plugins.log.classes | string | `"all"` |  |
+| config.zones."ip6.arpa:53".plugins.log.format | string | `"combined"` |  |
+| config.zones."ip6.arpa:53".plugins.prometheus | bool | `true` |  |
+| config.zones."ip6.arpa:53".plugins.reload | bool | `true` |  |
+| image.args.healthPort | int | `8080` |  |
+| image.args.interfaceName | string | `"nodelocaldns"` |  |
+| image.args.quiet | bool | `false` |  |
+| image.args.setupInterface | bool | `true` |  |
+| image.args.setupIptables | bool | `false` |  |
+| image.args.skipTeardown | bool | `true` |  |
+| image.args.syncInterval | string | `"1ns"` |  |
+| image.args.upstreamSvc | string | `"kube-dns"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"registry.k8s.io/dns/k8s-dns-node-cache"` |  |
+| image.tag | string | `"1.23.0"` |  |
+| imagePullSecrets | list | `[]` |  |
+| metrics.port | int | `9253` |  |
+| metrics.prometheusScrape | string | `"true"` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| podmonitor.enabled | bool | `false` |  |
+| podmonitor.metricRelabelings | list | `[]` |  |
+| priorityClassName | string | `"system-node-critical"` |  |
+| readinessProbe | string | `nil` |  |
+| resources.requests.cpu | string | `"30m"` |  |
+| resources.requests.memory | string | `"50Mi"` |  |
+| securityContext.privileged | bool | `true` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations[0].key | string | `"CriticalAddonsOnly"` |  |
+| tolerations[0].operator | string | `"Exists"` |  |
+| tolerations[1].effect | string | `"NoExecute"` |  |
+| tolerations[1].operator | string | `"Exists"` |  |
+| tolerations[2].effect | string | `"NoSchedule"` |  |
+| tolerations[2].operator | string | `"Exists"` |  |
+| updateStrategy.rollingUpdate.maxUnavailable | string | `"10%"` |  |
+| useHostNetwork | bool | `true` |  |
+
+## Additional Information
+
+### Cilium
+
+For clusters running [cilium](https://cilium.io/), there is a CRD,
+[local-redirect-policy](https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/),
+which needs be extra enabled via `--set localRedirectPolicy=true`.
+It enables pod traffic destined to an IP address and port/protocol tuple or Kubernetes service to be redirected
+locally to backend pod(s) within a node, using eBPF.
+The namespace of backend pod(s) need to match with that of the policy.
+
+For using this feature, values should provides the following extra configuration,
+
+For getting the `CLUSTER_DNS_IP`,
+
+```console
+kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}
+```
+
+```yaml
+config:
+  localDnsIp: CLUSTER_DNS_IP
+  cilium:
+    clusterDNSService: kube-dns
+    clusterDNSNamespace: kube-system
+    udp:
+      enabled: true
+      portName: dns
+    tcp:
+      enabled: true
+      portName: dns-tcp
+```
+
+#### RKE2
+
+As this feature heavily depends on the Cluster DNS implementation, for a [Rancher Kubernetes Engine 2](https://docs.rke2.io/) cluster,
+`clusterDNSService` should be `rke2-coredns-rke2-coredns`, and port names,
+`udp-53` and `tcp-53` respectively.
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/node-local-dns/README.md.gotmpl
+++ b/charts/node-local-dns/README.md.gotmpl
@@ -1,0 +1,59 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+[<img src="https://lablabs.io/static/ll-logo.png" width=350px>](https://lablabs.io/)
+
+## Installing the Chart
+
+This chart deploys NodeLocal DNSCache Daemon set according to <https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/>.
+
+It is designed to work both with iptables and IPVS setup.
+
+Latest available `node-local-dns` image can be found at [node-local-dns google container repository](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/k8s-dns-node-cache)
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+## Additional Information
+
+### Cilium
+
+For clusters running [cilium](https://cilium.io/), there is a CRD,
+[local-redirect-policy](https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/),
+which needs be extra enabled via `--set localRedirectPolicy=true`.
+It enables pod traffic destined to an IP address and port/protocol tuple or Kubernetes service to be redirected
+locally to backend pod(s) within a node, using eBPF.
+The namespace of backend pod(s) need to match with that of the policy.
+
+For using this feature, values should provides the following extra configuration,
+
+For getting the `CLUSTER_DNS_IP`,
+
+```console
+kubectl get svc kube-dns -n kube-system -o jsonpath={.spec.clusterIP}
+```
+
+```yaml
+config:
+  localDnsIp: CLUSTER_DNS_IP
+  cilium:
+    clusterDNSService: kube-dns
+    clusterDNSNamespace: kube-system
+    udp:
+      enabled: true
+      portName: dns
+    tcp:
+      enabled: true
+      portName: dns-tcp
+```
+
+#### RKE2
+
+As this feature heavily depends on the Cluster DNS implementation, for a [Rancher Kubernetes Engine 2](https://docs.rke2.io/) cluster,
+`clusterDNSService` should be `rke2-coredns-rke2-coredns`, and port names,
+`udp-53` and `tcp-53` respectively.
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/node-local-dns/templates/_helpers.tpl
+++ b/charts/node-local-dns/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-local-dns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "node-local-dns.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-local-dns.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "node-local-dns.labels" -}}
+helm.sh/chart: {{ include "node-local-dns.chart" . }}
+{{ include "node-local-dns.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "node-local-dns.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "node-local-dns.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "node-local-dns.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "node-local-dns.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
+++ b/charts/node-local-dns/templates/ciliumlocalredirectpolicy.yaml
@@ -1,0 +1,49 @@
+{{- if hasKey .Values.config "cilium" }}
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "node-local-dns"
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  redirectFrontend:
+    {{- if eq .Values.config.cilium.redirectType "address" }}
+    addressMatcher:
+      ip: {{ .Values.config.localDnsIp }}
+      toPorts:
+      {{- if .Values.config.cilium.udp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+        protocol: UDP
+     {{- end }}
+     {{- if .Values.config.cilium.tcp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+        protocol: TCP
+     {{- end }}
+    {{- else }}
+    serviceMatcher:
+      serviceName: {{ .Values.config.cilium.clusterDNSService | default "kube-dns" }}
+      namespace: {{ .Values.config.cilium.clusterDNSNamespace | default "kube-system" }}
+    {{- end }}
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        {{- include "node-local-dns.selectorLabels" . | nindent 8 }}
+    toPorts:
+      {{- if .Values.config.cilium.udp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+        protocol: UDP
+     {{- end }}
+     {{- if .Values.config.cilium.tcp.enabled }}
+      - port: "53"
+        name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+        protocol: TCP
+     {{- end }}
+{{- end }}

--- a/charts/node-local-dns/templates/configmap.yaml
+++ b/charts/node-local-dns/templates/configmap.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+data:
+  Corefile: |-
+    {{- $localDnsIp := .Values.config.localDnsIp -}}
+    {{- $metricsPort := .Values.metrics.port -}}
+    {{- $ciliumConfig := ternary true false (hasKey .Values.config "cilium") -}}
+
+    {{- range $k, $v := .Values.config.zones }}
+    {{ $k }} {
+    {{- range $v }}
+      {{- if $v.plugins.errors }}
+      errors
+      {{- end }}
+      cache {{ $v.plugins.cache.parameters }} {
+        {{- if $v.plugins.cache.denial }}
+        denial {{ $v.plugins.cache.denial.size }} {{ if $v.plugins.cache.denial.ttl }} {{ $v.plugins.cache.denial.ttl }} {{ end }}
+        {{- end }}
+        {{- if $v.plugins.cache.success }}
+        success {{ $v.plugins.cache.success.size }} {{ if $v.plugins.cache.success.ttl }} {{ $v.plugins.cache.success.ttl }} {{ end }}
+        {{- end }}
+        {{- if $v.plugins.cache.prefetch }}
+        prefetch {{ $v.plugins.cache.prefetch.amount }} {{ if $v.plugins.cache.prefetch.duration }} {{ $v.plugins.cache.prefetch.duration }} {{ end }} {{ if $v.plugins.cache.prefetch.percentage }} {{ $v.plugins.cache.prefetch.percentage }} {{ end }}
+        {{- end }}
+        {{- if $v.plugins.cache.serve_stale }}
+        serve_stale {{ $v.plugins.cache.serve_stale.duration | default "1h" }} {{ $v.plugins.cache.serve_stale.refresh_mode | default "immediate" }}
+        {{- end }}
+      }
+      {{- if $v.plugins.template }}
+      template {{ $v.plugins.template.parameters }} {
+        {{- if $v.plugins.template.match }}
+        match {{ $v.plugins.template.match }}
+        {{- end }}
+        {{- if $v.plugins.template.answer }}
+        answer {{ $v.plugins.template.answer }}
+        {{- end }}
+        {{- if $v.plugins.template.additional }}
+        additional {{ $v.plugins.template.additional }}
+        {{- end }}
+        {{- if $v.plugins.template.authority }}
+        authority {{ $v.plugins.template.authority }}
+        {{- end }}
+        {{- if $v.plugins.template.rcode }}
+        rcode {{ $v.plugins.template.rcode }}
+        {{- end }}
+        {{- if $v.plugins.template.ederror }}
+        ederror {{ $v.plugins.template.ederror }}
+        {{- end }}
+        {{- if $v.plugins.template.fallthrough }}
+        fallthrough {{ $v.plugins.template.fallthrough }}
+        {{- end }}
+      }
+      {{- end }}
+      {{- if $v.plugins.reload }}
+      reload
+      {{- end }}
+      {{- if $v.plugins.hosts }}
+      hosts {
+      {{- range $kk, $vv := $v.plugins.hosts.entries }}
+        {{ $vv.ip }} {{ $vv.name }}
+      {{- end }}
+      {{- if $v.plugins.hosts.ttl }}
+        ttl {{ $v.plugins.hosts.ttl }}
+      {{- end }}
+      {{- if $v.plugins.hosts.no_reverse }}
+        no_reverse
+      {{- end }}
+      {{- if $v.plugins.hosts.reload }}
+        reload {{ $v.plugins.hosts.reload | quote }}
+      {{- end }}
+      {{- if $v.plugins.hosts.fallthrough }}
+        fallthrough
+      {{- end }}
+      }
+      {{- end }}
+      {{- if $v.plugins.log }}
+      log . {{ default "combined" $v.plugins.log.format }} {
+        class {{ $v.plugins.log.classes }}
+      }
+      {{- end }}
+      {{- if $v.plugins.debug }}
+      debug
+      {{- end }}
+      loop
+      {{- if not $ciliumConfig }}
+      bind {{ $localDnsIp }}
+      {{- else }}
+      bind 0.0.0.0
+      {{- end }}
+      forward . {{ $v.plugins.forward.parameters }} {
+      {{- if $v.plugins.forward.policy }}
+        policy {{ $v.plugins.forward.policy }}
+      {{- end }}
+      {{- if $v.plugins.forward.force_tcp }}
+        force_tcp
+      {{- end }}
+      {{- if $v.plugins.forward.prefer_udp }}
+        prefer_udp
+      {{- end }}
+      {{- if $v.plugins.forward.max_fails }}
+        max_fails {{ $v.plugins.forward.max_fails }}
+      {{- end }}
+      {{- if $v.plugins.forward.expire }}
+        expire {{ $v.plugins.forward.expire }}
+      {{- end }}
+      {{- if $v.plugins.forward.health_check }}
+        health_check {{ $v.plugins.forward.health_check }}
+      {{- end }}
+      {{- if $v.plugins.forward.except }}
+        except {{ $v.plugins.forward.except }}
+      {{- end }}
+      }
+      {{- if $v.plugins.prometheus }}
+      prometheus :{{ $metricsPort }}
+      {{- end }}
+      {{- if $v.plugins.health }}
+      {{- if not $ciliumConfig }}
+      health {{ $localDnsIp }}:{{ $v.plugins.health.port }}
+      {{- else }}
+      health
+      {{- end }}
+      {{- end }}
+    {{- end }}
+    }
+    {{- end }}

--- a/charts/node-local-dns/templates/daemonset.yaml
+++ b/charts/node-local-dns/templates/daemonset.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "node-local-dns.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: {{ .Values.metrics.prometheusScrape | quote }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        checksum/configmaps: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "node-local-dns.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      serviceAccountName: {{ include "node-local-dns.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- if not (hasKey .Values.config "cilium") }}
+      hostNetwork: {{ .Values.useHostNetwork }}
+      {{- end }}
+      dnsPolicy: Default
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -localip
+            - "{{ .Values.config.localDnsIp }}"
+            {{- if .Values.image.args.skipTeardown }}
+            - -skipteardown=true
+            {{- else }}
+            - -skipteardown=false
+            {{- end }}
+            {{- if .Values.image.args.setupEptables }}
+            - -setupeptables
+            {{- end }}
+            {{- if .Values.image.args.setupInterface }}
+            - -setupinterface=true
+            {{- else }}
+            - -setupinterface=false
+            {{- end }}
+            {{- if .Values.image.args.setupIptables }}
+            - -setupiptables=true
+            {{- else }}
+            - -setupiptables=false
+            {{- end }}
+            {{- if .Values.image.args.quiet }}
+            - -quiet
+            {{- end }}
+            {{- if .Values.image.args.healthPort }}
+            - -health-port
+            - {{ .Values.image.args.healthPort | quote }}
+            {{- end }}
+            {{- if .Values.image.args.upstreamSvc }}
+            - -upstreamsvc
+            - {{ .Values.image.args.upstreamSvc | quote }}
+            {{- end }}
+            - -conf
+            - /etc/Corefile
+            - -syncinterval
+            - {{ .Values.image.args.syncInterval }}
+            {{- if .Values.image.args.setupInterface }}
+            - -interfacename
+            - {{ .Values.image.args.interfaceName }}
+            {{- end }}
+            - -metrics-listen-address
+            - "0.0.0.0:{{ add .Values.metrics.port 100 }}"
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+          {{- if (hasKey .Values.config "cilium") }}
+          {{- if .Values.config.cilium.udp.enabled }}
+            - name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+              containerPort: 53
+              protocol: UDP
+          {{- end }}
+          {{- if .Values.config.cilium.tcp.enabled }}
+            - name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+              containerPort: 53
+              protocol: TCP
+          {{- end }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              {{- if not (hasKey .Values.config "cilium") }}
+              host: {{ .Values.config.localDnsIp }}
+              {{- end }}
+              path: /health
+              port: {{ default "8080" .Values.image.args.healthPort }}
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - name: config
+              mountPath: /etc/coredns
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        - name: config
+          configMap:
+            name: {{ include "node-local-dns.fullname" . }}
+            items:
+              - key: Corefile
+                path: Corefile.base

--- a/charts/node-local-dns/templates/podmonitor.yaml
+++ b/charts/node-local-dns/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podmonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "node-local-dns.fullname" . }}
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+    {{- if .Values.podmonitor.promOperatorSelector }}
+    {{ toYaml .Values.podmonitor.promOperatorSelector | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podmonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "node-local-dns.selectorLabels" . | nindent 8 }}
+  podMetricsEndpoints:
+  - port: metrics
+    {{- if .Values.podmonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml .Values.podmonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/node-local-dns/templates/service.yaml
+++ b/charts/node-local-dns/templates/service.yaml
@@ -1,0 +1,31 @@
+{{- if hasKey .Values.config "cilium" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.image.args.upstreamSvc }}
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+    k8s-app: kube-dns
+    kubernetes.io/name: "KubeDNSUpstream"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+  {{- if .Values.config.cilium.udp.enabled }}
+  - name: {{ .Values.config.cilium.udp.portName | default "dns" }}
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  {{- end }}
+  {{- if .Values.config.cilium.tcp.enabled }}
+  - name: {{ .Values.config.cilium.tcp.portName | default "dns-tcp" }}
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  {{- end }}
+  selector:
+    k8s-app: kube-dns
+{{- end }}

--- a/charts/node-local-dns/templates/serviceaccount.yaml
+++ b/charts/node-local-dns/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "node-local-dns.serviceAccountName" . }}
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/node-local-dns/templates/tests/test-dns-resolution.yaml
+++ b/charts/node-local-dns/templates/tests/test-dns-resolution.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "node-local-dns.fullname" . }}-dns-test"
+  labels:
+    {{- include "node-local-dns.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: dns-test
+      image: tutum/dnsutils
+      command: ['dig']
+      args: ['google.com']
+  restartPolicy: Never

--- a/charts/node-local-dns/values.yaml
+++ b/charts/node-local-dns/values.yaml
@@ -1,0 +1,164 @@
+---
+commonLabels: {}
+
+image:
+  repository: registry.k8s.io/dns/k8s-dns-node-cache
+  pullPolicy: IfNotPresent
+  tag: 1.23.0
+  args:
+    interfaceName: nodelocaldns
+    healthPort: 8080
+    setupInterface: true
+    skipTeardown: true
+    setupIptables: false
+    syncInterval: 1ns
+    quiet: false
+    upstreamSvc: kube-dns
+
+imagePullSecrets: []
+
+config:
+  localDnsIp: 169.254.20.11
+#  cilium:
+#    clusterDNSService: kube-dns
+#    clusterDNSNamespace: kube-system
+#    redirectType: address
+#    udp:
+#      enabled: true
+#      portName: dns
+#    tcp:
+#      enabled: true
+#      portName: dns-tcp
+  zones:
+    .:53:
+      plugins:
+        errors: true
+        reload: true
+        debug: false
+        log:
+          format: combined
+          classes: all
+        template: {}                    # https://coredns.io/plugins/template/
+          # parameters: "ANY AAAA"
+          # match: ""
+          # additional: ""
+          # authority: ""
+          # rcode: "NOERROR"
+          # ederror: ""
+          # fallthrough: ""
+        cache:
+          parameters: 30
+          denial: {}
+            # size: 0
+            # ttl: 1
+          success: {}
+            # size: 8192
+            # ttl: 30
+          prefetch: {}
+            # amount: 1
+            # duration: 10m
+            # percentage: 20%
+          # Serve an expired answer when the upstream cannot be reached, instead
+          # of failing the query. Set to a map to enable:
+          #   serve_stale:
+          #     duration: 10m         # defaults to CoreDNS' 1h
+          #     refresh_mode: immediate   # immediate|verify, defaults to immediate
+          serve_stale: {}
+        forward:
+          parameters: __PILLAR__UPSTREAM__SERVERS__   # defaults to /etc/resolv.conf
+          force_tcp: false
+          prefer_udp: false
+          policy: ""    # random|round_robin|sequential
+          max_fails: ""   # 10
+          expire: ""    # 10s
+          health_check: ""    # 10s
+          except: ""    # space-separated list of domains to exclude from forwarding
+        prometheus: true
+        health:
+          port: 8080
+#        hosts:
+#          entries:     # dns.hosts INLINE
+#            - ip: 10.5.0.4
+#              name: blabla.lala
+#          ttl: 3600       # in seconds, 3600 (default)
+#          no_reverse: true    # set no_reverse
+#          reload: "0s"    # 0s disable (default), use duration notation, ie, "1.5h"
+#          fallthrough: true
+    ip6.arpa:53:
+      plugins:
+        errors: true
+        reload: true
+        debug: false
+        log:
+          format: combined
+          classes: all
+        cache:
+          parameters: 30
+        forward:
+          parameters: __PILLAR__UPSTREAM__SERVERS__   # defaults to /etc/resolv.conf
+          force_tcp: false
+        prometheus: true
+        health:
+          port: 8080
+    in-addr.arpa:53:
+      plugins:
+        errors: true
+        reload: true
+        debug: false
+        log:
+          format: combined
+          classes: all
+        cache:
+          parameters: 30
+        forward:
+          parameters: __PILLAR__UPSTREAM__SERVERS__   # defaults to /etc/resolv.conf
+          force_tcp: false
+        prometheus: true
+        health:
+          port: 8080
+
+# useHostNetwork is always false when using cilium
+useHostNetwork: true
+
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 10%
+
+priorityClassName: system-node-critical
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+
+securityContext:
+  privileged: true
+
+readinessProbe:
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+nodeSelector: {}
+affinity: {}
+
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+  - effect: NoSchedule
+    operator: Exists
+
+resources:
+  requests:
+    cpu: 30m
+    memory: 50Mi
+
+metrics:
+  prometheusScrape: "true"
+  port: 9253
+
+podmonitor:
+  enabled: false
+  metricRelabelings: []


### PR DESCRIPTION
Fork of lablabs/node-local-dns 2.4.0, which is the latest release, with two
rendering bugs fixed.

cache.serve_stale, as documented in values.yaml, was never read: the template
tested cache.server_stale. Even when triggered it emitted a bare serve_stale,
so the duration and refresh mode could not be set and CoreDNS fell back to its
1h immediate defaults. It now takes an optional duration and refresh_mode.

forward.health_check was rendered as expire, a different directive: upstream
health checking was silently disabled while the values claimed otherwise, and
an unrequested connection expiry was applied instead.

Both matter for infra-services, which relies on serve_stale to stop upstream
resolver timeouts from breaking CI jobs, and on health checking for upstream
failover.

Related: TASKS2-3994
