### PR TITLE
fix(elasticsearch-cluster): read cluster from $externalLabels in annotations

### DIFF
--- a/charts/elasticsearch-cluster/Chart.yaml
+++ b/charts/elasticsearch-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Elasticsearch cluster - a hat chart for several elasticsearch charts
 home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch-cluster
 name: elasticsearch-cluster
-version: 4.4.17
+version: 4.4.18
 appVersion: 8.19.12
 dependencies:
   - name: elasticsearch

--- a/charts/elasticsearch-cluster/values.yaml
+++ b/charts/elasticsearch-cluster/values.yaml
@@ -293,7 +293,7 @@ prometheus-elasticsearch-exporter:
           severity: critical
         annotations:
           summary: "Cluster health status is RED"
-          description: 'Cluster {{ "{{ $labels.cluster }}" }} health status is RED'
+          description: 'Cluster {{ "{{ $externalLabels.cluster }}" }} health status is RED'
       - alert: ESClusteStatusYELLOW
         expr: |
           elasticsearch_cluster_health_status{color="yellow", service="{{ template "elasticsearch-exporter.fullname" . }}"} == 1
@@ -302,7 +302,7 @@ prometheus-elasticsearch-exporter:
           severity: high
         annotations:
           summary: "Cluster health status is YELLOW"
-          description: 'Cluster {{ "{{ $labels.cluster }}" }} health status is YELLOW'
+          description: 'Cluster {{ "{{ $externalLabels.cluster }}" }} health status is YELLOW'
 
       ## Report any rejected request.
       - alert: ESBulkRequestsRejection
@@ -314,7 +314,7 @@ prometheus-elasticsearch-exporter:
         annotations:
           summary: "Elasticsearch Bulk Query Rejection"
           description: |
-            'Bulk Rejection at {{ "{{ $labels.name }}" }} node in {{ "{{ $labels.cluster }}" }} cluster'
+            'Bulk Rejection at {{ "{{ $labels.name }}" }} node in {{ "{{ $externalLabels.cluster }}" }} cluster'
 
       - alert: ESJVMHeapHigh
         expr: |
@@ -330,7 +330,7 @@ prometheus-elasticsearch-exporter:
         annotations:
           summary: "JVM Heap usage on the node is high"
           description: |
-            'JVM Heap usage on the node {{ "{{ $labels.node }}" }} in {{ "{{ $labels.cluster }}" }} cluster is {{ "{{ $value }}" }}%. There might be long running GCs now.'
+            'JVM Heap usage on the node {{ "{{ $labels.node }}" }} in {{ "{{ $externalLabels.cluster }}" }} cluster is {{ "{{ $value }}" }}%. There might be long running GCs now.'
 
 cerebro:
   enabled: false


### PR DESCRIPTION
`cluster` is a Prometheus external label, attached by the notifier after
rule evaluation, so it is absent from the local TSDB when annotations are
templated and $labels.cluster renders empty. Verified on the live stack that
the elasticsearch metrics carry no cluster label of their own: the only
values that label ever takes are the k8s cluster names.

Same fix as wiremind-services-configuration !7481, which covers the copies
of these alerts used by the logging release.
