### PR TITLE
feat(charts): support commonLabels in five charts

### DIFF
--- a/charts/cerebro/Chart.yaml
+++ b/charts/cerebro/Chart.yaml
@@ -1,5 +1,5 @@
 name: cerebro
-version: 2.3.0
+version: 2.4.0
 appVersion: 0.9.4
 apiVersion: v2
 description: A Helm chart for Cerebro - a web admin tool to manage ElasticSearch

--- a/charts/cerebro/templates/_helpers.tpl
+++ b/charts/cerebro/templates/_helpers.tpl
@@ -32,6 +32,20 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Labels stamped on every resource. The four base labels were repeated verbatim in each template
+before; commonLabels is appended so a parent chart can group everything this chart renders.
+*/}}
+{{- define "cerebro.labels" -}}
+app: {{ template "cerebro.name" . }}
+chart: {{ template "cerebro.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "cerebro.serviceAccountName" -}}

--- a/charts/cerebro/templates/deployment.yaml
+++ b/charts/cerebro/templates/deployment.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "cerebro.fullname" . }}
   labels:
-    app: {{ template "cerebro.name" . }}
-    chart: {{ template "cerebro.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cerebro.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.deployment.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/cerebro/templates/ingress.yaml
+++ b/charts/cerebro/templates/ingress.yaml
@@ -6,10 +6,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app: {{ template "cerebro.name" . }}
-    chart: {{ template "cerebro.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cerebro.labels" . | nindent 4 }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/cerebro/templates/secret-app.yaml
+++ b/charts/cerebro/templates/secret-app.yaml
@@ -5,10 +5,7 @@ type: Opaque
 metadata:
   name: {{ template "cerebro.fullname" . }}-app
   labels:
-    app: {{ template "cerebro.name" . }}
-    chart: {{ template "cerebro.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cerebro.labels" . | nindent 4 }}
 stringData:
   application.conf: |-
     secret = ${?CEREBRO_COOKIE_SECRET}

--- a/charts/cerebro/templates/secret-vars.yaml
+++ b/charts/cerebro/templates/secret-vars.yaml
@@ -5,10 +5,7 @@ type: Opaque
 metadata:
   name: {{ template "cerebro.fullname" . }}-vars
   labels:
-    app: {{ template "cerebro.name" . }}
-    chart: {{ template "cerebro.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cerebro.labels" . | nindent 4 }}
 data:
   {{- if .Values.config.secret }}
   CEREBRO_COOKIE_SECRET: {{ .Values.config.secret | b64enc | quote }}

--- a/charts/cerebro/templates/service.yaml
+++ b/charts/cerebro/templates/service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ template "cerebro.fullname" . }}
   labels:
-    app: {{ template "cerebro.name" . }}
-    chart: {{ template "cerebro.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cerebro.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/charts/cerebro/templates/serviceaccount.yaml
+++ b/charts/cerebro/templates/serviceaccount.yaml
@@ -4,10 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "cerebro.serviceAccountName" . }}
   labels:
-    app: {{ template "cerebro.name" . }}
-    chart: {{ template "cerebro.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cerebro.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceAccount.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/cerebro/values.yaml
+++ b/charts/cerebro/values.yaml
@@ -1,3 +1,6 @@
+# Labels added to every resource this chart renders.
+commonLabels: {}
+
 replicaCount: 1
 revisionHistoryLimit: 3
 

--- a/charts/elasticsearch-cluster/Chart.yaml
+++ b/charts/elasticsearch-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Elasticsearch cluster - a hat chart for several elasticsearch charts
 home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch-cluster
 name: elasticsearch-cluster
-version: 4.4.17
+version: 4.5.0
 appVersion: 8.19.12
 dependencies:
   - name: elasticsearch

--- a/charts/elasticsearch-cluster/templates/_helpers.tpl
+++ b/charts/elasticsearch-cluster/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "elasticsearch-cluster.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/elasticsearch-cluster/values.yaml
+++ b/charts/elasticsearch-cluster/values.yaml
@@ -1,3 +1,8 @@
+# Labels added to every resource this chart renders. Its children (the elasticsearch node
+# groups, kibana, cerebro) take their own commonLabels — set per alias, not propagated from
+# here, so nothing reaches a volumeClaimTemplate by accident.
+commonLabels: {}
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts
 name: elasticsearch
-version: 8.17.2
+version: 8.18.0
 appVersion: 8.19.12
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch

--- a/charts/elasticsearch/templates/configmap.yaml
+++ b/charts/elasticsearch/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
 {{- range $path, $config := .Values.esConfig }}
   {{ $path }}: |
@@ -26,6 +29,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
 {{- range $path, $config := .Values.esJvmOptions }}
   {{ $path }}: |

--- a/charts/elasticsearch/templates/ingress.yaml
+++ b/charts/elasticsearch/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{- with .Values.ingress.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/elasticsearch/templates/networkpolicy.yaml
+++ b/charts/elasticsearch/templates/networkpolicy.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/charts/elasticsearch/templates/poddisruptionbudget.yaml
@@ -7,6 +7,14 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "elasticsearch.uname" . }}-pdb"
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    app: "{{ template "elasticsearch.uname" . }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   maxUnavailable: {{ .Values.maxUnavailable }}
   selector:

--- a/charts/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/charts/elasticsearch/templates/podsecuritypolicy.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ $fullName | quote }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
 {{ toYaml .Values.podSecurityPolicy.spec | indent 2 }}
 {{- end -}}

--- a/charts/elasticsearch/templates/role.yaml
+++ b/charts/elasticsearch/templates/role.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ $fullName | quote }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - apiGroups:
       - extensions

--- a/charts/elasticsearch/templates/rolebinding.yaml
+++ b/charts/elasticsearch/templates/rolebinding.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ $fullName | quote }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
   - kind: ServiceAccount
     name: "{{ template "elasticsearch.serviceAccount" . }}"

--- a/charts/elasticsearch/templates/secret-cert.yaml
+++ b/charts/elasticsearch/templates/secret-cert.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: "{{ .Chart.Name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
 {{ ( include "elasticsearch.gen-certs" . ) | indent 2 }}
 {{- end }}

--- a/charts/elasticsearch/templates/secret.yaml
+++ b/charts/elasticsearch/templates/secret.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   username: {{ "elastic" | b64enc }}

--- a/charts/elasticsearch/templates/service.yaml
+++ b/charts/elasticsearch/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4}}
 {{- end }}
@@ -60,6 +63,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.service.labelsHeadless }}
 {{ toYaml .Values.service.labelsHeadless | indent 4 }}
 {{- end }}

--- a/charts/elasticsearch/templates/serviceaccount.yaml
+++ b/charts/elasticsearch/templates/serviceaccount.yaml
@@ -13,4 +13,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ $fullName | quote }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end -}}

--- a/charts/elasticsearch/templates/statefulset.yaml
+++ b/charts/elasticsearch/templates/statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"
     {{- range $key, $value := .Values.annotations }}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -88,6 +88,11 @@ podAnnotations: {}
 # iam.amazonaws.com/role: es-cluster
 
 # additionals labels
+# Labels added to every resource this chart renders. Unlike `labels`, these do NOT reach the
+# StatefulSet's volumeClaimTemplates, whose labels are immutable — so setting them cannot
+# turn an upgrade into a StatefulSet recreate.
+commonLabels: {}
+
 labels: {}
 
 # additionals annotations

--- a/charts/postgres-operator/Chart.yaml
+++ b/charts/postgres-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: postgres-operator
-version: 1.14.0-wiremind1
+version: 1.14.0-wiremind2
 appVersion: 1.14.0
 home: https://github.com/zalando/postgres-operator
 description: Zalando PostgreSQL operator (wiremind fork, adds deploymentAnnotations and operatorConfigurationAnnotations)

--- a/charts/postgres-operator/templates/_helpers.tpl
+++ b/charts/postgres-operator/templates/_helpers.tpl
@@ -77,3 +77,16 @@ Flatten nested config options when ConfigMap is used as ConfigTarget
     {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Labels stamped on every resource. The three base labels were repeated verbatim in each template
+before; commonLabels is appended so a parent chart can group everything this chart renders.
+*/}}
+{{- define "postgres-operator.labels" -}}
+app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
+helm.sh/chart: {{ template "postgres-operator.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}

--- a/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
+++ b/charts/postgres-operator/templates/clusterrole-postgres-pod.yaml
@@ -4,9 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "postgres-pod.serviceAccountName" . }}
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 # Patroni needs to watch and manage config maps or endpoints

--- a/charts/postgres-operator/templates/clusterrole.yaml
+++ b/charts/postgres-operator/templates/clusterrole.yaml
@@ -4,9 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "postgres-operator.serviceAccountName" . }}
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 rules:
 # all verbs allowed for custom operator resources

--- a/charts/postgres-operator/templates/clusterrolebinding.yaml
+++ b/charts/postgres-operator/templates/clusterrolebinding.yaml
@@ -4,9 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "postgres-operator.serviceAccountName" . }}
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/postgres-operator/templates/configmap.yaml
+++ b/charts/postgres-operator/templates/configmap.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "postgres-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
 {{- if or .Values.podPriorityClassName.create .Values.podPriorityClassName.name }}

--- a/charts/postgres-operator/templates/deployment.yaml
+++ b/charts/postgres-operator/templates/deployment.yaml
@@ -2,9 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   {{- with .Values.deploymentAnnotations }}
   annotations:

--- a/charts/postgres-operator/templates/operatorconfiguration.yaml
+++ b/charts/postgres-operator/templates/operatorconfiguration.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "postgres-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   {{- with .Values.operatorConfigurationAnnotations }}
   annotations:

--- a/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
+++ b/charts/postgres-operator/templates/postgres-pod-priority-class.yaml
@@ -4,9 +4,7 @@ description: 'Use only for databases controlled by Postgres operator'
 kind: PriorityClass
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ include "postgres-pod.priorityClassName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/postgres-operator/templates/service.yaml
+++ b/charts/postgres-operator/templates/service.yaml
@@ -2,9 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "postgres-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/postgres-operator/templates/serviceaccount.yaml
+++ b/charts/postgres-operator/templates/serviceaccount.yaml
@@ -5,8 +5,6 @@ metadata:
   name: {{ include "postgres-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ end }}

--- a/charts/postgres-operator/templates/user-facing-clusterroles.yaml
+++ b/charts/postgres-operator/templates/user-facing-clusterroles.yaml
@@ -4,9 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "postgres-operator.fullname" . }}:users:admin
 rules:
@@ -31,9 +29,7 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "postgres-operator.fullname" . }}:users:edit
 rules:
@@ -53,9 +49,7 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/name: {{ template "postgres-operator.name" . }}
-    helm.sh/chart: {{ template "postgres-operator.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "postgres-operator.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ template "postgres-operator.fullname" . }}:users:view
 rules:

--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -20,6 +20,9 @@ deploymentAnnotations: {}
 operatorConfigurationAnnotations: {}
 
 podAnnotations: {}
+# Labels added to every resource this chart renders.
+commonLabels: {}
+
 podLabels: {}
 
 configTarget: "OperatorConfigurationCRD"

--- a/charts/prometheus-safety-exporter/Chart.yaml
+++ b/charts/prometheus-safety-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-safety-exporter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.5.4
+version: 0.6.0
 appVersion: "0.7.0"  # version of json_exporter
 maintainers:
   - name: Wiremind

--- a/charts/prometheus-safety-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-safety-exporter/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "prometheus-safety-exporter.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/prometheus-safety-exporter/values.yaml
+++ b/charts/prometheus-safety-exporter/values.yaml
@@ -28,6 +28,9 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+# Labels added to every resource this chart renders.
+commonLabels: {}
+
 podLabels: {}
 deploymentAnnotations: {}
 deploymentLabels: {}


### PR DESCRIPTION
Adds a `commonLabels` value to five charts, so a parent chart can group every resource they render.

## Why

Wiremind's `wiremind` umbrella chart labels every resource it renders with
`app.wiremind.io/overwhelm`, which our ArgoCD "Components" view groups an Application's resources by.
Resources coming from these subcharts could not be labelled at all: they expose `podLabels` (which
only reaches a pod template) or per-resource hooks, but nothing that covers everything they render.
25 resources per environment ended up ungrouped; these five charts account for 16 of them.

`commonLabels` is the convention `keycloak`, `rabbitmq`, `redis` and `prometheus-openstack-exporter`
already use in this repo. Additive, defaulting to `{}`, so no existing consumer is affected.

## Per chart

| chart | version | change |
| --- | --- | --- |
| `prometheus-safety-exporter` | 0.5.4 → 0.6.0 | one edit: every template already used the `.labels` helper |
| `cerebro` | 2.3.0 → 2.4.0 | new `cerebro.labels` helper — the same 4 base labels were repeated in all 6 templates |
| `postgres-operator` | 1.14.0-wiremind1 → -wiremind2 | new `postgres-operator.labels` helper — the same 3 base labels were repeated in **12** places |
| `elasticsearch` | 8.17.2 → 8.18.0 | appended to 13 top-level label blocks; the PodDisruptionBudget had none and now gets the base set |
| `elasticsearch-cluster` | 4.4.17 → 4.5.0 | one edit to its `.labels` helper, covering the setup ConfigMap/Job and keystore Secret |

## Two judgement calls

**`elasticsearch` gets no shared helper**, unlike cerebro and postgres-operator. Its label blocks are
not uniform — `chart` is sometimes `{{ .Chart.Name }}` and sometimes `{{ .Chart.Name }}-{{ .Chart.Version }}`,
`app` is sometimes `elasticsearch.uname` and sometimes `$fullName`, and key order and quoting vary.
Unifying them would change the rendered labels, which this PR must not do. Worth doing, separately.

**`commonLabels` reaches `metadata.labels` only** — never a pod template, never
`volumeClaimTemplates`. `labels` *does* propagate into the volumeClaimTemplates, whose labels are
immutable, so a `commonLabels` that followed the same path would turn setting the value into a
StatefulSet recreate for every existing Elasticsearch cluster. Documented in `values.yaml` beside the
key so it does not get "tidied up" later.

`elasticsearch-cluster` likewise does not forward anything through `global`: its children take their
own `commonLabels`, set per alias by the consumer, so no value can reach a child's
volumeClaimTemplates by accident.

## Verification

A local harness renders each chart twice and compares parsed YAML:

1. with `commonLabels` **unset**, every resource's identity, labels and annotations are identical to
   `main` — 21 resources across the four leaf charts. Ignores `data`/`stringData` (elasticsearch and
   cerebro mint fresh certs and passwords on every render) and normalises `helm.sh/chart` (a version
   bump moves it by definition). The one intentional difference is the PodDisruptionBudget gaining
   the base label set.
2. with `commonLabels` **set**, every rendered resource carries it.
3. it never appears in a StatefulSet's `spec.selector`, pod template, or `volumeClaimTemplates` —
   negative-tested by planting a leak and confirming the check fails.

`helm lint --strict` passes on all five.

Not verifiable locally: `elasticsearch-cluster` resolves its children from the published repo at
`version: *`, so the aliased `elasticsearch`/`cerebro` changes only take effect once those charts are
released. I confirmed `commonLabels` reaches elasticsearch-cluster's own three resources.

## Follow-up, not here

Two of the 25 ungrouped resources' charts are genuinely third-party and unaffected by this PR:
`metabase` (pmint93, 6 resources) and `prometheus-elasticsearch-exporter` (prometheus-community, 3).
Those need upstream PRs, or a decision to stop using them.
