### PR TITLE
chore(agentgateway-crds): upgrade to 1.4.1

### DIFF
--- a/charts/agentgateway-crds/Chart.yaml
+++ b/charts/agentgateway-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: agentgateway-crds
-version: 1.3.1
-appVersion: "v1.3.1"
+version: 1.4.1
+appVersion: "v1.4.1"
 description: Manage agentgateway CRDs
 keywords:
   - agentgateway
@@ -11,7 +11,7 @@ keywords:
   - crds
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/agentgateway-crds
-  - https://github.com/agentgateway/agentgateway/tree/v1.3.1/controller/install/helm/agentgateway-crds
+  - https://github.com/agentgateway/agentgateway/tree/v1.4.1/controller/install/helm/agentgateway-crds
 icon: https://raw.githubusercontent.com/agentgateway/website/refs/heads/main/static/favicon.svg
 maintainers:
   - name: Wiremind

--- a/charts/agentgateway-crds/README.md
+++ b/charts/agentgateway-crds/README.md
@@ -8,12 +8,12 @@ The Chart has the same version as the `agentgateway` release, try to keep them e
 
 CRDs are located [here](https://github.com/agentgateway/agentgateway/tree/main/controller/install/helm/agentgateway-crds/templates).
 
-Use the release tag that matches `appVersion`, for example [v1.3.1](https://github.com/agentgateway/agentgateway/tree/v1.3.1/controller/install/helm/agentgateway-crds/templates).
+Use the release tag that matches `appVersion`, for example [v1.4.1](https://github.com/agentgateway/agentgateway/tree/v1.4.1/controller/install/helm/agentgateway-crds/templates).
 
 **Do not forget to change APP_VERSION**
 
 ```bash
-export APP_VERSION=v1.3.1
+export APP_VERSION=v1.4.1
 ./scripts/update_crds.sh -r agentgateway/agentgateway -b "$APP_VERSION" --folder controller/install/helm/agentgateway-crds/templates -o charts/agentgateway-crds/templates/
 ```
 

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -444,11 +444,9 @@ spec:
                                             this CRD."
                                           properties:
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                             value:
                                               description: Default value for the field.
@@ -505,11 +503,9 @@ spec:
                                             this CRD."
                                           properties:
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                             value:
                                               description: Default value for the field.
@@ -642,13 +638,13 @@ spec:
                                                       properties:
                                                         auth:
                                                           description: Settings for
-                                                            managing authentication
-                                                            to the backend.
+                                                            authenticating to AWS
+                                                            Bedrock Guardrails.
                                                           properties:
                                                             aws:
                                                               description: |-
-                                                                Explicit AWS authentication method for the backend.
-                                                                When omitted, default AWS SDK credential discovery is used.
+                                                                AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                                                default AWS SDK credential discovery.
                                                               properties:
                                                                 assumeRole:
                                                                   description: |-
@@ -662,31 +658,117 @@ spec:
                                                                       minLength: 1
                                                                       pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                                       type: string
+                                                                    sessionName:
+                                                                      description: |-
+                                                                        SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                                        Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                                      pattern: ^[\w+=,.@-]{2,64}$
+                                                                      type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
+                                                                    tags:
+                                                                      description: |-
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
+                                                                      items:
+                                                                        description: |-
+                                                                          AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                                          attribution. Exactly one of value and expression must be set.
+                                                                        properties:
+                                                                          expression:
+                                                                            description: |-
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
+                                                                            maxLength: 16384
+                                                                            minLength: 1
+                                                                            type: string
+                                                                          key:
+                                                                            description: Key
+                                                                              is the
+                                                                              tag
+                                                                              key.
+                                                                            maxLength: 128
+                                                                            minLength: 1
+                                                                            type: string
+                                                                          value:
+                                                                            description: Value
+                                                                              is a
+                                                                              static
+                                                                              tag
+                                                                              value.
+                                                                            maxLength: 256
+                                                                            type: string
+                                                                        required:
+                                                                        - key
+                                                                        type: object
+                                                                        x-kubernetes-validations:
+                                                                        - message: exactly
+                                                                            one of
+                                                                            value
+                                                                            or expression
+                                                                            must be
+                                                                            set
+                                                                          rule: has(self.value)
+                                                                            != has(self.expression)
+                                                                      maxItems: 50
+                                                                      type: array
+                                                                      x-kubernetes-list-map-keys:
+                                                                      - key
+                                                                      x-kubernetes-list-type: map
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
+                                                                region:
+                                                                  description: |-
+                                                                    AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                                    target AWS service is in a different region than the gateway. If unset,
+                                                                    typed AWS backends may provide this automatically; otherwise the ambient
+                                                                    AWS region is used.
+                                                                  maxLength: 256
+                                                                  minLength: 1
+                                                                  type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -723,155 +805,16 @@ spec:
                                                                   mutually exclusive
                                                                 rule: '!(has(self.secretRef)
                                                                   && has(self.assumeRole))'
-                                                            azure:
-                                                              description: Azure authentication
-                                                                method for the backend.
-                                                              properties:
-                                                                managedIdentity:
-                                                                  description: Managed
-                                                                    identity authentication
-                                                                    settings.
-                                                                  properties:
-                                                                    clientId:
-                                                                      type: string
-                                                                    objectId:
-                                                                      type: string
-                                                                    resourceId:
-                                                                      type: string
-                                                                  required:
-                                                                  - clientId
-                                                                  - objectId
-                                                                  - resourceId
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                              type: object
-                                                            gcp:
-                                                              description: |-
-                                                                Google authentication method for the backend.
-                                                                When omitted, default Google credential discovery is used.
-                                                              properties:
-                                                                audience:
-                                                                  description: |-
-                                                                    Explicit `aud` value for the ID token. Only
-                                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                                    derived from the backend hostname.
-                                                                  maxLength: 256
-                                                                  minLength: 1
-                                                                  type: string
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key. When omitted, ambient credentials are used.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                                type:
-                                                                  description: |-
-                                                                    The type of token to generate. To authenticate to GCP services,
-                                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                                    `IdToken` is used.
-                                                                  enum:
-                                                                  - AccessToken
-                                                                  - IdToken
-                                                                  type: string
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: audience
-                                                                  is only valid with
-                                                                  IdToken
-                                                                rule: 'has(self.audience)
-                                                                  ? self.type == ''IdToken''
-                                                                  : true'
                                                             key:
                                                               description: |-
-                                                                Inline key to use as the value of the
-                                                                `Authorization` header. This option is the least secure; usage of a
-                                                                `Secret` is preferred.
+                                                                Inline API key to use as the value of the `Authorization` header.
+                                                                This option is the least secure; usage of a `Secret` is preferred.
                                                               maxLength: 2048
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where API keys are inserted. Defaults to the `Authorization` header with
+                                                                the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -885,19 +828,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -927,35 +864,39 @@ spec:
                                                                   set
                                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                                   == 1'
-                                                            passthrough:
-                                                              description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
-                                                              type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key.
+                                                                Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                                                By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
+                                                                  type: string
+                                                                key:
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
+                                                                  maxLength: 253
+                                                                  minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -980,26 +921,25 @@ spec:
                                                           x-kubernetes-validations:
                                                           - message: location may
                                                               only be set for key
-                                                              or passthrough auth
+                                                              or secretRef auth
                                                             rule: 'has(self.location)
                                                               ? has(self.key) || has(self.secretRef)
-                                                              || has(self.passthrough)
                                                               : true'
                                                           - message: exactly one of
                                                               the fields in [key secretRef
-                                                              passthrough aws azure
-                                                              gcp] must be set
-                                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                                              aws] must be set
+                                                            rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
                                                               == 1'
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1013,17 +953,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -1032,12 +965,13 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1058,6 +992,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1081,6 +1016,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1096,10 +1032,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -1126,12 +1062,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -1140,15 +1072,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -1167,34 +1097,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -1263,9 +1194,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -1274,29 +1204,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1309,27 +1231,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -1350,6 +1270,12 @@ spec:
                                                           - backendRef
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-validations:
+                                                      - message: at least one of the
+                                                          fields in [auth http tcp
+                                                          tls tunnel] must be set
+                                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                                          >= 1'
                                                     region:
                                                       description: |-
                                                         AWS region where the guardrail is deployed, for example
@@ -1387,155 +1313,13 @@ spec:
                                                       properties:
                                                         auth:
                                                           description: Settings for
-                                                            managing authentication
-                                                            to the backend.
+                                                            authenticating to Google
+                                                            Model Armor.
                                                           properties:
-                                                            aws:
-                                                              description: |-
-                                                                Explicit AWS authentication method for the backend.
-                                                                When omitted, default AWS SDK credential discovery is used.
-                                                              properties:
-                                                                assumeRole:
-                                                                  description: |-
-                                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                                  properties:
-                                                                    roleArn:
-                                                                      description: AWS
-                                                                        IAM role ARN
-                                                                        to assume.
-                                                                      minLength: 1
-                                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                                      type: string
-                                                                  required:
-                                                                  - roleArn
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                                serviceName:
-                                                                  description: |-
-                                                                    AWS SigV4 signing service name, for example
-                                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                                    backends may provide this automatically.
-                                                                  maxLength: 256
-                                                                  minLength: 1
-                                                                  type: string
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: secretRef
-                                                                  and assumeRole are
-                                                                  mutually exclusive
-                                                                rule: '!(has(self.secretRef)
-                                                                  && has(self.assumeRole))'
-                                                            azure:
-                                                              description: Azure authentication
-                                                                method for the backend.
-                                                              properties:
-                                                                managedIdentity:
-                                                                  description: Managed
-                                                                    identity authentication
-                                                                    settings.
-                                                                  properties:
-                                                                    clientId:
-                                                                      type: string
-                                                                    objectId:
-                                                                      type: string
-                                                                    resourceId:
-                                                                      type: string
-                                                                  required:
-                                                                  - clientId
-                                                                  - objectId
-                                                                  - resourceId
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                              type: object
                                                             gcp:
                                                               description: |-
-                                                                Google authentication method for the backend.
-                                                                When omitted, default Google credential discovery is used.
+                                                                Google authentication method for Model Armor. Use `gcp: {}` for default
+                                                                Google credential discovery.
                                                               properties:
                                                                 audience:
                                                                   description: |-
@@ -1547,26 +1331,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key. When omitted, ambient credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
+                                                                      type: string
+                                                                    key:
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
+                                                                      maxLength: 253
+                                                                      minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -1605,146 +1405,23 @@ spec:
                                                                 rule: 'has(self.audience)
                                                                   ? self.type == ''IdToken''
                                                                   : true'
-                                                            key:
-                                                              description: |-
-                                                                Inline key to use as the value of the
-                                                                `Authorization` header. This option is the least secure; usage of a
-                                                                `Secret` is preferred.
-                                                              maxLength: 2048
-                                                              type: string
-                                                            location:
-                                                              description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
-                                                              properties:
-                                                                cookie:
-                                                                  properties:
-                                                                    name:
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                header:
-                                                                  properties:
-                                                                    name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                                                      type: string
-                                                                    prefix:
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                queryParameter:
-                                                                  properties:
-                                                                    name:
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: exactly one
-                                                                  of the fields in
-                                                                  [header queryParameter
-                                                                  cookie] must be
-                                                                  set
-                                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
-                                                                  == 1'
-                                                            passthrough:
-                                                              description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
-                                                              type: object
-                                                            secretRef:
-                                                              description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key.
-                                                              properties:
-                                                                group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
-                                                                  type: string
-                                                                kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
-                                                                  type: string
-                                                                name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
-                                                                  maxLength: 253
-                                                                  minLength: 1
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                              x-kubernetes-map-type: atomic
-                                                              x-kubernetes-validations:
-                                                              - message: custom credential
-                                                                  refs must set both
-                                                                  group and kind
-                                                                rule: '(!has(self.group)
-                                                                  || size(self.group)
-                                                                  == 0) ? (!has(self.kind)
-                                                                  || size(self.kind)
-                                                                  == 0 || self.kind
-                                                                  == ''Secret'') :
-                                                                  (has(self.kind)
-                                                                  && size(self.kind)
-                                                                  > 0)'
                                                           type: object
                                                           x-kubernetes-validations:
-                                                          - message: location may
-                                                              only be set for key
-                                                              or passthrough auth
-                                                            rule: 'has(self.location)
-                                                              ? has(self.key) || has(self.secretRef)
-                                                              || has(self.passthrough)
-                                                              : true'
                                                           - message: exactly one of
-                                                              the fields in [key secretRef
-                                                              passthrough aws azure
-                                                              gcp] must be set
-                                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                                              the fields in [gcp]
+                                                              must be set
+                                                            rule: '[has(self.gcp)].filter(x,x==true).size()
                                                               == 1'
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1758,17 +1435,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -1777,12 +1447,13 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1803,6 +1474,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1826,6 +1498,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1841,10 +1514,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -1871,12 +1544,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -1885,15 +1554,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -1912,34 +1579,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -2008,9 +1676,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -2019,29 +1686,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2054,27 +1713,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -2095,6 +1752,12 @@ spec:
                                                           - backendRef
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-validations:
+                                                      - message: at least one of the
+                                                          fields in [auth http tcp
+                                                          tls tunnel] must be set
+                                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                                          >= 1'
                                                     projectId:
                                                       description: Google Cloud project
                                                         ID.
@@ -2128,224 +1791,8 @@ spec:
                                                       properties:
                                                         auth:
                                                           description: Settings for
-                                                            managing authentication
-                                                            to the backend.
+                                                            authenticating to OpenAI.
                                                           properties:
-                                                            aws:
-                                                              description: |-
-                                                                Explicit AWS authentication method for the backend.
-                                                                When omitted, default AWS SDK credential discovery is used.
-                                                              properties:
-                                                                assumeRole:
-                                                                  description: |-
-                                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                                  properties:
-                                                                    roleArn:
-                                                                      description: AWS
-                                                                        IAM role ARN
-                                                                        to assume.
-                                                                      minLength: 1
-                                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                                      type: string
-                                                                  required:
-                                                                  - roleArn
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                                serviceName:
-                                                                  description: |-
-                                                                    AWS SigV4 signing service name, for example
-                                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                                    backends may provide this automatically.
-                                                                  maxLength: 256
-                                                                  minLength: 1
-                                                                  type: string
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: secretRef
-                                                                  and assumeRole are
-                                                                  mutually exclusive
-                                                                rule: '!(has(self.secretRef)
-                                                                  && has(self.assumeRole))'
-                                                            azure:
-                                                              description: Azure authentication
-                                                                method for the backend.
-                                                              properties:
-                                                                managedIdentity:
-                                                                  description: Managed
-                                                                    identity authentication
-                                                                    settings.
-                                                                  properties:
-                                                                    clientId:
-                                                                      type: string
-                                                                    objectId:
-                                                                      type: string
-                                                                    resourceId:
-                                                                      type: string
-                                                                  required:
-                                                                  - clientId
-                                                                  - objectId
-                                                                  - resourceId
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                              type: object
-                                                            gcp:
-                                                              description: |-
-                                                                Google authentication method for the backend.
-                                                                When omitted, default Google credential discovery is used.
-                                                              properties:
-                                                                audience:
-                                                                  description: |-
-                                                                    Explicit `aud` value for the ID token. Only
-                                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                                    derived from the backend hostname.
-                                                                  maxLength: 256
-                                                                  minLength: 1
-                                                                  type: string
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key. When omitted, ambient credentials are used.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                                type:
-                                                                  description: |-
-                                                                    The type of token to generate. To authenticate to GCP services,
-                                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                                    `IdToken` is used.
-                                                                  enum:
-                                                                  - AccessToken
-                                                                  - IdToken
-                                                                  type: string
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: audience
-                                                                  is only valid with
-                                                                  IdToken
-                                                                rule: 'has(self.audience)
-                                                                  ? self.type == ''IdToken''
-                                                                  : true'
                                                             key:
                                                               description: |-
                                                                 Inline key to use as the value of the
@@ -2355,9 +1802,8 @@ spec:
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                                header with the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -2371,19 +1817,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2413,35 +1853,39 @@ spec:
                                                                   set
                                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                                   == 1'
-                                                            passthrough:
-                                                              description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
-                                                              type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key.
+                                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
+                                                                  type: string
+                                                                key:
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
+                                                                  maxLength: 253
+                                                                  minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -2464,28 +1908,21 @@ spec:
                                                                   > 0)'
                                                           type: object
                                                           x-kubernetes-validations:
-                                                          - message: location may
-                                                              only be set for key
-                                                              or passthrough auth
-                                                            rule: 'has(self.location)
-                                                              ? has(self.key) || has(self.secretRef)
-                                                              || has(self.passthrough)
-                                                              : true'
                                                           - message: exactly one of
-                                                              the fields in [key secretRef
-                                                              passthrough aws azure
-                                                              gcp] must be set
-                                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                                              the fields in [key secretRef]
+                                                              must be set
+                                                            rule: '[has(self.key),has(self.secretRef)].filter(x,x==true).size()
                                                               == 1'
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -2499,17 +1936,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -2518,12 +1948,13 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -2544,6 +1975,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -2567,6 +1999,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -2582,10 +2015,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -2612,12 +2045,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -2626,15 +2055,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -2653,34 +2080,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -2749,9 +2177,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -2760,29 +2187,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2795,27 +2214,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -2836,6 +2253,12 @@ spec:
                                                           - backendRef
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-validations:
+                                                      - message: at least one of the
+                                                          fields in [auth http tcp
+                                                          tls tunnel] must be set
+                                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                                          >= 1'
                                                   type: object
                                                 regex:
                                                   description: Regular expression
@@ -2920,29 +2343,20 @@ spec:
                                                       properties:
                                                         group:
                                                           default: ""
-                                                          description: |-
-                                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                            When unspecified or empty string, core API group is inferred.
+                                                          description: Group of the
+                                                            referent, for example
+                                                            `gateway.networking.k8s.io`.
+                                                            Empty selects the core
+                                                            API group
                                                           maxLength: 253
                                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                           type: string
                                                         kind:
                                                           default: Service
-                                                          description: |-
-                                                            Kind is the Kubernetes resource kind of the referent. For example
-                                                            "Service".
-
-                                                            Defaults to "Service" when not specified.
-
-                                                            ExternalName services can refer to CNAME DNS records that may live
-                                                            outside of the cluster and as such are difficult to reason about in
-                                                            terms of conformance. They also may not be safe to forward to (see
-                                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                            support ExternalName Services.
-
-                                                            Support: Core (Services with a type other than ExternalName)
-
-                                                            Support: Implementation-specific (Services with type ExternalName)
+                                                          description: Kubernetes
+                                                            resource kind of the referent,
+                                                            for example `Service`.
+                                                            Defaults to `Service`
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2954,27 +2368,21 @@ spec:
                                                           minLength: 1
                                                           type: string
                                                         namespace:
-                                                          description: |-
-                                                            Namespace is the namespace of the backend. When unspecified, the local
-                                                            namespace is inferred.
-
-                                                            Note that when a namespace different than the local namespace is specified,
-                                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                                            documentation for details.
-
-                                                            Support: Core
+                                                          description: Namespace of
+                                                            the referent. Defaults
+                                                            to the local namespace.
+                                                            A cross-namespace reference
+                                                            requires a ReferenceGrant
+                                                            in the referent namespace
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                           type: string
                                                         port:
-                                                          description: |-
-                                                            Port specifies the destination port number to use for this resource.
-                                                            Port is required when the referent is a Kubernetes Service. In this
-                                                            case, the port number is the service port number, not the target port.
-                                                            For other resources, destination port might be derived from the referent
-                                                            resource or this field.
+                                                          description: Destination
+                                                            port number. Required
+                                                            when the referent is a
+                                                            Kubernetes `Service`
                                                           format: int32
                                                           maximum: 65535
                                                           minimum: 1
@@ -3009,51 +2417,31 @@ spec:
                                                           headers.
                                                         properties:
                                                           name:
-                                                            description: |-
-                                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                                              If multiple entries specify equivalent header names, only the first
-                                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                                              entries with an equivalent header name MUST be ignored. Due to the
-                                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                                              equivalent.
-
-                                                              When a header is repeated in an HTTP request, it is
-                                                              implementation-specific behavior as to how this is represented.
-                                                              Generally, proxies should follow the guidance from the RFC:
-                                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                                              processing a repeated header, with special handling for "Set-Cookie".
+                                                            description: Name of the
+                                                              HTTP header to match,
+                                                              case-insensitive. When
+                                                              names are equivalent,
+                                                              only the first matching
+                                                              entry is used
                                                             maxLength: 256
                                                             minLength: 1
                                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                                             type: string
                                                           type:
                                                             default: Exact
-                                                            description: |-
-                                                              Type specifies how to match against the value of the header.
-
-                                                              Support: Core (Exact)
-
-                                                              Support: Implementation-specific (RegularExpression)
-
-                                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                                              of regular expressions. Please read the implementation's documentation to
-                                                              determine the supported dialect.
+                                                            description: 'How to match
+                                                              against the header value:
+                                                              `Exact` (default) or
+                                                              `RegularExpression`.
+                                                              The regex dialect is
+                                                              implementation-specific'
                                                             enum:
                                                             - Exact
                                                             - RegularExpression
                                                             type: string
                                                           value:
-                                                            description: |-
-                                                              Value is the value of HTTP Header to be matched.
-                                                              <gateway:experimental:description>
-                                                              Must consist of printable US-ASCII characters, optionally separated
-                                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                                              </gateway:experimental:description>
-
-                                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                                            description: Value of
+                                                              the HTTP header to match
                                                             maxLength: 4096
                                                             minLength: 1
                                                             type: string
@@ -3062,6 +2450,17 @@ spec:
                                                         - value
                                                         type: object
                                                       type: array
+                                                    headers:
+                                                      additionalProperties:
+                                                        description: A Common Expression
+                                                          Language (CEL) expression.
+                                                        maxLength: 16384
+                                                        minLength: 1
+                                                        type: string
+                                                      description: CEL-computed headers
+                                                        to include in webhook requests.
+                                                      maxProperties: 64
+                                                      type: object
                                                   required:
                                                   - backendRef
                                                   type: object
@@ -3101,13 +2500,13 @@ spec:
                                                       properties:
                                                         auth:
                                                           description: Settings for
-                                                            managing authentication
-                                                            to the backend.
+                                                            authenticating to AWS
+                                                            Bedrock Guardrails.
                                                           properties:
                                                             aws:
                                                               description: |-
-                                                                Explicit AWS authentication method for the backend.
-                                                                When omitted, default AWS SDK credential discovery is used.
+                                                                AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                                                default AWS SDK credential discovery.
                                                               properties:
                                                                 assumeRole:
                                                                   description: |-
@@ -3121,31 +2520,117 @@ spec:
                                                                       minLength: 1
                                                                       pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                                       type: string
+                                                                    sessionName:
+                                                                      description: |-
+                                                                        SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                                        Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                                      pattern: ^[\w+=,.@-]{2,64}$
+                                                                      type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
+                                                                    tags:
+                                                                      description: |-
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
+                                                                      items:
+                                                                        description: |-
+                                                                          AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                                          attribution. Exactly one of value and expression must be set.
+                                                                        properties:
+                                                                          expression:
+                                                                            description: |-
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
+                                                                            maxLength: 16384
+                                                                            minLength: 1
+                                                                            type: string
+                                                                          key:
+                                                                            description: Key
+                                                                              is the
+                                                                              tag
+                                                                              key.
+                                                                            maxLength: 128
+                                                                            minLength: 1
+                                                                            type: string
+                                                                          value:
+                                                                            description: Value
+                                                                              is a
+                                                                              static
+                                                                              tag
+                                                                              value.
+                                                                            maxLength: 256
+                                                                            type: string
+                                                                        required:
+                                                                        - key
+                                                                        type: object
+                                                                        x-kubernetes-validations:
+                                                                        - message: exactly
+                                                                            one of
+                                                                            value
+                                                                            or expression
+                                                                            must be
+                                                                            set
+                                                                          rule: has(self.value)
+                                                                            != has(self.expression)
+                                                                      maxItems: 50
+                                                                      type: array
+                                                                      x-kubernetes-list-map-keys:
+                                                                      - key
+                                                                      x-kubernetes-list-type: map
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
+                                                                region:
+                                                                  description: |-
+                                                                    AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                                    target AWS service is in a different region than the gateway. If unset,
+                                                                    typed AWS backends may provide this automatically; otherwise the ambient
+                                                                    AWS region is used.
+                                                                  maxLength: 256
+                                                                  minLength: 1
+                                                                  type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -3182,155 +2667,16 @@ spec:
                                                                   mutually exclusive
                                                                 rule: '!(has(self.secretRef)
                                                                   && has(self.assumeRole))'
-                                                            azure:
-                                                              description: Azure authentication
-                                                                method for the backend.
-                                                              properties:
-                                                                managedIdentity:
-                                                                  description: Managed
-                                                                    identity authentication
-                                                                    settings.
-                                                                  properties:
-                                                                    clientId:
-                                                                      type: string
-                                                                    objectId:
-                                                                      type: string
-                                                                    resourceId:
-                                                                      type: string
-                                                                  required:
-                                                                  - clientId
-                                                                  - objectId
-                                                                  - resourceId
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                              type: object
-                                                            gcp:
-                                                              description: |-
-                                                                Google authentication method for the backend.
-                                                                When omitted, default Google credential discovery is used.
-                                                              properties:
-                                                                audience:
-                                                                  description: |-
-                                                                    Explicit `aud` value for the ID token. Only
-                                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                                    derived from the backend hostname.
-                                                                  maxLength: 256
-                                                                  minLength: 1
-                                                                  type: string
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key. When omitted, ambient credentials are used.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                                type:
-                                                                  description: |-
-                                                                    The type of token to generate. To authenticate to GCP services,
-                                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                                    `IdToken` is used.
-                                                                  enum:
-                                                                  - AccessToken
-                                                                  - IdToken
-                                                                  type: string
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: audience
-                                                                  is only valid with
-                                                                  IdToken
-                                                                rule: 'has(self.audience)
-                                                                  ? self.type == ''IdToken''
-                                                                  : true'
                                                             key:
                                                               description: |-
-                                                                Inline key to use as the value of the
-                                                                `Authorization` header. This option is the least secure; usage of a
-                                                                `Secret` is preferred.
+                                                                Inline API key to use as the value of the `Authorization` header.
+                                                                This option is the least secure; usage of a `Secret` is preferred.
                                                               maxLength: 2048
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where API keys are inserted. Defaults to the `Authorization` header with
+                                                                the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -3344,19 +2690,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3386,35 +2726,39 @@ spec:
                                                                   set
                                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                                   == 1'
-                                                            passthrough:
-                                                              description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
-                                                              type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key.
+                                                                Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                                                By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
+                                                                  type: string
+                                                                key:
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
+                                                                  maxLength: 253
+                                                                  minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -3439,26 +2783,25 @@ spec:
                                                           x-kubernetes-validations:
                                                           - message: location may
                                                               only be set for key
-                                                              or passthrough auth
+                                                              or secretRef auth
                                                             rule: 'has(self.location)
                                                               ? has(self.key) || has(self.secretRef)
-                                                              || has(self.passthrough)
                                                               : true'
                                                           - message: exactly one of
                                                               the fields in [key secretRef
-                                                              passthrough aws azure
-                                                              gcp] must be set
-                                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                                              aws] must be set
+                                                            rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
                                                               == 1'
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -3472,17 +2815,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -3491,12 +2827,13 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -3517,6 +2854,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -3540,6 +2878,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -3555,10 +2894,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -3585,12 +2924,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -3599,15 +2934,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -3626,34 +2959,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -3722,9 +3056,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -3733,29 +3066,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3768,27 +3093,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -3809,6 +3132,12 @@ spec:
                                                           - backendRef
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-validations:
+                                                      - message: at least one of the
+                                                          fields in [auth http tcp
+                                                          tls tunnel] must be set
+                                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                                          >= 1'
                                                     region:
                                                       description: |-
                                                         AWS region where the guardrail is deployed, for example
@@ -3846,155 +3175,13 @@ spec:
                                                       properties:
                                                         auth:
                                                           description: Settings for
-                                                            managing authentication
-                                                            to the backend.
+                                                            authenticating to Google
+                                                            Model Armor.
                                                           properties:
-                                                            aws:
-                                                              description: |-
-                                                                Explicit AWS authentication method for the backend.
-                                                                When omitted, default AWS SDK credential discovery is used.
-                                                              properties:
-                                                                assumeRole:
-                                                                  description: |-
-                                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                                  properties:
-                                                                    roleArn:
-                                                                      description: AWS
-                                                                        IAM role ARN
-                                                                        to assume.
-                                                                      minLength: 1
-                                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                                      type: string
-                                                                  required:
-                                                                  - roleArn
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                                serviceName:
-                                                                  description: |-
-                                                                    AWS SigV4 signing service name, for example
-                                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                                    backends may provide this automatically.
-                                                                  maxLength: 256
-                                                                  minLength: 1
-                                                                  type: string
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: secretRef
-                                                                  and assumeRole are
-                                                                  mutually exclusive
-                                                                rule: '!(has(self.secretRef)
-                                                                  && has(self.assumeRole))'
-                                                            azure:
-                                                              description: Azure authentication
-                                                                method for the backend.
-                                                              properties:
-                                                                managedIdentity:
-                                                                  description: Managed
-                                                                    identity authentication
-                                                                    settings.
-                                                                  properties:
-                                                                    clientId:
-                                                                      type: string
-                                                                    objectId:
-                                                                      type: string
-                                                                    resourceId:
-                                                                      type: string
-                                                                  required:
-                                                                  - clientId
-                                                                  - objectId
-                                                                  - resourceId
-                                                                  type: object
-                                                                secretRef:
-                                                                  description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
-                                                                  properties:
-                                                                    group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
-                                                                      type: string
-                                                                    kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
-                                                                      type: string
-                                                                    name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
-                                                                      maxLength: 253
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                  x-kubernetes-map-type: atomic
-                                                                  x-kubernetes-validations:
-                                                                  - message: custom
-                                                                      credential refs
-                                                                      must set both
-                                                                      group and kind
-                                                                    rule: '(!has(self.group)
-                                                                      || size(self.group)
-                                                                      == 0) ? (!has(self.kind)
-                                                                      || size(self.kind)
-                                                                      == 0 || self.kind
-                                                                      == ''Secret'')
-                                                                      : (has(self.kind)
-                                                                      && size(self.kind)
-                                                                      > 0)'
-                                                              type: object
                                                             gcp:
                                                               description: |-
-                                                                Google authentication method for the backend.
-                                                                When omitted, default Google credential discovery is used.
+                                                                Google authentication method for Model Armor. Use `gcp: {}` for default
+                                                                Google credential discovery.
                                                               properties:
                                                                 audience:
                                                                   description: |-
@@ -4006,26 +3193,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key. When omitted, ambient credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
+                                                                      type: string
+                                                                    key:
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
+                                                                      maxLength: 253
+                                                                      minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -4064,146 +3267,23 @@ spec:
                                                                 rule: 'has(self.audience)
                                                                   ? self.type == ''IdToken''
                                                                   : true'
-                                                            key:
-                                                              description: |-
-                                                                Inline key to use as the value of the
-                                                                `Authorization` header. This option is the least secure; usage of a
-                                                                `Secret` is preferred.
-                                                              maxLength: 2048
-                                                              type: string
-                                                            location:
-                                                              description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
-                                                              properties:
-                                                                cookie:
-                                                                  properties:
-                                                                    name:
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                header:
-                                                                  properties:
-                                                                    name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                                                      type: string
-                                                                    prefix:
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                                queryParameter:
-                                                                  properties:
-                                                                    name:
-                                                                      maxLength: 256
-                                                                      minLength: 1
-                                                                      type: string
-                                                                  required:
-                                                                  - name
-                                                                  type: object
-                                                              type: object
-                                                              x-kubernetes-validations:
-                                                              - message: exactly one
-                                                                  of the fields in
-                                                                  [header queryParameter
-                                                                  cookie] must be
-                                                                  set
-                                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
-                                                                  == 1'
-                                                            passthrough:
-                                                              description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
-                                                              type: object
-                                                            secretRef:
-                                                              description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key.
-                                                              properties:
-                                                                group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
-                                                                  type: string
-                                                                kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
-                                                                  type: string
-                                                                name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
-                                                                  maxLength: 253
-                                                                  minLength: 1
-                                                                  type: string
-                                                              required:
-                                                              - name
-                                                              type: object
-                                                              x-kubernetes-map-type: atomic
-                                                              x-kubernetes-validations:
-                                                              - message: custom credential
-                                                                  refs must set both
-                                                                  group and kind
-                                                                rule: '(!has(self.group)
-                                                                  || size(self.group)
-                                                                  == 0) ? (!has(self.kind)
-                                                                  || size(self.kind)
-                                                                  == 0 || self.kind
-                                                                  == ''Secret'') :
-                                                                  (has(self.kind)
-                                                                  && size(self.kind)
-                                                                  > 0)'
                                                           type: object
                                                           x-kubernetes-validations:
-                                                          - message: location may
-                                                              only be set for key
-                                                              or passthrough auth
-                                                            rule: 'has(self.location)
-                                                              ? has(self.key) || has(self.secretRef)
-                                                              || has(self.passthrough)
-                                                              : true'
                                                           - message: exactly one of
-                                                              the fields in [key secretRef
-                                                              passthrough aws azure
-                                                              gcp] must be set
-                                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                                              the fields in [gcp]
+                                                              must be set
+                                                            rule: '[has(self.gcp)].filter(x,x==true).size()
                                                               == 1'
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -4217,17 +3297,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -4236,12 +3309,13 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -4262,6 +3336,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -4285,6 +3360,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -4300,10 +3376,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -4330,12 +3406,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -4344,15 +3416,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -4371,34 +3441,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -4467,9 +3538,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -4478,29 +3548,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4513,27 +3575,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -4554,6 +3614,12 @@ spec:
                                                           - backendRef
                                                           type: object
                                                       type: object
+                                                      x-kubernetes-validations:
+                                                      - message: at least one of the
+                                                          fields in [auth http tcp
+                                                          tls tunnel] must be set
+                                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                                          >= 1'
                                                     projectId:
                                                       description: Google Cloud project
                                                         ID.
@@ -4653,29 +3719,20 @@ spec:
                                                       properties:
                                                         group:
                                                           default: ""
-                                                          description: |-
-                                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                            When unspecified or empty string, core API group is inferred.
+                                                          description: Group of the
+                                                            referent, for example
+                                                            `gateway.networking.k8s.io`.
+                                                            Empty selects the core
+                                                            API group
                                                           maxLength: 253
                                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                           type: string
                                                         kind:
                                                           default: Service
-                                                          description: |-
-                                                            Kind is the Kubernetes resource kind of the referent. For example
-                                                            "Service".
-
-                                                            Defaults to "Service" when not specified.
-
-                                                            ExternalName services can refer to CNAME DNS records that may live
-                                                            outside of the cluster and as such are difficult to reason about in
-                                                            terms of conformance. They also may not be safe to forward to (see
-                                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                            support ExternalName Services.
-
-                                                            Support: Core (Services with a type other than ExternalName)
-
-                                                            Support: Implementation-specific (Services with type ExternalName)
+                                                          description: Kubernetes
+                                                            resource kind of the referent,
+                                                            for example `Service`.
+                                                            Defaults to `Service`
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4687,27 +3744,21 @@ spec:
                                                           minLength: 1
                                                           type: string
                                                         namespace:
-                                                          description: |-
-                                                            Namespace is the namespace of the backend. When unspecified, the local
-                                                            namespace is inferred.
-
-                                                            Note that when a namespace different than the local namespace is specified,
-                                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                                            documentation for details.
-
-                                                            Support: Core
+                                                          description: Namespace of
+                                                            the referent. Defaults
+                                                            to the local namespace.
+                                                            A cross-namespace reference
+                                                            requires a ReferenceGrant
+                                                            in the referent namespace
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                           type: string
                                                         port:
-                                                          description: |-
-                                                            Port specifies the destination port number to use for this resource.
-                                                            Port is required when the referent is a Kubernetes Service. In this
-                                                            case, the port number is the service port number, not the target port.
-                                                            For other resources, destination port might be derived from the referent
-                                                            resource or this field.
+                                                          description: Destination
+                                                            port number. Required
+                                                            when the referent is a
+                                                            Kubernetes `Service`
                                                           format: int32
                                                           maximum: 65535
                                                           minimum: 1
@@ -4742,51 +3793,31 @@ spec:
                                                           headers.
                                                         properties:
                                                           name:
-                                                            description: |-
-                                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                                              If multiple entries specify equivalent header names, only the first
-                                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                                              entries with an equivalent header name MUST be ignored. Due to the
-                                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                                              equivalent.
-
-                                                              When a header is repeated in an HTTP request, it is
-                                                              implementation-specific behavior as to how this is represented.
-                                                              Generally, proxies should follow the guidance from the RFC:
-                                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                                              processing a repeated header, with special handling for "Set-Cookie".
+                                                            description: Name of the
+                                                              HTTP header to match,
+                                                              case-insensitive. When
+                                                              names are equivalent,
+                                                              only the first matching
+                                                              entry is used
                                                             maxLength: 256
                                                             minLength: 1
                                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                                             type: string
                                                           type:
                                                             default: Exact
-                                                            description: |-
-                                                              Type specifies how to match against the value of the header.
-
-                                                              Support: Core (Exact)
-
-                                                              Support: Implementation-specific (RegularExpression)
-
-                                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                                              of regular expressions. Please read the implementation's documentation to
-                                                              determine the supported dialect.
+                                                            description: 'How to match
+                                                              against the header value:
+                                                              `Exact` (default) or
+                                                              `RegularExpression`.
+                                                              The regex dialect is
+                                                              implementation-specific'
                                                             enum:
                                                             - Exact
                                                             - RegularExpression
                                                             type: string
                                                           value:
-                                                            description: |-
-                                                              Value is the value of HTTP Header to be matched.
-                                                              <gateway:experimental:description>
-                                                              Must consist of printable US-ASCII characters, optionally separated
-                                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                                              </gateway:experimental:description>
-
-                                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                                            description: Value of
+                                                              the HTTP header to match
                                                             maxLength: 4096
                                                             minLength: 1
                                                             type: string
@@ -4795,6 +3826,17 @@ spec:
                                                         - value
                                                         type: object
                                                       type: array
+                                                    headers:
+                                                      additionalProperties:
+                                                        description: A Common Expression
+                                                          Language (CEL) expression.
+                                                        maxLength: 16384
+                                                        minLength: 1
+                                                        type: string
+                                                      description: CEL-computed headers
+                                                        to include in webhook requests.
+                                                      maxProperties: 64
+                                                      type: object
                                                   required:
                                                   - backendRef
                                                   type: object
@@ -4864,11 +3906,9 @@ spec:
                                               minLength: 1
                                               type: string
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field to set.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                           required:
                                           - expression
@@ -4887,7 +3927,7 @@ spec:
                                         >= 1'
                                   auth:
                                     description: Settings for managing authentication
-                                      to the backend.
+                                      to the backend
                                     properties:
                                       aws:
                                         description: |-
@@ -4904,29 +3944,97 @@ spec:
                                                 minLength: 1
                                                 pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                 type: string
+                                              sessionName:
+                                                description: |-
+                                                  SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                  Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                pattern: ^[\w+=,.@-]{2,64}$
+                                                type: string
+                                              sessionNameExpression:
+                                                description: |-
+                                                  SessionNameExpression is a CEL expression evaluated against each request
+                                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                                  session name at request time, the request is rejected.
+                                                maxLength: 16384
+                                                minLength: 1
+                                                type: string
+                                              tags:
+                                                description: |-
+                                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                  & Usage Report, once activated. STS allows at most 50 per role session.
+                                                items:
+                                                  description: |-
+                                                    AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                    attribution. Exactly one of value and expression must be set.
+                                                  properties:
+                                                    expression:
+                                                      description: |-
+                                                        CEL expression evaluated against each request to produce the tag value,
+                                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                        tag values are rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
+                                                    key:
+                                                      description: Key is the tag
+                                                        key.
+                                                      maxLength: 128
+                                                      minLength: 1
+                                                      type: string
+                                                    value:
+                                                      description: Value is a static
+                                                        tag value.
+                                                      maxLength: 256
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: exactly one of value
+                                                      or expression must be set
+                                                    rule: has(self.value) != has(self.expression)
+                                                maxItems: 50
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - key
+                                                x-kubernetes-list-type: map
                                             required:
                                             - roleArn
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: at most one of the fields in
+                                                [sessionName sessionNameExpression]
+                                                may be set
+                                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                <= 1'
+                                          region:
+                                            description: |-
+                                              AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                              target AWS service is in a different region than the gateway. If unset,
+                                              typed AWS backends may provide this automatically; otherwise the ambient
+                                              AWS region is used.
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
                                           secretRef:
                                             description: |-
-                                              Credential source, defaulting to a Kubernetes
-                                              `Secret`, containing the AWS credentials. When using the default Secret
-                                              resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                              optionally `sessionToken`.
+                                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                              `sessionToken` keys.
                                             properties:
                                               group:
-                                                description: |-
-                                                  The API group of the referenced credential.
-                                                  Empty selects the core API group.
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
                                                 type: string
                                               kind:
-                                                description: |-
-                                                  The kind of the referenced credential.
-                                                  Empty defaults to `Secret`.
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
                                                 type: string
                                               name:
-                                                description: The name of the referenced
-                                                  credential.
+                                                description: Name of the referenced
+                                                  credential
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
@@ -4976,24 +4084,22 @@ spec:
                                             type: object
                                           secretRef:
                                             description: |-
-                                              Credential source, defaulting to a Kubernetes
-                                              `Secret`, containing the Azure credentials. When using the default Secret
-                                              resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                              `clientSecret`.
+                                              Credential source for Azure credentials, defaulting to a Kubernetes
+                                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                              `clientSecret` keys.
                                             properties:
                                               group:
-                                                description: |-
-                                                  The API group of the referenced credential.
-                                                  Empty selects the core API group.
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
                                                 type: string
                                               kind:
-                                                description: |-
-                                                  The kind of the referenced credential.
-                                                  Empty defaults to `Secret`.
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
                                                 type: string
                                               name:
-                                                description: The name of the referenced
-                                                  credential.
+                                                description: Name of the referenced
+                                                  credential
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
@@ -5009,6 +4115,801 @@ spec:
                                                 == 0 || self.kind == ''Secret'') :
                                                 (has(self.kind) && size(self.kind)
                                                 > 0)'
+                                          workloadIdentity:
+                                            description: |-
+                                              Workload identity authentication settings. Uses the federated token and
+                                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                                              Workload Identity enabled.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: at most one of the fields in [secretRef
+                                            managedIdentity workloadIdentity] may
+                                            be set
+                                          rule: '[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size()
+                                            <= 1'
+                                      credentials:
+                                        description: |-
+                                          Credentials is a list of additional credentials to inject on the
+                                          backend request. Each entry resolves a Secret key and writes its value
+                                          to the entry's location. `credentials` is independent of the primary
+                                          `key`/`secretRef`/`passthrough` mechanism and may be set on its own or
+                                          alongside it.
+                                        items:
+                                          description: |-
+                                            BackendAuthCredential specifies one additional credential to inject on the
+                                            backend request.
+                                          properties:
+                                            location:
+                                              description: Where the credential is
+                                                inserted on the backend request.
+                                              properties:
+                                                cookie:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                header:
+                                                  properties:
+                                                    name:
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                      type: string
+                                                    prefix:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                queryParameter:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: exactly one of the fields
+                                                  in [header queryParameter cookie]
+                                                  must be set
+                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                                  == 1'
+                                            secretRef:
+                                              description: |-
+                                                SecretRef references a Kubernetes Secret holding the credential value, and
+                                                optionally overrides the key read from it. Defaults to `Authorization`,
+                                                matching the key convention used by the top-level `secretRef`.
+                                              properties:
+                                                group:
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
+                                                  type: string
+                                                name:
+                                                  description: Name of the referenced
+                                                    credential
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                              x-kubernetes-validations:
+                                              - message: custom credential refs must
+                                                  set both group and kind
+                                                rule: '(!has(self.group) || size(self.group)
+                                                  == 0) ? (!has(self.kind) || size(self.kind)
+                                                  == 0 || self.kind == ''Secret'')
+                                                  : (has(self.kind) && size(self.kind)
+                                                  > 0)'
+                                          required:
+                                          - location
+                                          - secretRef
+                                          type: object
+                                        maxItems: 8
+                                        minItems: 1
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      crossAppAccess:
+                                        description: Cross App Access (Identity Assertion
+                                          / ID-JAG) authentication.
+                                        properties:
+                                          audience:
+                                            description: Identifier of the resource
+                                              authorization server. The issued ID-JAG
+                                              is bound to this audience.
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          cache:
+                                            description: Response cache configuration.
+                                            properties:
+                                              inMemory:
+                                                properties:
+                                                  defaultTtl:
+                                                    description: TTL used when the
+                                                      token endpoint omits expires_in.
+                                                      Default 300s.
+                                                    type: string
+                                                  maxEntries:
+                                                    description: Default 8192; 0 disables
+                                                      the cache.
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                            type: object
+                                          identityProvider:
+                                            description: User identity provider authorization
+                                              server, used for the RFC 8693 ID-JAG
+                                              exchange.
+                                            properties:
+                                              backendRef:
+                                                description: Token endpoint backend.
+                                                properties:
+                                                  group:
+                                                    default: ""
+                                                    description: Group of the referent,
+                                                      for example `gateway.networking.k8s.io`.
+                                                      Empty selects the core API group
+                                                    maxLength: 253
+                                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                    type: string
+                                                  kind:
+                                                    default: Service
+                                                    description: Kubernetes resource
+                                                      kind of the referent, for example
+                                                      `Service`. Defaults to `Service`
+                                                    maxLength: 63
+                                                    minLength: 1
+                                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of the referent.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                  namespace:
+                                                    description: Namespace of the
+                                                      referent. Defaults to the local
+                                                      namespace. A cross-namespace
+                                                      reference requires a ReferenceGrant
+                                                      in the referent namespace
+                                                    maxLength: 63
+                                                    minLength: 1
+                                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                    type: string
+                                                  port:
+                                                    description: Destination port
+                                                      number. Required when the referent
+                                                      is a Kubernetes `Service`
+                                                    format: int32
+                                                    maximum: 65535
+                                                    minimum: 1
+                                                    type: integer
+                                                required:
+                                                - name
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: Must have port for Service
+                                                    reference
+                                                  rule: '(size(self.group) == 0 &&
+                                                    self.kind == ''Service'') ? has(self.port)
+                                                    : true'
+                                              clientAuth:
+                                                description: Client authentication
+                                                  for the token endpoint.
+                                                properties:
+                                                  clientId:
+                                                    description: Client ID sent to
+                                                      the token endpoint.
+                                                    minLength: 1
+                                                    type: string
+                                                  method:
+                                                    description: Client authentication
+                                                      method. Defaults to ClientSecretBasic.
+                                                    enum:
+                                                    - ClientSecretBasic
+                                                    - ClientSecretPost
+                                                    - PrivateKeyJwt
+                                                    type: string
+                                                  privateKeyJwt:
+                                                    description: Client assertion
+                                                      settings. Required when method
+                                                      is PrivateKeyJwt.
+                                                    properties:
+                                                      alg:
+                                                        description: JWS signing algorithm.
+                                                          Defaults to RS256.
+                                                        enum:
+                                                        - ES256
+                                                        - ES384
+                                                        - PS256
+                                                        - RS256
+                                                        - RS384
+                                                        - RS512
+                                                        type: string
+                                                      assertionAudience:
+                                                        description: Audience for
+                                                          the client assertion, typically
+                                                          the token endpoint URL.
+                                                        minLength: 1
+                                                        type: string
+                                                      certificateHeader:
+                                                        description: JWS certificate
+                                                          header. Required when certificateRef
+                                                          is set.
+                                                        enum:
+                                                        - x5c
+                                                        - x5t#S256
+                                                        type: string
+                                                      certificateRef:
+                                                        description: |-
+                                                          PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                                          leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                                          but the token endpoint will reject the assertions. Required when
+                                                          certificateHeader is set. The key defaults to `certificate`.
+                                                        properties:
+                                                          group:
+                                                            description: API group
+                                                              of the referenced credential;
+                                                              empty selects the core
+                                                              API group
+                                                            type: string
+                                                          key:
+                                                            description: Key in the
+                                                              referenced Secret. If
+                                                              omitted, a location-specific
+                                                              default is used
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                          kind:
+                                                            description: Kind of the
+                                                              referenced credential;
+                                                              empty defaults to `Secret`
+                                                            type: string
+                                                          name:
+                                                            description: Name of the
+                                                              referenced credential
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                        x-kubernetes-validations:
+                                                        - message: custom credential
+                                                            refs must set both group
+                                                            and kind
+                                                          rule: '(!has(self.group)
+                                                            || size(self.group) ==
+                                                            0) ? (!has(self.kind)
+                                                            || size(self.kind) ==
+                                                            0 || self.kind == ''Secret'')
+                                                            : (has(self.kind) && size(self.kind)
+                                                            > 0)'
+                                                      kid:
+                                                        description: Optional JWS
+                                                          key ID header.
+                                                        type: string
+                                                      signingKeyRef:
+                                                        description: PEM-encoded RSA
+                                                          or EC private key; key defaults
+                                                          to `signingKey`.
+                                                        properties:
+                                                          group:
+                                                            description: API group
+                                                              of the referenced credential;
+                                                              empty selects the core
+                                                              API group
+                                                            type: string
+                                                          key:
+                                                            description: Key in the
+                                                              referenced Secret. If
+                                                              omitted, a location-specific
+                                                              default is used
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                          kind:
+                                                            description: Kind of the
+                                                              referenced credential;
+                                                              empty defaults to `Secret`
+                                                            type: string
+                                                          name:
+                                                            description: Name of the
+                                                              referenced credential
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                        x-kubernetes-validations:
+                                                        - message: custom credential
+                                                            refs must set both group
+                                                            and kind
+                                                          rule: '(!has(self.group)
+                                                            || size(self.group) ==
+                                                            0) ? (!has(self.kind)
+                                                            || size(self.kind) ==
+                                                            0 || self.kind == ''Secret'')
+                                                            : (has(self.kind) && size(self.kind)
+                                                            > 0)'
+                                                    required:
+                                                    - assertionAudience
+                                                    - signingKeyRef
+                                                    type: object
+                                                    x-kubernetes-validations:
+                                                    - message: certificateRef and
+                                                        certificateHeader must be
+                                                        set together
+                                                      rule: has(self.certificateRef)
+                                                        == has(self.certificateHeader)
+                                                  secretRef:
+                                                    description: |-
+                                                      Secret providing the `clientSecret` key by default; override via
+                                                      `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                                      is only valid with ClientSecretPost.
+                                                    properties:
+                                                      group:
+                                                        description: API group of
+                                                          the referenced credential;
+                                                          empty selects the core API
+                                                          group
+                                                        type: string
+                                                      key:
+                                                        description: Key in the referenced
+                                                          Secret. If omitted, a location-specific
+                                                          default is used
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                      kind:
+                                                        description: Kind of the referenced
+                                                          credential; empty defaults
+                                                          to `Secret`
+                                                        type: string
+                                                      name:
+                                                        description: Name of the referenced
+                                                          credential
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                    x-kubernetes-validations:
+                                                    - message: custom credential refs
+                                                        must set both group and kind
+                                                      rule: '(!has(self.group) ||
+                                                        size(self.group) == 0) ? (!has(self.kind)
+                                                        || size(self.kind) == 0 ||
+                                                        self.kind == ''Secret'') :
+                                                        (has(self.kind) && size(self.kind)
+                                                        > 0)'
+                                                required:
+                                                - clientId
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: privateKeyJwt settings
+                                                    require method PrivateKeyJwt
+                                                  rule: has(self.privateKeyJwt) ==
+                                                    (has(self.method) && self.method
+                                                    == 'PrivateKeyJwt')
+                                                - message: secretRef is not valid
+                                                    with method PrivateKeyJwt
+                                                  rule: '!has(self.secretRef) || !has(self.method)
+                                                    || self.method != ''PrivateKeyJwt'''
+                                                - message: clientAuth without secretRef
+                                                    requires method ClientSecretPost
+                                                    or PrivateKeyJwt
+                                                  rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                                    || (has(self.method) && self.method
+                                                    == 'ClientSecretPost')
+                                              path:
+                                                description: Token endpoint path;
+                                                  defaults to "/". Must start with
+                                                  "/".
+                                                pattern: ^/
+                                                type: string
+                                            required:
+                                            - backendRef
+                                            - clientAuth
+                                            type: object
+                                          resourceAuthorizationServer:
+                                            description: Resource authorization server,
+                                              used for the RFC 7523 jwt-bearer exchange.
+                                            properties:
+                                              backendRef:
+                                                description: Token endpoint backend.
+                                                properties:
+                                                  group:
+                                                    default: ""
+                                                    description: Group of the referent,
+                                                      for example `gateway.networking.k8s.io`.
+                                                      Empty selects the core API group
+                                                    maxLength: 253
+                                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                    type: string
+                                                  kind:
+                                                    default: Service
+                                                    description: Kubernetes resource
+                                                      kind of the referent, for example
+                                                      `Service`. Defaults to `Service`
+                                                    maxLength: 63
+                                                    minLength: 1
+                                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of the referent.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                  namespace:
+                                                    description: Namespace of the
+                                                      referent. Defaults to the local
+                                                      namespace. A cross-namespace
+                                                      reference requires a ReferenceGrant
+                                                      in the referent namespace
+                                                    maxLength: 63
+                                                    minLength: 1
+                                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                    type: string
+                                                  port:
+                                                    description: Destination port
+                                                      number. Required when the referent
+                                                      is a Kubernetes `Service`
+                                                    format: int32
+                                                    maximum: 65535
+                                                    minimum: 1
+                                                    type: integer
+                                                required:
+                                                - name
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: Must have port for Service
+                                                    reference
+                                                  rule: '(size(self.group) == 0 &&
+                                                    self.kind == ''Service'') ? has(self.port)
+                                                    : true'
+                                              clientAuth:
+                                                description: Client authentication
+                                                  for the token endpoint.
+                                                properties:
+                                                  clientId:
+                                                    description: Client ID sent to
+                                                      the token endpoint.
+                                                    minLength: 1
+                                                    type: string
+                                                  method:
+                                                    description: Client authentication
+                                                      method. Defaults to ClientSecretBasic.
+                                                    enum:
+                                                    - ClientSecretBasic
+                                                    - ClientSecretPost
+                                                    - PrivateKeyJwt
+                                                    type: string
+                                                  privateKeyJwt:
+                                                    description: Client assertion
+                                                      settings. Required when method
+                                                      is PrivateKeyJwt.
+                                                    properties:
+                                                      alg:
+                                                        description: JWS signing algorithm.
+                                                          Defaults to RS256.
+                                                        enum:
+                                                        - ES256
+                                                        - ES384
+                                                        - PS256
+                                                        - RS256
+                                                        - RS384
+                                                        - RS512
+                                                        type: string
+                                                      assertionAudience:
+                                                        description: Audience for
+                                                          the client assertion, typically
+                                                          the token endpoint URL.
+                                                        minLength: 1
+                                                        type: string
+                                                      certificateHeader:
+                                                        description: JWS certificate
+                                                          header. Required when certificateRef
+                                                          is set.
+                                                        enum:
+                                                        - x5c
+                                                        - x5t#S256
+                                                        type: string
+                                                      certificateRef:
+                                                        description: |-
+                                                          PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                                          leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                                          but the token endpoint will reject the assertions. Required when
+                                                          certificateHeader is set. The key defaults to `certificate`.
+                                                        properties:
+                                                          group:
+                                                            description: API group
+                                                              of the referenced credential;
+                                                              empty selects the core
+                                                              API group
+                                                            type: string
+                                                          key:
+                                                            description: Key in the
+                                                              referenced Secret. If
+                                                              omitted, a location-specific
+                                                              default is used
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                          kind:
+                                                            description: Kind of the
+                                                              referenced credential;
+                                                              empty defaults to `Secret`
+                                                            type: string
+                                                          name:
+                                                            description: Name of the
+                                                              referenced credential
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                        x-kubernetes-validations:
+                                                        - message: custom credential
+                                                            refs must set both group
+                                                            and kind
+                                                          rule: '(!has(self.group)
+                                                            || size(self.group) ==
+                                                            0) ? (!has(self.kind)
+                                                            || size(self.kind) ==
+                                                            0 || self.kind == ''Secret'')
+                                                            : (has(self.kind) && size(self.kind)
+                                                            > 0)'
+                                                      kid:
+                                                        description: Optional JWS
+                                                          key ID header.
+                                                        type: string
+                                                      signingKeyRef:
+                                                        description: PEM-encoded RSA
+                                                          or EC private key; key defaults
+                                                          to `signingKey`.
+                                                        properties:
+                                                          group:
+                                                            description: API group
+                                                              of the referenced credential;
+                                                              empty selects the core
+                                                              API group
+                                                            type: string
+                                                          key:
+                                                            description: Key in the
+                                                              referenced Secret. If
+                                                              omitted, a location-specific
+                                                              default is used
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                          kind:
+                                                            description: Kind of the
+                                                              referenced credential;
+                                                              empty defaults to `Secret`
+                                                            type: string
+                                                          name:
+                                                            description: Name of the
+                                                              referenced credential
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                        x-kubernetes-validations:
+                                                        - message: custom credential
+                                                            refs must set both group
+                                                            and kind
+                                                          rule: '(!has(self.group)
+                                                            || size(self.group) ==
+                                                            0) ? (!has(self.kind)
+                                                            || size(self.kind) ==
+                                                            0 || self.kind == ''Secret'')
+                                                            : (has(self.kind) && size(self.kind)
+                                                            > 0)'
+                                                    required:
+                                                    - assertionAudience
+                                                    - signingKeyRef
+                                                    type: object
+                                                    x-kubernetes-validations:
+                                                    - message: certificateRef and
+                                                        certificateHeader must be
+                                                        set together
+                                                      rule: has(self.certificateRef)
+                                                        == has(self.certificateHeader)
+                                                  secretRef:
+                                                    description: |-
+                                                      Secret providing the `clientSecret` key by default; override via
+                                                      `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                                      is only valid with ClientSecretPost.
+                                                    properties:
+                                                      group:
+                                                        description: API group of
+                                                          the referenced credential;
+                                                          empty selects the core API
+                                                          group
+                                                        type: string
+                                                      key:
+                                                        description: Key in the referenced
+                                                          Secret. If omitted, a location-specific
+                                                          default is used
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                      kind:
+                                                        description: Kind of the referenced
+                                                          credential; empty defaults
+                                                          to `Secret`
+                                                        type: string
+                                                      name:
+                                                        description: Name of the referenced
+                                                          credential
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                    x-kubernetes-validations:
+                                                    - message: custom credential refs
+                                                        must set both group and kind
+                                                      rule: '(!has(self.group) ||
+                                                        size(self.group) == 0) ? (!has(self.kind)
+                                                        || size(self.kind) == 0 ||
+                                                        self.kind == ''Secret'') :
+                                                        (has(self.kind) && size(self.kind)
+                                                        > 0)'
+                                                required:
+                                                - clientId
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: privateKeyJwt settings
+                                                    require method PrivateKeyJwt
+                                                  rule: has(self.privateKeyJwt) ==
+                                                    (has(self.method) && self.method
+                                                    == 'PrivateKeyJwt')
+                                                - message: secretRef is not valid
+                                                    with method PrivateKeyJwt
+                                                  rule: '!has(self.secretRef) || !has(self.method)
+                                                    || self.method != ''PrivateKeyJwt'''
+                                                - message: clientAuth without secretRef
+                                                    requires method ClientSecretPost
+                                                    or PrivateKeyJwt
+                                                  rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                                    || (has(self.method) && self.method
+                                                    == 'ClientSecretPost')
+                                              path:
+                                                description: Token endpoint path;
+                                                  defaults to "/". Must start with
+                                                  "/".
+                                                pattern: ^/
+                                                type: string
+                                            required:
+                                            - backendRef
+                                            - clientAuth
+                                            type: object
+                                          resources:
+                                            description: Resources sent to the token
+                                              endpoint.
+                                            items:
+                                              type: string
+                                            maxItems: 64
+                                            minItems: 1
+                                            type: array
+                                          scopes:
+                                            description: Scopes sent to the token
+                                              endpoint.
+                                            items:
+                                              type: string
+                                            maxItems: 64
+                                            minItems: 1
+                                            type: array
+                                          subjectToken:
+                                            description: |-
+                                              Subject token sent to the identity provider. Defaults to an OpenID Connect
+                                              ID token read from the Authorization Bearer header.
+                                            properties:
+                                              source:
+                                                description: Where to read the subject
+                                                  token. Defaults to the Authorization
+                                                  Bearer header.
+                                                properties:
+                                                  cookie:
+                                                    properties:
+                                                      name:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  expression:
+                                                    description: CEL expression that
+                                                      extracts the credential from
+                                                      the request.
+                                                    maxLength: 16384
+                                                    minLength: 1
+                                                    type: string
+                                                  header:
+                                                    properties:
+                                                      name:
+                                                        description: Name of an HTTP
+                                                          header. HTTP/2 pseudo-headers
+                                                          (names beginning with `:`)
+                                                          are not supported
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      prefix:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  queryParameter:
+                                                    properties:
+                                                      name:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: exactly one of the fields
+                                                    in [header queryParameter cookie
+                                                    expression] must be set
+                                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                                    == 1'
+                                            type: object
+                                        required:
+                                        - audience
+                                        - identityProvider
+                                        - resourceAuthorizationServer
                                         type: object
                                       gcp:
                                         description: |-
@@ -5025,24 +4926,30 @@ spec:
                                             type: string
                                           secretRef:
                                             description: |-
-                                              Credential source, defaulting to a Kubernetes
-                                              `Secret`, containing ADC-compatible Google credential JSON. When using
-                                              the default Secret resolver, this must be stored in the `credentials.json`
-                                              key. When omitted, ambient credentials are used.
+                                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                                              a Kubernetes `Secret`. By default, the value is read from
+                                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                              ambient credentials are used.
                                             properties:
                                               group:
-                                                description: |-
-                                                  The API group of the referenced credential.
-                                                  Empty selects the core API group.
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              key:
+                                                description: Key in the referenced
+                                                  Secret. If omitted, a location-specific
+                                                  default is used
+                                                maxLength: 253
+                                                minLength: 1
                                                 type: string
                                               kind:
-                                                description: |-
-                                                  The kind of the referenced credential.
-                                                  Empty defaults to `Secret`.
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
                                                 type: string
                                               name:
-                                                description: The name of the referenced
-                                                  credential.
+                                                description: Name of the referenced
+                                                  credential
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
@@ -5083,7 +4990,7 @@ spec:
                                         description: |-
                                           Where backend credentials are inserted.
                                           If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                          This applies to `key`, `secretRef`, and `passthrough`.
+                                          This applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.
                                         properties:
                                           cookie:
                                             properties:
@@ -5097,19 +5004,9 @@ spec:
                                           header:
                                             properties:
                                               name:
-                                                description: |-
-                                                  HTTPHeaderName is the name of an HTTP header.
-
-                                                  Valid values include:
-
-                                                  * "Authorization"
-                                                  * "Set-Cookie"
-
-                                                  Invalid values include:
-
-                                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                      headers are not currently supported by this type.
-                                                    - "/invalid" - "/ " is an invalid character
+                                                description: Name of an HTTP header.
+                                                  HTTP/2 pseudo-headers (names beginning
+                                                  with `:`) are not supported
                                                 maxLength: 256
                                                 minLength: 1
                                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -5136,34 +5033,587 @@ spec:
                                             queryParameter cookie] must be set
                                           rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                             == 1'
+                                      oauthTokenExchange:
+                                        description: OAuth 2.0 token exchange (RFC
+                                          8693) / jwt-bearer (RFC 7523) authentication.
+                                        properties:
+                                          actorToken:
+                                            description: RFC 8693 delegation actor
+                                              token. TokenExchange grant only.
+                                            properties:
+                                              mayAct:
+                                                description: may_act claim validation
+                                                  mode. When omitted, may_act is not
+                                                  enforced.
+                                                enum:
+                                                - Required
+                                                type: string
+                                              source:
+                                                description: Where to read the actor
+                                                  token. Actor tokens have no default
+                                                  source.
+                                                properties:
+                                                  cookie:
+                                                    properties:
+                                                      name:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  expression:
+                                                    description: CEL expression that
+                                                      extracts the credential from
+                                                      the request.
+                                                    maxLength: 16384
+                                                    minLength: 1
+                                                    type: string
+                                                  header:
+                                                    properties:
+                                                      name:
+                                                        description: Name of an HTTP
+                                                          header. HTTP/2 pseudo-headers
+                                                          (names beginning with `:`)
+                                                          are not supported
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      prefix:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  queryParameter:
+                                                    properties:
+                                                      name:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: exactly one of the fields
+                                                    in [header queryParameter cookie
+                                                    expression] must be set
+                                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                                    == 1'
+                                              tokenType:
+                                                description: |-
+                                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                  are supported for actor tokens.
+                                                type: string
+                                            required:
+                                            - source
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: mayAct Required requires tokenType
+                                                Jwt
+                                              rule: '!has(self.mayAct) || self.mayAct
+                                                != ''Required'' || (has(self.tokenType)
+                                                && self.tokenType == ''Jwt'')'
+                                          additionalParams:
+                                            additionalProperties:
+                                              description: A Common Expression Language
+                                                (CEL) expression.
+                                              maxLength: 16384
+                                              minLength: 1
+                                              type: string
+                                            description: Extra form params; values
+                                              are CEL expressions over the incoming
+                                              request.
+                                            maxProperties: 64
+                                            type: object
+                                          audiences:
+                                            description: Audiences sent to the token
+                                              endpoint.
+                                            items:
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                            maxItems: 64
+                                            minItems: 1
+                                            type: array
+                                          backendRef:
+                                            description: RFC 8693 token endpoint backend.
+                                            properties:
+                                              group:
+                                                default: ""
+                                                description: Group of the referent,
+                                                  for example `gateway.networking.k8s.io`.
+                                                  Empty selects the core API group
+                                                maxLength: 253
+                                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                type: string
+                                              kind:
+                                                default: Service
+                                                description: Kubernetes resource kind
+                                                  of the referent, for example `Service`.
+                                                  Defaults to `Service`
+                                                maxLength: 63
+                                                minLength: 1
+                                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                type: string
+                                              name:
+                                                description: Name is the name of the
+                                                  referent.
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                              namespace:
+                                                description: Namespace of the referent.
+                                                  Defaults to the local namespace.
+                                                  A cross-namespace reference requires
+                                                  a ReferenceGrant in the referent
+                                                  namespace
+                                                maxLength: 63
+                                                minLength: 1
+                                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                type: string
+                                              port:
+                                                description: Destination port number.
+                                                  Required when the referent is a
+                                                  Kubernetes `Service`
+                                                format: int32
+                                                maximum: 65535
+                                                minimum: 1
+                                                type: integer
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: Must have port for Service
+                                                reference
+                                              rule: '(size(self.group) == 0 && self.kind
+                                                == ''Service'') ? has(self.port) :
+                                                true'
+                                          cache:
+                                            description: Response cache configuration.
+                                            properties:
+                                              inMemory:
+                                                properties:
+                                                  defaultTtl:
+                                                    description: TTL used when the
+                                                      token endpoint omits expires_in.
+                                                      Default 300s.
+                                                    type: string
+                                                  maxEntries:
+                                                    description: Default 8192; 0 disables
+                                                      the cache.
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                            type: object
+                                          clientAuth:
+                                            description: Client authentication for
+                                              the token endpoint. When unset, none
+                                              is sent.
+                                            properties:
+                                              clientId:
+                                                description: Client ID sent to the
+                                                  token endpoint.
+                                                minLength: 1
+                                                type: string
+                                              method:
+                                                description: Client authentication
+                                                  method. Defaults to ClientSecretBasic.
+                                                enum:
+                                                - ClientSecretBasic
+                                                - ClientSecretPost
+                                                - PrivateKeyJwt
+                                                type: string
+                                              privateKeyJwt:
+                                                description: Client assertion settings.
+                                                  Required when method is PrivateKeyJwt.
+                                                properties:
+                                                  alg:
+                                                    description: JWS signing algorithm.
+                                                      Defaults to RS256.
+                                                    enum:
+                                                    - ES256
+                                                    - ES384
+                                                    - PS256
+                                                    - RS256
+                                                    - RS384
+                                                    - RS512
+                                                    type: string
+                                                  assertionAudience:
+                                                    description: Audience for the
+                                                      client assertion, typically
+                                                      the token endpoint URL.
+                                                    minLength: 1
+                                                    type: string
+                                                  certificateHeader:
+                                                    description: JWS certificate header.
+                                                      Required when certificateRef
+                                                      is set.
+                                                    enum:
+                                                    - x5c
+                                                    - x5t#S256
+                                                    type: string
+                                                  certificateRef:
+                                                    description: |-
+                                                      PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                                      leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                                      but the token endpoint will reject the assertions. Required when
+                                                      certificateHeader is set. The key defaults to `certificate`.
+                                                    properties:
+                                                      group:
+                                                        description: API group of
+                                                          the referenced credential;
+                                                          empty selects the core API
+                                                          group
+                                                        type: string
+                                                      key:
+                                                        description: Key in the referenced
+                                                          Secret. If omitted, a location-specific
+                                                          default is used
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                      kind:
+                                                        description: Kind of the referenced
+                                                          credential; empty defaults
+                                                          to `Secret`
+                                                        type: string
+                                                      name:
+                                                        description: Name of the referenced
+                                                          credential
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                    x-kubernetes-validations:
+                                                    - message: custom credential refs
+                                                        must set both group and kind
+                                                      rule: '(!has(self.group) ||
+                                                        size(self.group) == 0) ? (!has(self.kind)
+                                                        || size(self.kind) == 0 ||
+                                                        self.kind == ''Secret'') :
+                                                        (has(self.kind) && size(self.kind)
+                                                        > 0)'
+                                                  kid:
+                                                    description: Optional JWS key
+                                                      ID header.
+                                                    type: string
+                                                  signingKeyRef:
+                                                    description: PEM-encoded RSA or
+                                                      EC private key; key defaults
+                                                      to `signingKey`.
+                                                    properties:
+                                                      group:
+                                                        description: API group of
+                                                          the referenced credential;
+                                                          empty selects the core API
+                                                          group
+                                                        type: string
+                                                      key:
+                                                        description: Key in the referenced
+                                                          Secret. If omitted, a location-specific
+                                                          default is used
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                      kind:
+                                                        description: Kind of the referenced
+                                                          credential; empty defaults
+                                                          to `Secret`
+                                                        type: string
+                                                      name:
+                                                        description: Name of the referenced
+                                                          credential
+                                                        maxLength: 253
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                    x-kubernetes-validations:
+                                                    - message: custom credential refs
+                                                        must set both group and kind
+                                                      rule: '(!has(self.group) ||
+                                                        size(self.group) == 0) ? (!has(self.kind)
+                                                        || size(self.kind) == 0 ||
+                                                        self.kind == ''Secret'') :
+                                                        (has(self.kind) && size(self.kind)
+                                                        > 0)'
+                                                required:
+                                                - assertionAudience
+                                                - signingKeyRef
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: certificateRef and certificateHeader
+                                                    must be set together
+                                                  rule: has(self.certificateRef) ==
+                                                    has(self.certificateHeader)
+                                              secretRef:
+                                                description: |-
+                                                  Secret providing the `clientSecret` key by default; override via
+                                                  `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                                  is only valid with ClientSecretPost.
+                                                properties:
+                                                  group:
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
+                                                    type: string
+                                                  key:
+                                                    description: Key in the referenced
+                                                      Secret. If omitted, a location-specific
+                                                      default is used
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                  kind:
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
+                                                    type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      credential
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                                x-kubernetes-validations:
+                                                - message: custom credential refs
+                                                    must set both group and kind
+                                                  rule: '(!has(self.group) || size(self.group)
+                                                    == 0) ? (!has(self.kind) || size(self.kind)
+                                                    == 0 || self.kind == ''Secret'')
+                                                    : (has(self.kind) && size(self.kind)
+                                                    > 0)'
+                                            required:
+                                            - clientId
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: privateKeyJwt settings require
+                                                method PrivateKeyJwt
+                                              rule: has(self.privateKeyJwt) == (has(self.method)
+                                                && self.method == 'PrivateKeyJwt')
+                                            - message: secretRef is not valid with
+                                                method PrivateKeyJwt
+                                              rule: '!has(self.secretRef) || !has(self.method)
+                                                || self.method != ''PrivateKeyJwt'''
+                                            - message: clientAuth without secretRef
+                                                requires method ClientSecretPost or
+                                                PrivateKeyJwt
+                                              rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                                || (has(self.method) && self.method
+                                                == 'ClientSecretPost')
+                                          grantType:
+                                            description: RFC followed by the request.
+                                              Defaults to TokenExchange (RFC 8693).
+                                            enum:
+                                            - JwtBearer
+                                            - TokenExchange
+                                            type: string
+                                          location:
+                                            description: |-
+                                              Where the exchanged token is written to the backend request.
+                                              Defaults to Authorization: Bearer.
+                                            properties:
+                                              cookie:
+                                                properties:
+                                                  name:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              header:
+                                                properties:
+                                                  name:
+                                                    description: Name of an HTTP header.
+                                                      HTTP/2 pseudo-headers (names
+                                                      beginning with `:`) are not
+                                                      supported
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                    type: string
+                                                  prefix:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              queryParameter:
+                                                properties:
+                                                  name:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: exactly one of the fields in
+                                                [header queryParameter cookie] must
+                                                be set
+                                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                                == 1'
+                                          path:
+                                            description: Token endpoint path; defaults
+                                              to "/". Must start with "/".
+                                            pattern: ^/
+                                            type: string
+                                          requestedTokenType:
+                                            description: |-
+                                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                              built-in values may be requested; custom URIs are not supported here.
+                                            enum:
+                                            - AccessToken
+                                            - Jwt
+                                            - IdToken
+                                            - IdJag
+                                            type: string
+                                          resources:
+                                            description: Resources sent to the token
+                                              endpoint.
+                                            items:
+                                              type: string
+                                            maxItems: 64
+                                            minItems: 1
+                                            type: array
+                                          scopes:
+                                            description: Scopes sent to the token
+                                              endpoint.
+                                            items:
+                                              type: string
+                                            maxItems: 64
+                                            minItems: 1
+                                            type: array
+                                          subjectToken:
+                                            description: |-
+                                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                              The token type may be a built-in value or a custom absolute URI for providers
+                                              that support custom token exchange profiles.
+                                            properties:
+                                              source:
+                                                description: Where to read the token.
+                                                  CEL `expression` variant is permitted.
+                                                properties:
+                                                  cookie:
+                                                    properties:
+                                                      name:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  expression:
+                                                    description: CEL expression that
+                                                      extracts the credential from
+                                                      the request.
+                                                    maxLength: 16384
+                                                    minLength: 1
+                                                    type: string
+                                                  header:
+                                                    properties:
+                                                      name:
+                                                        description: Name of an HTTP
+                                                          header. HTTP/2 pseudo-headers
+                                                          (names beginning with `:`)
+                                                          are not supported
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      prefix:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  queryParameter:
+                                                    properties:
+                                                      name:
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: exactly one of the fields
+                                                    in [header queryParameter cookie
+                                                    expression] must be set
+                                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                                    == 1'
+                                              tokenType:
+                                                description: |-
+                                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                  are supported for subject tokens.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - backendRef
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: actorToken is only valid with TokenExchange
+                                            grantType
+                                          rule: '!(has(self.actorToken) && has(self.grantType)
+                                            && self.grantType == ''JwtBearer'')'
+                                        - message: requestedTokenType is only valid
+                                            with TokenExchange grantType
+                                          rule: '!(has(self.requestedTokenType) &&
+                                            has(self.grantType) && self.grantType
+                                            == ''JwtBearer'')'
+                                        - message: requestedTokenType IdJag is only
+                                            supported by crossAppAccess
+                                          rule: '!has(self.requestedTokenType) ||
+                                            self.requestedTokenType != ''IdJag'''
                                       passthrough:
                                         description: |-
-                                          Passes through an existing token that has been sent by the
-                                          client and validated. Other policies, like JWT and API key
-                                          authentication, will strip the original client credentials. Passthrough backend authentication
-                                          causes the original token to be added back into the request. If there are no client authentication policies on the
-                                          request, the original token would be unchanged, so this would have no effect.
+                                          Reuses a client token already validated by another policy. Those policies
+                                          may strip client credentials; passthrough adds the original token back to
+                                          the backend request. Without client auth policies, this has no effect.
                                         type: object
                                       secretRef:
                                         description: |-
-                                          Credential source, defaulting to a Kubernetes
-                                          `Secret`, storing the key to use as the authorization value. When using
-                                          the default Secret resolver, this must be stored in the `Authorization`
-                                          key.
+                                          Credential source for the authorization value, defaulting to a Kubernetes
+                                          `Secret`. By default, the value is read from the `Authorization` key; set
+                                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                          the default `Authorization` key.
                                         properties:
                                           group:
-                                            description: |-
-                                              The API group of the referenced credential.
-                                              Empty selects the core API group.
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
                                             type: string
                                           kind:
-                                            description: |-
-                                              The kind of the referenced credential.
-                                              Empty defaults to `Secret`.
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
                                             type: string
                                           name:
-                                            description: The name of the referenced
-                                              credential.
+                                            description: Name of the referenced credential
                                             maxLength: 253
                                             minLength: 1
                                             type: string
@@ -5180,15 +5630,24 @@ spec:
                                             && size(self.kind) > 0)'
                                     type: object
                                     x-kubernetes-validations:
-                                    - message: location may only be set for key or
-                                        passthrough auth
+                                    - message: must specify credentials, or at most
+                                        one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                                        (credentials may be combined with a primary
+                                        auth kind)
+                                      rule: has(self.credentials) || has(self.key)
+                                        || has(self.secretRef) || has(self.passthrough)
+                                        || has(self.aws) || has(self.azure) || has(self.gcp)
+                                        || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                                    - message: location may only be set for key, secretRef,
+                                        or passthrough auth
                                       rule: 'has(self.location) ? has(self.key) ||
                                         has(self.secretRef) || has(self.passthrough)
                                         : true'
-                                    - message: exactly one of the fields in [key secretRef
-                                        passthrough aws azure gcp] must be set
-                                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
-                                        == 1'
+                                    - message: at most one of the fields in [key secretRef
+                                        passthrough aws azure gcp oauthTokenExchange
+                                        crossAppAccess] may be set
+                                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                                        <= 1'
                                   health:
                                     description: Settings for passive and active health
                                       checking.
@@ -5214,6 +5673,7 @@ spec:
                                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                                               rather than failing entirely.
                                               If unset, defaults to `3s`.
+                                            maxLength: 32
                                             type: string
                                             x-kubernetes-validations:
                                             - message: invalid duration value
@@ -5223,13 +5683,12 @@ spec:
                                               rule: duration(self) >= duration('1s')
                                           healthThreshold:
                                             description: |-
-                                              EWMA health score threshold, expressed as 0 to 100.
-                                              When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-                                              For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-                                              Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-                                              so a single success in a stream of failures can delay eviction.
-                                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-                                              When neither is set, a single unhealthy response triggers eviction.
+                                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                                              only if its computed health drops below this value after an unhealthy
+                                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                                              consecutiveFailures, this sliding-window average lets a single success delay
+                                              eviction. If both are set, either condition evicts; if neither, a single
+                                              unhealthy response evicts.
                                             format: int32
                                             maximum: 100
                                             minimum: 0
@@ -5259,11 +5718,12 @@ spec:
                                     type: object
                                   http:
                                     description: Settings for managing HTTP requests
-                                      to the backend.
+                                      to the backend
                                     properties:
                                       requestTimeout:
                                         description: Deadline for receiving a response
                                           from the backend.
+                                        maxLength: 32
                                         type: string
                                         x-kubernetes-validations:
                                         - message: invalid duration value
@@ -5273,17 +5733,10 @@ spec:
                                           rule: duration(self) >= duration('1ms')
                                       version:
                                         description: |-
-                                          HTTP protocol version to use when connecting to
-                                          the backend.
-                                          If not specified, the version is automatically determined:
-                                          * `Service` types can specify it with `appProtocol` on the `Service`
-                                            port.
-                                          * If traffic is identified as gRPC, `HTTP2` is used.
-                                          * If the incoming traffic was plaintext HTTP, the original protocol will
-                                            be used.
-                                          * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                            because most clients will transparently upgrade HTTPS traffic to
-                                            `HTTP2`, even if the backend doesn't support it.
+                                          HTTP protocol version for backend connections. If unset, it is inferred:
+                                          `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                          plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                          to HTTP/2 even when the backend does not support it.
                                         enum:
                                         - HTTP1
                                         - HTTP2
@@ -5291,12 +5744,13 @@ spec:
                                     type: object
                                   tcp:
                                     description: Settings for managing TCP connections
-                                      to the backend.
+                                      to the backend
                                     properties:
                                       connectTimeout:
                                         description: |-
                                           Deadline for establishing a connection to
                                           the destination.
+                                        maxLength: 32
                                         type: string
                                         x-kubernetes-validations:
                                         - message: invalid duration value
@@ -5313,6 +5767,7 @@ spec:
                                             description: |-
                                               Time between keepalive probes.
                                               If unset, this defaults to 180s.
+                                            maxLength: 32
                                             type: string
                                             x-kubernetes-validations:
                                             - message: invalid duration value
@@ -5332,6 +5787,7 @@ spec:
                                             description: |-
                                               Time a connection needs to be idle before keepalive probes start being sent.
                                               If unset, this defaults to 180s.
+                                            maxLength: 32
                                             type: string
                                             x-kubernetes-validations:
                                             - message: invalid duration value
@@ -5342,10 +5798,10 @@ spec:
                                     type: object
                                   tls:
                                     description: |-
-                                      Settings for managing TLS connections to the backend.
+                                      Settings for managing TLS connections to the backend
 
-                                      If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                      validate the server, and the SNI will automatically be set based on the destination.
+                                      When set, TLS is originated to the backend using the system trusted CA
+                                      certificates, and SNI is inferred from the destination.
                                     properties:
                                       alpnProtocols:
                                         description: |-
@@ -5372,12 +5828,7 @@ spec:
                                           properties:
                                             name:
                                               default: ""
-                                              description: |-
-                                                Name of the referent.
-                                                This field is effectively required, but due to backwards compatibility is
-                                                allowed to be empty. Instances of this type with an empty value here are
-                                                almost certainly wrong.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              description: Name of the referent
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -5386,15 +5837,13 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       insecureSkipVerify:
                                         description: |-
-                                          Originates TLS but skips verification of the backend's certificate.
-                                          WARNING: This is an insecure option that should only be used if the risks are understood.
+                                          Originates TLS but skips verification of the backend's certificate
+                                          WARNING: insecure; only use if the risks are understood
 
-                                          There are two modes:
-                                          * `All` disables all TLS verification.
-                                          * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                            mismatch of hostname or SANs. Note that this method is still insecure;
-                                            prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                            if possible.
+                                          Modes:
+                                          * `All` disables all TLS verification
+                                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                            Still insecure; prefer `verifySubjectAltNames` where possible.
                                         enum:
                                         - All
                                         - Hostname
@@ -5413,33 +5862,28 @@ spec:
                                         type: array
                                       mtlsCertificateRef:
                                         description: |-
-                                          Enables mutual TLS to the backend, using the
-                                          specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                          credential source, defaulting to a Kubernetes `Secret`.
-
-                                          An optional `ca.cert` field, if present, will be used to verify the
-                                          server certificate. If `caCertificateRefs` is also specified, the
-                                          `caCertificateRefs` field takes priority.
-
-                                          If unspecified, no client certificate will be used.
+                                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                          optional `ca.cert`, if present, verifies the server certificate, but
+                                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                          is used.
                                         items:
                                           description: |-
-                                            References a same-namespace credential.
-                                            Set only `name` to reference a Kubernetes Secret.
+                                            References a same-namespace credential
+                                            Set only `name` for a Kubernetes Secret
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -5754,8 +6198,8 @@ spec:
                                       rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
                                         >= 1'
                                   tunnel:
-                                    description: Settings for managing tunnel connections,
-                                      with behavior like `HTTPS_PROXY`, to the backend.
+                                    description: Settings for managing tunnel connections
+                                      to the backend, like `HTTPS_PROXY`
                                     properties:
                                       backendRef:
                                         description: |-
@@ -5764,29 +6208,17 @@ spec:
                                         properties:
                                           group:
                                             default: ""
-                                            description: |-
-                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                              When unspecified or empty string, core API group is inferred.
+                                            description: Group of the referent, for
+                                              example `gateway.networking.k8s.io`.
+                                              Empty selects the core API group
                                             maxLength: 253
                                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                             type: string
                                           kind:
                                             default: Service
-                                            description: |-
-                                              Kind is the Kubernetes resource kind of the referent. For example
-                                              "Service".
-
-                                              Defaults to "Service" when not specified.
-
-                                              ExternalName services can refer to CNAME DNS records that may live
-                                              outside of the cluster and as such are difficult to reason about in
-                                              terms of conformance. They also may not be safe to forward to (see
-                                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                              support ExternalName Services.
-
-                                              Support: Core (Services with a type other than ExternalName)
-
-                                              Support: Implementation-specific (Services with type ExternalName)
+                                            description: Kubernetes resource kind
+                                              of the referent, for example `Service`.
+                                              Defaults to `Service`
                                             maxLength: 63
                                             minLength: 1
                                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5797,27 +6229,18 @@ spec:
                                             minLength: 1
                                             type: string
                                           namespace:
-                                            description: |-
-                                              Namespace is the namespace of the backend. When unspecified, the local
-                                              namespace is inferred.
-
-                                              Note that when a namespace different than the local namespace is specified,
-                                              a ReferenceGrant object is required in the referent namespace to allow that
-                                              namespace's owner to accept the reference. See the ReferenceGrant
-                                              documentation for details.
-
-                                              Support: Core
+                                            description: Namespace of the referent.
+                                              Defaults to the local namespace. A cross-namespace
+                                              reference requires a ReferenceGrant
+                                              in the referent namespace
                                             maxLength: 63
                                             minLength: 1
                                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                             type: string
                                           port:
-                                            description: |-
-                                              Port specifies the destination port number to use for this resource.
-                                              Port is required when the referent is a Kubernetes Service. In this
-                                              case, the port number is the service port number, not the target port.
-                                              For other resources, destination port might be derived from the referent
-                                              resource or this field.
+                                            description: Destination port number.
+                                              Required when the referent is a Kubernetes
+                                              `Service`
                                             format: int32
                                             maximum: 65535
                                             minimum: 1
@@ -6308,6 +6731,19 @@ spec:
                     - FailClosed
                     - FailOpen
                     type: string
+                  prefixMode:
+                    description: |-
+                      How tool and prompt names are prefixed with the target name. Resource URIs
+                      always retain target routing information when multiplexing and are unaffected.
+                      `Conditional` (default) prefixes only when there are multiple targets.
+                      `Always` prefixes even with a single target. `Never` exposes unprefixed
+                      names and routes calls by looking up which target serves the name;
+                      names must be unique across targets.
+                    enum:
+                    - Always
+                    - Conditional
+                    - Never
+                    type: string
                   sessionRouting:
                     description: |-
                       MCP session routing behavior.
@@ -6453,12 +6889,7 @@ spec:
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  description: Name of the referent
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -6486,7 +6917,7 @@ spec:
                               properties:
                                 auth:
                                   description: Settings for managing authentication
-                                    to the backend.
+                                    to the backend
                                   properties:
                                     aws:
                                       description: |-
@@ -6503,29 +6934,96 @@ spec:
                                               minLength: 1
                                               pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                               type: string
+                                            sessionName:
+                                              description: |-
+                                                SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                              pattern: ^[\w+=,.@-]{2,64}$
+                                              type: string
+                                            sessionNameExpression:
+                                              description: |-
+                                                SessionNameExpression is a CEL expression evaluated against each request
+                                                to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                `request.headers["x-team"]`. If the expression does not produce a valid
+                                                session name at request time, the request is rejected.
+                                              maxLength: 16384
+                                              minLength: 1
+                                              type: string
+                                            tags:
+                                              description: |-
+                                                Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                & Usage Report, once activated. STS allows at most 50 per role session.
+                                              items:
+                                                description: |-
+                                                  AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                  attribution. Exactly one of value and expression must be set.
+                                                properties:
+                                                  expression:
+                                                    description: |-
+                                                      CEL expression evaluated against each request to produce the tag value,
+                                                      for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                      tag values are rejected.
+                                                    maxLength: 16384
+                                                    minLength: 1
+                                                    type: string
+                                                  key:
+                                                    description: Key is the tag key.
+                                                    maxLength: 128
+                                                    minLength: 1
+                                                    type: string
+                                                  value:
+                                                    description: Value is a static
+                                                      tag value.
+                                                    maxLength: 256
+                                                    type: string
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: exactly one of value or
+                                                    expression must be set
+                                                  rule: has(self.value) != has(self.expression)
+                                              maxItems: 50
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - key
+                                              x-kubernetes-list-type: map
                                           required:
                                           - roleArn
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: at most one of the fields in
+                                              [sessionName sessionNameExpression]
+                                              may be set
+                                            rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                              <= 1'
+                                        region:
+                                          description: |-
+                                            AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                            target AWS service is in a different region than the gateway. If unset,
+                                            typed AWS backends may provide this automatically; otherwise the ambient
+                                            AWS region is used.
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
                                         secretRef:
                                           description: |-
-                                            Credential source, defaulting to a Kubernetes
-                                            `Secret`, containing the AWS credentials. When using the default Secret
-                                            resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                            optionally `sessionToken`.
+                                            Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                            The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                            `sessionToken` keys.
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -6574,24 +7072,22 @@ spec:
                                           type: object
                                         secretRef:
                                           description: |-
-                                            Credential source, defaulting to a Kubernetes
-                                            `Secret`, containing the Azure credentials. When using the default Secret
-                                            resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                            `clientSecret`.
+                                            Credential source for Azure credentials, defaulting to a Kubernetes
+                                            `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                            `clientSecret` keys.
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -6606,6 +7102,782 @@ spec:
                                               == 0) ? (!has(self.kind) || size(self.kind)
                                               == 0 || self.kind == ''Secret'') : (has(self.kind)
                                               && size(self.kind) > 0)'
+                                        workloadIdentity:
+                                          description: |-
+                                            Workload identity authentication settings. Uses the federated token and
+                                            Azure env vars projected into the data plane pod. Recommended on AKS with
+                                            Workload Identity enabled.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: at most one of the fields in [secretRef
+                                          managedIdentity workloadIdentity] may be
+                                          set
+                                        rule: '[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size()
+                                          <= 1'
+                                    credentials:
+                                      description: |-
+                                        Credentials is a list of additional credentials to inject on the
+                                        backend request. Each entry resolves a Secret key and writes its value
+                                        to the entry's location. `credentials` is independent of the primary
+                                        `key`/`secretRef`/`passthrough` mechanism and may be set on its own or
+                                        alongside it.
+                                      items:
+                                        description: |-
+                                          BackendAuthCredential specifies one additional credential to inject on the
+                                          backend request.
+                                        properties:
+                                          location:
+                                            description: Where the credential is inserted
+                                              on the backend request.
+                                            properties:
+                                              cookie:
+                                                properties:
+                                                  name:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              header:
+                                                properties:
+                                                  name:
+                                                    description: Name of an HTTP header.
+                                                      HTTP/2 pseudo-headers (names
+                                                      beginning with `:`) are not
+                                                      supported
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                    type: string
+                                                  prefix:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              queryParameter:
+                                                properties:
+                                                  name:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: exactly one of the fields in
+                                                [header queryParameter cookie] must
+                                                be set
+                                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                                == 1'
+                                          secretRef:
+                                            description: |-
+                                              SecretRef references a Kubernetes Secret holding the credential value, and
+                                              optionally overrides the key read from it. Defaults to `Authorization`,
+                                              matching the key convention used by the top-level `secretRef`.
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              key:
+                                                description: Key in the referenced
+                                                  Secret. If omitted, a location-specific
+                                                  default is used
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                        required:
+                                        - location
+                                        - secretRef
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    crossAppAccess:
+                                      description: Cross App Access (Identity Assertion
+                                        / ID-JAG) authentication.
+                                      properties:
+                                        audience:
+                                          description: Identifier of the resource
+                                            authorization server. The issued ID-JAG
+                                            is bound to this audience.
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        cache:
+                                          description: Response cache configuration.
+                                          properties:
+                                            inMemory:
+                                              properties:
+                                                defaultTtl:
+                                                  description: TTL used when the token
+                                                    endpoint omits expires_in. Default
+                                                    300s.
+                                                  type: string
+                                                maxEntries:
+                                                  description: Default 8192; 0 disables
+                                                    the cache.
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                          type: object
+                                        identityProvider:
+                                          description: User identity provider authorization
+                                            server, used for the RFC 8693 ID-JAG exchange.
+                                          properties:
+                                            backendRef:
+                                              description: Token endpoint backend.
+                                              properties:
+                                                group:
+                                                  default: ""
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
+                                                  maxLength: 253
+                                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                  type: string
+                                                kind:
+                                                  default: Service
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
+                                                  maxLength: 63
+                                                  minLength: 1
+                                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of
+                                                    the referent.
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                                namespace:
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
+                                                  maxLength: 63
+                                                  minLength: 1
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                port:
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
+                                                  format: int32
+                                                  maximum: 65535
+                                                  minimum: 1
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: Must have port for Service
+                                                  reference
+                                                rule: '(size(self.group) == 0 && self.kind
+                                                  == ''Service'') ? has(self.port)
+                                                  : true'
+                                            clientAuth:
+                                              description: Client authentication for
+                                                the token endpoint.
+                                              properties:
+                                                clientId:
+                                                  description: Client ID sent to the
+                                                    token endpoint.
+                                                  minLength: 1
+                                                  type: string
+                                                method:
+                                                  description: Client authentication
+                                                    method. Defaults to ClientSecretBasic.
+                                                  enum:
+                                                  - ClientSecretBasic
+                                                  - ClientSecretPost
+                                                  - PrivateKeyJwt
+                                                  type: string
+                                                privateKeyJwt:
+                                                  description: Client assertion settings.
+                                                    Required when method is PrivateKeyJwt.
+                                                  properties:
+                                                    alg:
+                                                      description: JWS signing algorithm.
+                                                        Defaults to RS256.
+                                                      enum:
+                                                      - ES256
+                                                      - ES384
+                                                      - PS256
+                                                      - RS256
+                                                      - RS384
+                                                      - RS512
+                                                      type: string
+                                                    assertionAudience:
+                                                      description: Audience for the
+                                                        client assertion, typically
+                                                        the token endpoint URL.
+                                                      minLength: 1
+                                                      type: string
+                                                    certificateHeader:
+                                                      description: JWS certificate
+                                                        header. Required when certificateRef
+                                                        is set.
+                                                      enum:
+                                                      - x5c
+                                                      - x5t#S256
+                                                      type: string
+                                                    certificateRef:
+                                                      description: |-
+                                                        PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                                        leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                                        but the token endpoint will reject the assertions. Required when
+                                                        certificateHeader is set. The key defaults to `certificate`.
+                                                      properties:
+                                                        group:
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
+                                                          type: string
+                                                        key:
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                        kind:
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
+                                                          type: string
+                                                        name:
+                                                          description: Name of the
+                                                            referenced credential
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                      x-kubernetes-validations:
+                                                      - message: custom credential
+                                                          refs must set both group
+                                                          and kind
+                                                        rule: '(!has(self.group) ||
+                                                          size(self.group) == 0) ?
+                                                          (!has(self.kind) || size(self.kind)
+                                                          == 0 || self.kind == ''Secret'')
+                                                          : (has(self.kind) && size(self.kind)
+                                                          > 0)'
+                                                    kid:
+                                                      description: Optional JWS key
+                                                        ID header.
+                                                      type: string
+                                                    signingKeyRef:
+                                                      description: PEM-encoded RSA
+                                                        or EC private key; key defaults
+                                                        to `signingKey`.
+                                                      properties:
+                                                        group:
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
+                                                          type: string
+                                                        key:
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                        kind:
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
+                                                          type: string
+                                                        name:
+                                                          description: Name of the
+                                                            referenced credential
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                      x-kubernetes-validations:
+                                                      - message: custom credential
+                                                          refs must set both group
+                                                          and kind
+                                                        rule: '(!has(self.group) ||
+                                                          size(self.group) == 0) ?
+                                                          (!has(self.kind) || size(self.kind)
+                                                          == 0 || self.kind == ''Secret'')
+                                                          : (has(self.kind) && size(self.kind)
+                                                          > 0)'
+                                                  required:
+                                                  - assertionAudience
+                                                  - signingKeyRef
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: certificateRef and certificateHeader
+                                                      must be set together
+                                                    rule: has(self.certificateRef)
+                                                      == has(self.certificateHeader)
+                                                secretRef:
+                                                  description: |-
+                                                    Secret providing the `clientSecret` key by default; override via
+                                                    `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                                    is only valid with ClientSecretPost.
+                                                  properties:
+                                                    group:
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                    kind:
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
+                                                      type: string
+                                                    name:
+                                                      description: Name of the referenced
+                                                        credential
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                  x-kubernetes-validations:
+                                                  - message: custom credential refs
+                                                      must set both group and kind
+                                                    rule: '(!has(self.group) || size(self.group)
+                                                      == 0) ? (!has(self.kind) ||
+                                                      size(self.kind) == 0 || self.kind
+                                                      == ''Secret'') : (has(self.kind)
+                                                      && size(self.kind) > 0)'
+                                              required:
+                                              - clientId
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: privateKeyJwt settings require
+                                                  method PrivateKeyJwt
+                                                rule: has(self.privateKeyJwt) == (has(self.method)
+                                                  && self.method == 'PrivateKeyJwt')
+                                              - message: secretRef is not valid with
+                                                  method PrivateKeyJwt
+                                                rule: '!has(self.secretRef) || !has(self.method)
+                                                  || self.method != ''PrivateKeyJwt'''
+                                              - message: clientAuth without secretRef
+                                                  requires method ClientSecretPost
+                                                  or PrivateKeyJwt
+                                                rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                                  || (has(self.method) && self.method
+                                                  == 'ClientSecretPost')
+                                            path:
+                                              description: Token endpoint path; defaults
+                                                to "/". Must start with "/".
+                                              pattern: ^/
+                                              type: string
+                                          required:
+                                          - backendRef
+                                          - clientAuth
+                                          type: object
+                                        resourceAuthorizationServer:
+                                          description: Resource authorization server,
+                                            used for the RFC 7523 jwt-bearer exchange.
+                                          properties:
+                                            backendRef:
+                                              description: Token endpoint backend.
+                                              properties:
+                                                group:
+                                                  default: ""
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
+                                                  maxLength: 253
+                                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                  type: string
+                                                kind:
+                                                  default: Service
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
+                                                  maxLength: 63
+                                                  minLength: 1
+                                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of
+                                                    the referent.
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                                namespace:
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
+                                                  maxLength: 63
+                                                  minLength: 1
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                port:
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
+                                                  format: int32
+                                                  maximum: 65535
+                                                  minimum: 1
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: Must have port for Service
+                                                  reference
+                                                rule: '(size(self.group) == 0 && self.kind
+                                                  == ''Service'') ? has(self.port)
+                                                  : true'
+                                            clientAuth:
+                                              description: Client authentication for
+                                                the token endpoint.
+                                              properties:
+                                                clientId:
+                                                  description: Client ID sent to the
+                                                    token endpoint.
+                                                  minLength: 1
+                                                  type: string
+                                                method:
+                                                  description: Client authentication
+                                                    method. Defaults to ClientSecretBasic.
+                                                  enum:
+                                                  - ClientSecretBasic
+                                                  - ClientSecretPost
+                                                  - PrivateKeyJwt
+                                                  type: string
+                                                privateKeyJwt:
+                                                  description: Client assertion settings.
+                                                    Required when method is PrivateKeyJwt.
+                                                  properties:
+                                                    alg:
+                                                      description: JWS signing algorithm.
+                                                        Defaults to RS256.
+                                                      enum:
+                                                      - ES256
+                                                      - ES384
+                                                      - PS256
+                                                      - RS256
+                                                      - RS384
+                                                      - RS512
+                                                      type: string
+                                                    assertionAudience:
+                                                      description: Audience for the
+                                                        client assertion, typically
+                                                        the token endpoint URL.
+                                                      minLength: 1
+                                                      type: string
+                                                    certificateHeader:
+                                                      description: JWS certificate
+                                                        header. Required when certificateRef
+                                                        is set.
+                                                      enum:
+                                                      - x5c
+                                                      - x5t#S256
+                                                      type: string
+                                                    certificateRef:
+                                                      description: |-
+                                                        PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                                        leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                                        but the token endpoint will reject the assertions. Required when
+                                                        certificateHeader is set. The key defaults to `certificate`.
+                                                      properties:
+                                                        group:
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
+                                                          type: string
+                                                        key:
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                        kind:
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
+                                                          type: string
+                                                        name:
+                                                          description: Name of the
+                                                            referenced credential
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                      x-kubernetes-validations:
+                                                      - message: custom credential
+                                                          refs must set both group
+                                                          and kind
+                                                        rule: '(!has(self.group) ||
+                                                          size(self.group) == 0) ?
+                                                          (!has(self.kind) || size(self.kind)
+                                                          == 0 || self.kind == ''Secret'')
+                                                          : (has(self.kind) && size(self.kind)
+                                                          > 0)'
+                                                    kid:
+                                                      description: Optional JWS key
+                                                        ID header.
+                                                      type: string
+                                                    signingKeyRef:
+                                                      description: PEM-encoded RSA
+                                                        or EC private key; key defaults
+                                                        to `signingKey`.
+                                                      properties:
+                                                        group:
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
+                                                          type: string
+                                                        key:
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                        kind:
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
+                                                          type: string
+                                                        name:
+                                                          description: Name of the
+                                                            referenced credential
+                                                          maxLength: 253
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                      x-kubernetes-validations:
+                                                      - message: custom credential
+                                                          refs must set both group
+                                                          and kind
+                                                        rule: '(!has(self.group) ||
+                                                          size(self.group) == 0) ?
+                                                          (!has(self.kind) || size(self.kind)
+                                                          == 0 || self.kind == ''Secret'')
+                                                          : (has(self.kind) && size(self.kind)
+                                                          > 0)'
+                                                  required:
+                                                  - assertionAudience
+                                                  - signingKeyRef
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: certificateRef and certificateHeader
+                                                      must be set together
+                                                    rule: has(self.certificateRef)
+                                                      == has(self.certificateHeader)
+                                                secretRef:
+                                                  description: |-
+                                                    Secret providing the `clientSecret` key by default; override via
+                                                    `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                                    is only valid with ClientSecretPost.
+                                                  properties:
+                                                    group:
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                    kind:
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
+                                                      type: string
+                                                    name:
+                                                      description: Name of the referenced
+                                                        credential
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                  x-kubernetes-validations:
+                                                  - message: custom credential refs
+                                                      must set both group and kind
+                                                    rule: '(!has(self.group) || size(self.group)
+                                                      == 0) ? (!has(self.kind) ||
+                                                      size(self.kind) == 0 || self.kind
+                                                      == ''Secret'') : (has(self.kind)
+                                                      && size(self.kind) > 0)'
+                                              required:
+                                              - clientId
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: privateKeyJwt settings require
+                                                  method PrivateKeyJwt
+                                                rule: has(self.privateKeyJwt) == (has(self.method)
+                                                  && self.method == 'PrivateKeyJwt')
+                                              - message: secretRef is not valid with
+                                                  method PrivateKeyJwt
+                                                rule: '!has(self.secretRef) || !has(self.method)
+                                                  || self.method != ''PrivateKeyJwt'''
+                                              - message: clientAuth without secretRef
+                                                  requires method ClientSecretPost
+                                                  or PrivateKeyJwt
+                                                rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                                  || (has(self.method) && self.method
+                                                  == 'ClientSecretPost')
+                                            path:
+                                              description: Token endpoint path; defaults
+                                                to "/". Must start with "/".
+                                              pattern: ^/
+                                              type: string
+                                          required:
+                                          - backendRef
+                                          - clientAuth
+                                          type: object
+                                        resources:
+                                          description: Resources sent to the token
+                                            endpoint.
+                                          items:
+                                            type: string
+                                          maxItems: 64
+                                          minItems: 1
+                                          type: array
+                                        scopes:
+                                          description: Scopes sent to the token endpoint.
+                                          items:
+                                            type: string
+                                          maxItems: 64
+                                          minItems: 1
+                                          type: array
+                                        subjectToken:
+                                          description: |-
+                                            Subject token sent to the identity provider. Defaults to an OpenID Connect
+                                            ID token read from the Authorization Bearer header.
+                                          properties:
+                                            source:
+                                              description: Where to read the subject
+                                                token. Defaults to the Authorization
+                                                Bearer header.
+                                              properties:
+                                                cookie:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                expression:
+                                                  description: CEL expression that
+                                                    extracts the credential from the
+                                                    request.
+                                                  maxLength: 16384
+                                                  minLength: 1
+                                                  type: string
+                                                header:
+                                                  properties:
+                                                    name:
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                      type: string
+                                                    prefix:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                queryParameter:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: exactly one of the fields
+                                                  in [header queryParameter cookie
+                                                  expression] must be set
+                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                                  == 1'
+                                          type: object
+                                      required:
+                                      - audience
+                                      - identityProvider
+                                      - resourceAuthorizationServer
                                       type: object
                                     gcp:
                                       description: |-
@@ -6622,24 +7894,30 @@ spec:
                                           type: string
                                         secretRef:
                                           description: |-
-                                            Credential source, defaulting to a Kubernetes
-                                            `Secret`, containing ADC-compatible Google credential JSON. When using
-                                            the default Secret resolver, this must be stored in the `credentials.json`
-                                            key. When omitted, ambient credentials are used.
+                                            Credential source for ADC-compatible Google credential JSON, defaulting to
+                                            a Kubernetes `Secret`. By default, the value is read from
+                                            `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                            ambient credentials are used.
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
+                                              type: string
+                                            key:
+                                              description: Key in the referenced Secret.
+                                                If omitted, a location-specific default
+                                                is used
+                                              maxLength: 253
+                                              minLength: 1
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -6679,7 +7957,7 @@ spec:
                                       description: |-
                                         Where backend credentials are inserted.
                                         If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                        This applies to `key`, `secretRef`, and `passthrough`.
+                                        This applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.
                                       properties:
                                         cookie:
                                           properties:
@@ -6693,19 +7971,9 @@ spec:
                                         header:
                                           properties:
                                             name:
-                                              description: |-
-                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                Valid values include:
-
-                                                * "Authorization"
-                                                * "Set-Cookie"
-
-                                                Invalid values include:
-
-                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                    headers are not currently supported by this type.
-                                                  - "/invalid" - "/ " is an invalid character
+                                              description: Name of an HTTP header.
+                                                HTTP/2 pseudo-headers (names beginning
+                                                with `:`) are not supported
                                               maxLength: 256
                                               minLength: 1
                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6732,34 +8000,575 @@ spec:
                                           queryParameter cookie] must be set
                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                           == 1'
+                                    oauthTokenExchange:
+                                      description: OAuth 2.0 token exchange (RFC 8693)
+                                        / jwt-bearer (RFC 7523) authentication.
+                                      properties:
+                                        actorToken:
+                                          description: RFC 8693 delegation actor token.
+                                            TokenExchange grant only.
+                                          properties:
+                                            mayAct:
+                                              description: may_act claim validation
+                                                mode. When omitted, may_act is not
+                                                enforced.
+                                              enum:
+                                              - Required
+                                              type: string
+                                            source:
+                                              description: Where to read the actor
+                                                token. Actor tokens have no default
+                                                source.
+                                              properties:
+                                                cookie:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                expression:
+                                                  description: CEL expression that
+                                                    extracts the credential from the
+                                                    request.
+                                                  maxLength: 16384
+                                                  minLength: 1
+                                                  type: string
+                                                header:
+                                                  properties:
+                                                    name:
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                      type: string
+                                                    prefix:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                queryParameter:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: exactly one of the fields
+                                                  in [header queryParameter cookie
+                                                  expression] must be set
+                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                                  == 1'
+                                            tokenType:
+                                              description: |-
+                                                OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                are supported for actor tokens.
+                                              type: string
+                                          required:
+                                          - source
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: mayAct Required requires tokenType
+                                              Jwt
+                                            rule: '!has(self.mayAct) || self.mayAct
+                                              != ''Required'' || (has(self.tokenType)
+                                              && self.tokenType == ''Jwt'')'
+                                        additionalParams:
+                                          additionalProperties:
+                                            description: A Common Expression Language
+                                              (CEL) expression.
+                                            maxLength: 16384
+                                            minLength: 1
+                                            type: string
+                                          description: Extra form params; values are
+                                            CEL expressions over the incoming request.
+                                          maxProperties: 64
+                                          type: object
+                                        audiences:
+                                          description: Audiences sent to the token
+                                            endpoint.
+                                          items:
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 64
+                                          minItems: 1
+                                          type: array
+                                        backendRef:
+                                          description: RFC 8693 token endpoint backend.
+                                          properties:
+                                            group:
+                                              default: ""
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              default: Service
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                            port:
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind
+                                              == ''Service'') ? has(self.port) : true'
+                                        cache:
+                                          description: Response cache configuration.
+                                          properties:
+                                            inMemory:
+                                              properties:
+                                                defaultTtl:
+                                                  description: TTL used when the token
+                                                    endpoint omits expires_in. Default
+                                                    300s.
+                                                  type: string
+                                                maxEntries:
+                                                  description: Default 8192; 0 disables
+                                                    the cache.
+                                                  format: int32
+                                                  type: integer
+                                              type: object
+                                          type: object
+                                        clientAuth:
+                                          description: Client authentication for the
+                                            token endpoint. When unset, none is sent.
+                                          properties:
+                                            clientId:
+                                              description: Client ID sent to the token
+                                                endpoint.
+                                              minLength: 1
+                                              type: string
+                                            method:
+                                              description: Client authentication method.
+                                                Defaults to ClientSecretBasic.
+                                              enum:
+                                              - ClientSecretBasic
+                                              - ClientSecretPost
+                                              - PrivateKeyJwt
+                                              type: string
+                                            privateKeyJwt:
+                                              description: Client assertion settings.
+                                                Required when method is PrivateKeyJwt.
+                                              properties:
+                                                alg:
+                                                  description: JWS signing algorithm.
+                                                    Defaults to RS256.
+                                                  enum:
+                                                  - ES256
+                                                  - ES384
+                                                  - PS256
+                                                  - RS256
+                                                  - RS384
+                                                  - RS512
+                                                  type: string
+                                                assertionAudience:
+                                                  description: Audience for the client
+                                                    assertion, typically the token
+                                                    endpoint URL.
+                                                  minLength: 1
+                                                  type: string
+                                                certificateHeader:
+                                                  description: JWS certificate header.
+                                                    Required when certificateRef is
+                                                    set.
+                                                  enum:
+                                                  - x5c
+                                                  - x5t#S256
+                                                  type: string
+                                                certificateRef:
+                                                  description: |-
+                                                    PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                                    leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                                    but the token endpoint will reject the assertions. Required when
+                                                    certificateHeader is set. The key defaults to `certificate`.
+                                                  properties:
+                                                    group:
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                    kind:
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
+                                                      type: string
+                                                    name:
+                                                      description: Name of the referenced
+                                                        credential
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                  x-kubernetes-validations:
+                                                  - message: custom credential refs
+                                                      must set both group and kind
+                                                    rule: '(!has(self.group) || size(self.group)
+                                                      == 0) ? (!has(self.kind) ||
+                                                      size(self.kind) == 0 || self.kind
+                                                      == ''Secret'') : (has(self.kind)
+                                                      && size(self.kind) > 0)'
+                                                kid:
+                                                  description: Optional JWS key ID
+                                                    header.
+                                                  type: string
+                                                signingKeyRef:
+                                                  description: PEM-encoded RSA or
+                                                    EC private key; key defaults to
+                                                    `signingKey`.
+                                                  properties:
+                                                    group:
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                    kind:
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
+                                                      type: string
+                                                    name:
+                                                      description: Name of the referenced
+                                                        credential
+                                                      maxLength: 253
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                  x-kubernetes-validations:
+                                                  - message: custom credential refs
+                                                      must set both group and kind
+                                                    rule: '(!has(self.group) || size(self.group)
+                                                      == 0) ? (!has(self.kind) ||
+                                                      size(self.kind) == 0 || self.kind
+                                                      == ''Secret'') : (has(self.kind)
+                                                      && size(self.kind) > 0)'
+                                              required:
+                                              - assertionAudience
+                                              - signingKeyRef
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: certificateRef and certificateHeader
+                                                  must be set together
+                                                rule: has(self.certificateRef) ==
+                                                  has(self.certificateHeader)
+                                            secretRef:
+                                              description: |-
+                                                Secret providing the `clientSecret` key by default; override via
+                                                `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                                is only valid with ClientSecretPost.
+                                              properties:
+                                                group:
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
+                                                  type: string
+                                                name:
+                                                  description: Name of the referenced
+                                                    credential
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                              x-kubernetes-validations:
+                                              - message: custom credential refs must
+                                                  set both group and kind
+                                                rule: '(!has(self.group) || size(self.group)
+                                                  == 0) ? (!has(self.kind) || size(self.kind)
+                                                  == 0 || self.kind == ''Secret'')
+                                                  : (has(self.kind) && size(self.kind)
+                                                  > 0)'
+                                          required:
+                                          - clientId
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: privateKeyJwt settings require
+                                              method PrivateKeyJwt
+                                            rule: has(self.privateKeyJwt) == (has(self.method)
+                                              && self.method == 'PrivateKeyJwt')
+                                          - message: secretRef is not valid with method
+                                              PrivateKeyJwt
+                                            rule: '!has(self.secretRef) || !has(self.method)
+                                              || self.method != ''PrivateKeyJwt'''
+                                          - message: clientAuth without secretRef
+                                              requires method ClientSecretPost or
+                                              PrivateKeyJwt
+                                            rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                              || (has(self.method) && self.method
+                                              == 'ClientSecretPost')
+                                        grantType:
+                                          description: RFC followed by the request.
+                                            Defaults to TokenExchange (RFC 8693).
+                                          enum:
+                                          - JwtBearer
+                                          - TokenExchange
+                                          type: string
+                                        location:
+                                          description: |-
+                                            Where the exchanged token is written to the backend request.
+                                            Defaults to Authorization: Bearer.
+                                          properties:
+                                            cookie:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            header:
+                                              properties:
+                                                name:
+                                                  description: Name of an HTTP header.
+                                                    HTTP/2 pseudo-headers (names beginning
+                                                    with `:`) are not supported
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                  type: string
+                                                prefix:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            queryParameter:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [header queryParameter cookie] must
+                                              be set
+                                            rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                              == 1'
+                                        path:
+                                          description: Token endpoint path; defaults
+                                            to "/". Must start with "/".
+                                          pattern: ^/
+                                          type: string
+                                        requestedTokenType:
+                                          description: |-
+                                            RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                            built-in values may be requested; custom URIs are not supported here.
+                                          enum:
+                                          - AccessToken
+                                          - Jwt
+                                          - IdToken
+                                          - IdJag
+                                          type: string
+                                        resources:
+                                          description: Resources sent to the token
+                                            endpoint.
+                                          items:
+                                            type: string
+                                          maxItems: 64
+                                          minItems: 1
+                                          type: array
+                                        scopes:
+                                          description: Scopes sent to the token endpoint.
+                                          items:
+                                            type: string
+                                          maxItems: 64
+                                          minItems: 1
+                                          type: array
+                                        subjectToken:
+                                          description: |-
+                                            Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                            The token type may be a built-in value or a custom absolute URI for providers
+                                            that support custom token exchange profiles.
+                                          properties:
+                                            source:
+                                              description: Where to read the token.
+                                                CEL `expression` variant is permitted.
+                                              properties:
+                                                cookie:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                expression:
+                                                  description: CEL expression that
+                                                    extracts the credential from the
+                                                    request.
+                                                  maxLength: 16384
+                                                  minLength: 1
+                                                  type: string
+                                                header:
+                                                  properties:
+                                                    name:
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                      type: string
+                                                    prefix:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                queryParameter:
+                                                  properties:
+                                                    name:
+                                                      maxLength: 256
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: exactly one of the fields
+                                                  in [header queryParameter cookie
+                                                  expression] must be set
+                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                                  == 1'
+                                            tokenType:
+                                              description: |-
+                                                OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                are supported for subject tokens.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - backendRef
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: actorToken is only valid with TokenExchange
+                                          grantType
+                                        rule: '!(has(self.actorToken) && has(self.grantType)
+                                          && self.grantType == ''JwtBearer'')'
+                                      - message: requestedTokenType is only valid
+                                          with TokenExchange grantType
+                                        rule: '!(has(self.requestedTokenType) && has(self.grantType)
+                                          && self.grantType == ''JwtBearer'')'
+                                      - message: requestedTokenType IdJag is only
+                                          supported by crossAppAccess
+                                        rule: '!has(self.requestedTokenType) || self.requestedTokenType
+                                          != ''IdJag'''
                                     passthrough:
                                       description: |-
-                                        Passes through an existing token that has been sent by the
-                                        client and validated. Other policies, like JWT and API key
-                                        authentication, will strip the original client credentials. Passthrough backend authentication
-                                        causes the original token to be added back into the request. If there are no client authentication policies on the
-                                        request, the original token would be unchanged, so this would have no effect.
+                                        Reuses a client token already validated by another policy. Those policies
+                                        may strip client credentials; passthrough adds the original token back to
+                                        the backend request. Without client auth policies, this has no effect.
                                       type: object
                                     secretRef:
                                       description: |-
-                                        Credential source, defaulting to a Kubernetes
-                                        `Secret`, storing the key to use as the authorization value. When using
-                                        the default Secret resolver, this must be stored in the `Authorization`
-                                        key.
+                                        Credential source for the authorization value, defaulting to a Kubernetes
+                                        `Secret`. By default, the value is read from the `Authorization` key; set
+                                        `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                        the default `Authorization` key.
                                       properties:
                                         group:
-                                          description: |-
-                                            The API group of the referenced credential.
-                                            Empty selects the core API group.
+                                          description: API group of the referenced
+                                            credential; empty selects the core API
+                                            group
+                                          type: string
+                                        key:
+                                          description: Key in the referenced Secret.
+                                            If omitted, a location-specific default
+                                            is used
+                                          maxLength: 253
+                                          minLength: 1
                                           type: string
                                         kind:
-                                          description: |-
-                                            The kind of the referenced credential.
-                                            Empty defaults to `Secret`.
+                                          description: Kind of the referenced credential;
+                                            empty defaults to `Secret`
                                           type: string
                                         name:
-                                          description: The name of the referenced
-                                            credential.
+                                          description: Name of the referenced credential
                                           maxLength: 253
                                           minLength: 1
                                           type: string
@@ -6776,21 +8585,31 @@ spec:
                                           && size(self.kind) > 0)'
                                   type: object
                                   x-kubernetes-validations:
-                                  - message: location may only be set for key or passthrough
-                                      auth
+                                  - message: must specify credentials, or at most
+                                      one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                                      (credentials may be combined with a primary
+                                      auth kind)
+                                    rule: has(self.credentials) || has(self.key) ||
+                                      has(self.secretRef) || has(self.passthrough)
+                                      || has(self.aws) || has(self.azure) || has(self.gcp)
+                                      || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                                  - message: location may only be set for key, secretRef,
+                                      or passthrough auth
                                     rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
                                       || has(self.passthrough) : true'
-                                  - message: exactly one of the fields in [key secretRef
-                                      passthrough aws azure gcp] must be set
-                                    rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
-                                      == 1'
+                                  - message: at most one of the fields in [key secretRef
+                                      passthrough aws azure gcp oauthTokenExchange
+                                      crossAppAccess] may be set
+                                    rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                                      <= 1'
                                 http:
                                   description: Settings for managing HTTP requests
-                                    to the backend.
+                                    to the backend
                                   properties:
                                     requestTimeout:
                                       description: Deadline for receiving a response
                                         from the backend.
+                                      maxLength: 32
                                       type: string
                                       x-kubernetes-validations:
                                       - message: invalid duration value
@@ -6799,17 +8618,10 @@ spec:
                                         rule: duration(self) >= duration('1ms')
                                     version:
                                       description: |-
-                                        HTTP protocol version to use when connecting to
-                                        the backend.
-                                        If not specified, the version is automatically determined:
-                                        * `Service` types can specify it with `appProtocol` on the `Service`
-                                          port.
-                                        * If traffic is identified as gRPC, `HTTP2` is used.
-                                        * If the incoming traffic was plaintext HTTP, the original protocol will
-                                          be used.
-                                        * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                          because most clients will transparently upgrade HTTPS traffic to
-                                          `HTTP2`, even if the backend doesn't support it.
+                                        HTTP protocol version for backend connections. If unset, it is inferred:
+                                        `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                        plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                        to HTTP/2 even when the backend does not support it.
                                       enum:
                                       - HTTP1
                                       - HTTP2
@@ -6817,12 +8629,13 @@ spec:
                                   type: object
                                 tcp:
                                   description: Settings for managing TCP connections
-                                    to the backend.
+                                    to the backend
                                   properties:
                                     connectTimeout:
                                       description: |-
                                         Deadline for establishing a connection to
                                         the destination.
+                                      maxLength: 32
                                       type: string
                                       x-kubernetes-validations:
                                       - message: invalid duration value
@@ -6838,6 +8651,7 @@ spec:
                                           description: |-
                                             Time between keepalive probes.
                                             If unset, this defaults to 180s.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -6856,6 +8670,7 @@ spec:
                                           description: |-
                                             Time a connection needs to be idle before keepalive probes start being sent.
                                             If unset, this defaults to 180s.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -6866,10 +8681,10 @@ spec:
                                   type: object
                                 tls:
                                   description: |-
-                                    Settings for managing TLS connections to the backend.
+                                    Settings for managing TLS connections to the backend
 
-                                    If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                    validate the server, and the SNI will automatically be set based on the destination.
+                                    When set, TLS is originated to the backend using the system trusted CA
+                                    certificates, and SNI is inferred from the destination.
                                   properties:
                                     alpnProtocols:
                                       description: |-
@@ -6896,12 +8711,7 @@ spec:
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            description: Name of the referent
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -6910,15 +8720,13 @@ spec:
                                       x-kubernetes-list-type: atomic
                                     insecureSkipVerify:
                                       description: |-
-                                        Originates TLS but skips verification of the backend's certificate.
-                                        WARNING: This is an insecure option that should only be used if the risks are understood.
+                                        Originates TLS but skips verification of the backend's certificate
+                                        WARNING: insecure; only use if the risks are understood
 
-                                        There are two modes:
-                                        * `All` disables all TLS verification.
-                                        * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                          mismatch of hostname or SANs. Note that this method is still insecure;
-                                          prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                          if possible.
+                                        Modes:
+                                        * `All` disables all TLS verification
+                                        * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                          Still insecure; prefer `verifySubjectAltNames` where possible.
                                       enum:
                                       - All
                                       - Hostname
@@ -6937,33 +8745,27 @@ spec:
                                       type: array
                                     mtlsCertificateRef:
                                       description: |-
-                                        Enables mutual TLS to the backend, using the
-                                        specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                        credential source, defaulting to a Kubernetes `Secret`.
-
-                                        An optional `ca.cert` field, if present, will be used to verify the
-                                        server certificate. If `caCertificateRefs` is also specified, the
-                                        `caCertificateRefs` field takes priority.
-
-                                        If unspecified, no client certificate will be used.
+                                        Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                        referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                        optional `ca.cert`, if present, verifies the server certificate, but
+                                        `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                        is used.
                                       items:
                                         description: |-
-                                          References a same-namespace credential.
-                                          Set only `name` to reference a Kubernetes Secret.
+                                          References a same-namespace credential
+                                          Set only `name` for a Kubernetes Secret
                                         properties:
                                           group:
-                                            description: |-
-                                              The API group of the referenced credential.
-                                              Empty selects the core API group.
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
                                             type: string
                                           kind:
-                                            description: |-
-                                              The kind of the referenced credential.
-                                              Empty defaults to `Secret`.
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
                                             type: string
                                           name:
-                                            description: The name of the referenced
-                                              credential.
+                                            description: Name of the referenced credential
                                             maxLength: 253
                                             minLength: 1
                                             type: string
@@ -7018,8 +8820,8 @@ spec:
                                     rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
                                       <= 1'
                                 tunnel:
-                                  description: Settings for managing tunnel connections,
-                                    with behavior like `HTTPS_PROXY`, to the backend.
+                                  description: Settings for managing tunnel connections
+                                    to the backend, like `HTTPS_PROXY`
                                   properties:
                                     backendRef:
                                       description: |-
@@ -7028,29 +8830,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7061,27 +8851,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -7177,11 +8957,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -7228,11 +9006,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -7360,13 +9136,13 @@ spec:
                                         AWS Bedrock Guardrails.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to AWS Bedrock Guardrails.
                                           properties:
                                             aws:
                                               description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
+                                                AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                                default AWS SDK credential discovery.
                                               properties:
                                                 assumeRole:
                                                   description: |-
@@ -7379,29 +9155,100 @@ spec:
                                                       minLength: 1
                                                       pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                       type: string
+                                                    sessionName:
+                                                      description: |-
+                                                        SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                        Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                      pattern: ^[\w+=,.@-]{2,64}$
+                                                      type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
+                                                    tags:
+                                                      description: |-
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
+                                                      items:
+                                                        description: |-
+                                                          AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                          attribution. Exactly one of value and expression must be set.
+                                                        properties:
+                                                          expression:
+                                                            description: |-
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
+                                                            maxLength: 16384
+                                                            minLength: 1
+                                                            type: string
+                                                          key:
+                                                            description: Key is the
+                                                              tag key.
+                                                            maxLength: 128
+                                                            minLength: 1
+                                                            type: string
+                                                          value:
+                                                            description: Value is
+                                                              a static tag value.
+                                                            maxLength: 256
+                                                            type: string
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                        x-kubernetes-validations:
+                                                        - message: exactly one of
+                                                            value or expression must
+                                                            be set
+                                                          rule: has(self.value) !=
+                                                            has(self.expression)
+                                                      maxItems: 50
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                      - key
+                                                      x-kubernetes-list-type: map
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
+                                                region:
+                                                  description: |-
+                                                    AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                    target AWS service is in a different region than the gateway. If unset,
+                                                    typed AWS backends may provide this automatically; otherwise the ambient
+                                                    AWS region is used.
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -7430,136 +9277,16 @@ spec:
                                               - message: secretRef and assumeRole
                                                   are mutually exclusive
                                                 rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
-                                            gcp:
-                                              description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
-                                              properties:
-                                                audience:
-                                                  description: |-
-                                                    Explicit `aud` value for the ID token. Only
-                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                    derived from the backend hostname.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                type:
-                                                  description: |-
-                                                    The type of token to generate. To authenticate to GCP services,
-                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                    `IdToken` is used.
-                                                  enum:
-                                                  - AccessToken
-                                                  - IdToken
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: audience is only valid with
-                                                  IdToken
-                                                rule: 'has(self.audience) ? self.type
-                                                  == ''IdToken'' : true'
                                             key:
                                               description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
+                                                Inline API key to use as the value of the `Authorization` header.
+                                                This option is the least secure; usage of a `Secret` is preferred.
                                               maxLength: 2048
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where API keys are inserted. Defaults to the `Authorization` header with
+                                                the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -7573,19 +9300,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7613,34 +9331,33 @@ spec:
                                                   must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                   == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
+                                                Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                                By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -7659,22 +9376,21 @@ spec:
                                           type: object
                                           x-kubernetes-validations:
                                           - message: location may only be set for
-                                              key or passthrough auth
+                                              key or secretRef auth
                                             rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
+                                              || has(self.secretRef) : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [key secretRef aws] must be set
+                                            rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -7684,17 +9400,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -7702,12 +9411,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -7724,6 +9434,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -7743,6 +9454,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -7754,10 +9466,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -7784,12 +9496,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -7798,15 +9505,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -7825,33 +9530,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -7909,8 +9610,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -7919,29 +9619,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7953,27 +9641,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -7991,6 +9671,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     region:
                                       description: |-
                                         AWS region where the guardrail is deployed, for example
@@ -8026,135 +9711,13 @@ spec:
                                         Google Model Armor.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to Google Model Armor.
                                           properties:
-                                            aws:
-                                              description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
-                                              properties:
-                                                assumeRole:
-                                                  description: |-
-                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                  properties:
-                                                    roleArn:
-                                                      description: AWS IAM role ARN
-                                                        to assume.
-                                                      minLength: 1
-                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                      type: string
-                                                  required:
-                                                  - roleArn
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                serviceName:
-                                                  description: |-
-                                                    AWS SigV4 signing service name, for example
-                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                    backends may provide this automatically.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: secretRef and assumeRole
-                                                  are mutually exclusive
-                                                rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
                                             gcp:
                                               description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
+                                                Google authentication method for Model Armor. Use `gcp: {}` for default
+                                                Google credential discovery.
                                               properties:
                                                 audience:
                                                   description: |-
@@ -8166,24 +9729,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -8214,133 +9784,20 @@ spec:
                                                   IdToken
                                                 rule: 'has(self.audience) ? self.type
                                                   == ''IdToken'' : true'
-                                            key:
-                                              description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
-                                              maxLength: 2048
-                                              type: string
-                                            location:
-                                              description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
-                                              properties:
-                                                cookie:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                header:
-                                                  properties:
-                                                    name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                                      type: string
-                                                    prefix:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                queryParameter:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: exactly one of the fields
-                                                  in [header queryParameter cookie]
-                                                  must be set
-                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
-                                                  == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
-                                            secretRef:
-                                              description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
-                                              properties:
-                                                group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
-                                                  type: string
-                                                kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
-                                                  type: string
-                                                name:
-                                                  description: The name of the referenced
-                                                    credential.
-                                                  maxLength: 253
-                                                  minLength: 1
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                              x-kubernetes-validations:
-                                              - message: custom credential refs must
-                                                  set both group and kind
-                                                rule: '(!has(self.group) || size(self.group)
-                                                  == 0) ? (!has(self.kind) || size(self.kind)
-                                                  == 0 || self.kind == ''Secret'')
-                                                  : (has(self.kind) && size(self.kind)
-                                                  > 0)'
                                           type: object
                                           x-kubernetes-validations:
-                                          - message: location may only be set for
-                                              key or passthrough auth
-                                            rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [gcp] must be set
+                                            rule: '[has(self.gcp)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -8350,17 +9807,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -8368,12 +9818,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -8390,6 +9841,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -8409,6 +9861,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -8420,10 +9873,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -8450,12 +9903,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -8464,15 +9912,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -8491,33 +9937,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -8575,8 +10017,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -8585,29 +10026,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8619,27 +10048,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -8657,6 +10078,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     projectId:
                                       description: Google Cloud project ID.
                                       maxLength: 256
@@ -8687,194 +10113,9 @@ spec:
                                         OpenAI.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to OpenAI.
                                           properties:
-                                            aws:
-                                              description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
-                                              properties:
-                                                assumeRole:
-                                                  description: |-
-                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                  properties:
-                                                    roleArn:
-                                                      description: AWS IAM role ARN
-                                                        to assume.
-                                                      minLength: 1
-                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                      type: string
-                                                  required:
-                                                  - roleArn
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                serviceName:
-                                                  description: |-
-                                                    AWS SigV4 signing service name, for example
-                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                    backends may provide this automatically.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: secretRef and assumeRole
-                                                  are mutually exclusive
-                                                rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
-                                            gcp:
-                                              description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
-                                              properties:
-                                                audience:
-                                                  description: |-
-                                                    Explicit `aud` value for the ID token. Only
-                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                    derived from the backend hostname.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                type:
-                                                  description: |-
-                                                    The type of token to generate. To authenticate to GCP services,
-                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                    `IdToken` is used.
-                                                  enum:
-                                                  - AccessToken
-                                                  - IdToken
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: audience is only valid with
-                                                  IdToken
-                                                rule: 'has(self.audience) ? self.type
-                                                  == ''IdToken'' : true'
                                             key:
                                               description: |-
                                                 Inline key to use as the value of the
@@ -8884,9 +10125,8 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -8900,19 +10140,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -8940,34 +10171,33 @@ spec:
                                                   must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                   == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -8985,23 +10215,18 @@ spec:
                                                   > 0)'
                                           type: object
                                           x-kubernetes-validations:
-                                          - message: location may only be set for
-                                              key or passthrough auth
-                                            rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [key secretRef] must be set
+                                            rule: '[has(self.key),has(self.secretRef)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9011,17 +10236,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -9029,12 +10247,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9051,6 +10270,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9070,6 +10290,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9081,10 +10302,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -9111,12 +10332,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -9125,15 +10341,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -9152,33 +10366,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -9236,8 +10446,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -9246,29 +10455,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9280,27 +10477,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -9318,6 +10507,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                   type: object
                                 regex:
                                   description: Regular expression (regex) matching
@@ -9399,29 +10593,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9432,27 +10614,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -9485,51 +10657,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -9538,6 +10685,17 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                    headers:
+                                      additionalProperties:
+                                        description: A Common Expression Language
+                                          (CEL) expression.
+                                        maxLength: 16384
+                                        minLength: 1
+                                        type: string
+                                      description: CEL-computed headers to include
+                                        in webhook requests.
+                                      maxProperties: 64
+                                      type: object
                                   required:
                                   - backendRef
                                   type: object
@@ -9574,13 +10732,13 @@ spec:
                                         AWS Bedrock Guardrails.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to AWS Bedrock Guardrails.
                                           properties:
                                             aws:
                                               description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
+                                                AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                                default AWS SDK credential discovery.
                                               properties:
                                                 assumeRole:
                                                   description: |-
@@ -9593,29 +10751,100 @@ spec:
                                                       minLength: 1
                                                       pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                       type: string
+                                                    sessionName:
+                                                      description: |-
+                                                        SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                        Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                      pattern: ^[\w+=,.@-]{2,64}$
+                                                      type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
+                                                    tags:
+                                                      description: |-
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
+                                                      items:
+                                                        description: |-
+                                                          AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                          attribution. Exactly one of value and expression must be set.
+                                                        properties:
+                                                          expression:
+                                                            description: |-
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
+                                                            maxLength: 16384
+                                                            minLength: 1
+                                                            type: string
+                                                          key:
+                                                            description: Key is the
+                                                              tag key.
+                                                            maxLength: 128
+                                                            minLength: 1
+                                                            type: string
+                                                          value:
+                                                            description: Value is
+                                                              a static tag value.
+                                                            maxLength: 256
+                                                            type: string
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                        x-kubernetes-validations:
+                                                        - message: exactly one of
+                                                            value or expression must
+                                                            be set
+                                                          rule: has(self.value) !=
+                                                            has(self.expression)
+                                                      maxItems: 50
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                      - key
+                                                      x-kubernetes-list-type: map
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
+                                                region:
+                                                  description: |-
+                                                    AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                    target AWS service is in a different region than the gateway. If unset,
+                                                    typed AWS backends may provide this automatically; otherwise the ambient
+                                                    AWS region is used.
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -9644,136 +10873,16 @@ spec:
                                               - message: secretRef and assumeRole
                                                   are mutually exclusive
                                                 rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
-                                            gcp:
-                                              description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
-                                              properties:
-                                                audience:
-                                                  description: |-
-                                                    Explicit `aud` value for the ID token. Only
-                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                    derived from the backend hostname.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                type:
-                                                  description: |-
-                                                    The type of token to generate. To authenticate to GCP services,
-                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                    `IdToken` is used.
-                                                  enum:
-                                                  - AccessToken
-                                                  - IdToken
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: audience is only valid with
-                                                  IdToken
-                                                rule: 'has(self.audience) ? self.type
-                                                  == ''IdToken'' : true'
                                             key:
                                               description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
+                                                Inline API key to use as the value of the `Authorization` header.
+                                                This option is the least secure; usage of a `Secret` is preferred.
                                               maxLength: 2048
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where API keys are inserted. Defaults to the `Authorization` header with
+                                                the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -9787,19 +10896,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -9827,34 +10927,33 @@ spec:
                                                   must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                   == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
+                                                Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                                By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -9873,22 +10972,21 @@ spec:
                                           type: object
                                           x-kubernetes-validations:
                                           - message: location may only be set for
-                                              key or passthrough auth
+                                              key or secretRef auth
                                             rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
+                                              || has(self.secretRef) : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [key secretRef aws] must be set
+                                            rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9898,17 +10996,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -9916,12 +11007,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9938,6 +11030,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9957,6 +11050,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9968,10 +11062,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -9998,12 +11092,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -10012,15 +11101,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -10039,33 +11126,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -10123,8 +11206,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -10133,29 +11215,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -10167,27 +11237,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -10205,6 +11267,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     region:
                                       description: |-
                                         AWS region where the guardrail is deployed, for example
@@ -10240,135 +11307,13 @@ spec:
                                         Google Model Armor.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to Google Model Armor.
                                           properties:
-                                            aws:
-                                              description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
-                                              properties:
-                                                assumeRole:
-                                                  description: |-
-                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                  properties:
-                                                    roleArn:
-                                                      description: AWS IAM role ARN
-                                                        to assume.
-                                                      minLength: 1
-                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                      type: string
-                                                  required:
-                                                  - roleArn
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                serviceName:
-                                                  description: |-
-                                                    AWS SigV4 signing service name, for example
-                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                    backends may provide this automatically.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: secretRef and assumeRole
-                                                  are mutually exclusive
-                                                rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
                                             gcp:
                                               description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
+                                                Google authentication method for Model Armor. Use `gcp: {}` for default
+                                                Google credential discovery.
                                               properties:
                                                 audience:
                                                   description: |-
@@ -10380,24 +11325,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -10428,133 +11380,20 @@ spec:
                                                   IdToken
                                                 rule: 'has(self.audience) ? self.type
                                                   == ''IdToken'' : true'
-                                            key:
-                                              description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
-                                              maxLength: 2048
-                                              type: string
-                                            location:
-                                              description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
-                                              properties:
-                                                cookie:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                header:
-                                                  properties:
-                                                    name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                                      type: string
-                                                    prefix:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                queryParameter:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: exactly one of the fields
-                                                  in [header queryParameter cookie]
-                                                  must be set
-                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
-                                                  == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
-                                            secretRef:
-                                              description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
-                                              properties:
-                                                group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
-                                                  type: string
-                                                kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
-                                                  type: string
-                                                name:
-                                                  description: The name of the referenced
-                                                    credential.
-                                                  maxLength: 253
-                                                  minLength: 1
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                              x-kubernetes-validations:
-                                              - message: custom credential refs must
-                                                  set both group and kind
-                                                rule: '(!has(self.group) || size(self.group)
-                                                  == 0) ? (!has(self.kind) || size(self.kind)
-                                                  == 0 || self.kind == ''Secret'')
-                                                  : (has(self.kind) && size(self.kind)
-                                                  > 0)'
                                           type: object
                                           x-kubernetes-validations:
-                                          - message: location may only be set for
-                                              key or passthrough auth
-                                            rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [gcp] must be set
+                                            rule: '[has(self.gcp)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -10564,17 +11403,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -10582,12 +11414,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -10604,6 +11437,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -10623,6 +11457,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -10634,10 +11469,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -10664,12 +11499,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -10678,15 +11508,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -10705,33 +11533,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -10789,8 +11613,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -10799,29 +11622,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -10833,27 +11644,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -10871,6 +11674,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     projectId:
                                       description: Google Cloud project ID.
                                       maxLength: 256
@@ -10965,29 +11773,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -10998,27 +11794,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -11051,51 +11837,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -11104,6 +11865,17 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                    headers:
+                                      additionalProperties:
+                                        description: A Common Expression Language
+                                          (CEL) expression.
+                                        maxLength: 16384
+                                        minLength: 1
+                                        type: string
+                                      description: CEL-computed headers to include
+                                        in webhook requests.
+                                      maxProperties: 64
+                                      type: object
                                   required:
                                   - backendRef
                                   type: object
@@ -11172,11 +11944,9 @@ spec:
                               minLength: 1
                               type: string
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field to set.
                               maxLength: 256
+                              minLength: 1
                               type: string
                           required:
                           - expression
@@ -11193,7 +11963,7 @@ spec:
                       rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                         >= 1'
                   auth:
-                    description: Settings for managing authentication to the backend.
+                    description: Settings for managing authentication to the backend
                     properties:
                       aws:
                         description: |-
@@ -11210,28 +11980,92 @@ spec:
                                 minLength: 1
                                 pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                 type: string
+                              sessionName:
+                                description: |-
+                                  SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                  Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                pattern: ^[\w+=,.@-]{2,64}$
+                                type: string
+                              sessionNameExpression:
+                                description: |-
+                                  SessionNameExpression is a CEL expression evaluated against each request
+                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                  session name at request time, the request is rejected.
+                                maxLength: 16384
+                                minLength: 1
+                                type: string
+                              tags:
+                                description: |-
+                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                  & Usage Report, once activated. STS allows at most 50 per role session.
+                                items:
+                                  description: |-
+                                    AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                    attribution. Exactly one of value and expression must be set.
+                                  properties:
+                                    expression:
+                                      description: |-
+                                        CEL expression evaluated against each request to produce the tag value,
+                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                        tag values are rejected.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                    key:
+                                      description: Key is the tag key.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value is a static tag value.
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: exactly one of value or expression must
+                                      be set
+                                    rule: has(self.value) != has(self.expression)
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
                             required:
                             - roleArn
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [sessionName sessionNameExpression]
+                                may be set
+                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                <= 1'
+                          region:
+                            description: |-
+                              AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                              target AWS service is in a different region than the gateway. If unset,
+                              typed AWS backends may provide this automatically; otherwise the ambient
+                              AWS region is used.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the AWS credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                              optionally `sessionToken`.
+                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                              `sessionToken` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -11277,23 +12111,20 @@ spec:
                             type: object
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the Azure credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                              `clientSecret`.
+                              Credential source for Azure credentials, defaulting to a Kubernetes
+                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                              `clientSecret` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -11308,6 +12139,695 @@ spec:
                                 (!has(self.kind) || size(self.kind) == 0 || self.kind
                                 == ''Secret'') : (has(self.kind) && size(self.kind)
                                 > 0)'
+                          workloadIdentity:
+                            description: |-
+                              Workload identity authentication settings. Uses the federated token and
+                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                              Workload Identity enabled.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: at most one of the fields in [secretRef managedIdentity
+                            workloadIdentity] may be set
+                          rule: '[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size()
+                            <= 1'
+                      credentials:
+                        description: |-
+                          Credentials is a list of additional credentials to inject on the
+                          backend request. Each entry resolves a Secret key and writes its value
+                          to the entry's location. `credentials` is independent of the primary
+                          `key`/`secretRef`/`passthrough` mechanism and may be set on its own or
+                          alongside it.
+                        items:
+                          description: |-
+                            BackendAuthCredential specifies one additional credential to inject on the
+                            backend request.
+                          properties:
+                            location:
+                              description: Where the credential is inserted on the
+                                backend request.
+                              properties:
+                                cookie:
+                                  properties:
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                header:
+                                  properties:
+                                    name:
+                                      description: Name of an HTTP header. HTTP/2
+                                        pseudo-headers (names beginning with `:`)
+                                        are not supported
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    prefix:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryParameter:
+                                  properties:
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: exactly one of the fields in [header queryParameter
+                                  cookie] must be set
+                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                  == 1'
+                            secretRef:
+                              description: |-
+                                SecretRef references a Kubernetes Secret holding the credential value, and
+                                optionally overrides the key read from it. Defaults to `Authorization`,
+                                matching the key convention used by the top-level `secretRef`.
+                              properties:
+                                group:
+                                  description: API group of the referenced credential;
+                                    empty selects the core API group
+                                  type: string
+                                key:
+                                  description: Key in the referenced Secret. If omitted,
+                                    a location-specific default is used
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                kind:
+                                  description: Kind of the referenced credential;
+                                    empty defaults to `Secret`
+                                  type: string
+                                name:
+                                  description: Name of the referenced credential
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                              x-kubernetes-validations:
+                              - message: custom credential refs must set both group
+                                  and kind
+                                rule: '(!has(self.group) || size(self.group) == 0)
+                                  ? (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                  == ''Secret'') : (has(self.kind) && size(self.kind)
+                                  > 0)'
+                          required:
+                          - location
+                          - secretRef
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      crossAppAccess:
+                        description: Cross App Access (Identity Assertion / ID-JAG)
+                          authentication.
+                        properties:
+                          audience:
+                            description: Identifier of the resource authorization
+                              server. The issued ID-JAG is bound to this audience.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          cache:
+                            description: Response cache configuration.
+                            properties:
+                              inMemory:
+                                properties:
+                                  defaultTtl:
+                                    description: TTL used when the token endpoint
+                                      omits expires_in. Default 300s.
+                                    type: string
+                                  maxEntries:
+                                    description: Default 8192; 0 disables the cache.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          identityProvider:
+                            description: User identity provider authorization server,
+                              used for the RFC 8693 ID-JAG exchange.
+                            properties:
+                              backendRef:
+                                description: Token endpoint backend.
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              clientAuth:
+                                description: Client authentication for the token endpoint.
+                                properties:
+                                  clientId:
+                                    description: Client ID sent to the token endpoint.
+                                    minLength: 1
+                                    type: string
+                                  method:
+                                    description: Client authentication method. Defaults
+                                      to ClientSecretBasic.
+                                    enum:
+                                    - ClientSecretBasic
+                                    - ClientSecretPost
+                                    - PrivateKeyJwt
+                                    type: string
+                                  privateKeyJwt:
+                                    description: Client assertion settings. Required
+                                      when method is PrivateKeyJwt.
+                                    properties:
+                                      alg:
+                                        description: JWS signing algorithm. Defaults
+                                          to RS256.
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - PS256
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      assertionAudience:
+                                        description: Audience for the client assertion,
+                                          typically the token endpoint URL.
+                                        minLength: 1
+                                        type: string
+                                      certificateHeader:
+                                        description: JWS certificate header. Required
+                                          when certificateRef is set.
+                                        enum:
+                                        - x5c
+                                        - x5t#S256
+                                        type: string
+                                      certificateRef:
+                                        description: |-
+                                          PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                          leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                          but the token endpoint will reject the assertions. Required when
+                                          certificateHeader is set. The key defaults to `certificate`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                      kid:
+                                        description: Optional JWS key ID header.
+                                        type: string
+                                      signingKeyRef:
+                                        description: PEM-encoded RSA or EC private
+                                          key; key defaults to `signingKey`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                    required:
+                                    - assertionAudience
+                                    - signingKeyRef
+                                    type: object
+                                    x-kubernetes-validations:
+                                    - message: certificateRef and certificateHeader
+                                        must be set together
+                                      rule: has(self.certificateRef) == has(self.certificateHeader)
+                                  secretRef:
+                                    description: |-
+                                      Secret providing the `clientSecret` key by default; override via
+                                      `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                      is only valid with ClientSecretPost.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - clientId
+                                type: object
+                                x-kubernetes-validations:
+                                - message: privateKeyJwt settings require method PrivateKeyJwt
+                                  rule: has(self.privateKeyJwt) == (has(self.method)
+                                    && self.method == 'PrivateKeyJwt')
+                                - message: secretRef is not valid with method PrivateKeyJwt
+                                  rule: '!has(self.secretRef) || !has(self.method)
+                                    || self.method != ''PrivateKeyJwt'''
+                                - message: clientAuth without secretRef requires method
+                                    ClientSecretPost or PrivateKeyJwt
+                                  rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                    || (has(self.method) && self.method == 'ClientSecretPost')
+                              path:
+                                description: Token endpoint path; defaults to "/".
+                                  Must start with "/".
+                                pattern: ^/
+                                type: string
+                            required:
+                            - backendRef
+                            - clientAuth
+                            type: object
+                          resourceAuthorizationServer:
+                            description: Resource authorization server, used for the
+                              RFC 7523 jwt-bearer exchange.
+                            properties:
+                              backendRef:
+                                description: Token endpoint backend.
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              clientAuth:
+                                description: Client authentication for the token endpoint.
+                                properties:
+                                  clientId:
+                                    description: Client ID sent to the token endpoint.
+                                    minLength: 1
+                                    type: string
+                                  method:
+                                    description: Client authentication method. Defaults
+                                      to ClientSecretBasic.
+                                    enum:
+                                    - ClientSecretBasic
+                                    - ClientSecretPost
+                                    - PrivateKeyJwt
+                                    type: string
+                                  privateKeyJwt:
+                                    description: Client assertion settings. Required
+                                      when method is PrivateKeyJwt.
+                                    properties:
+                                      alg:
+                                        description: JWS signing algorithm. Defaults
+                                          to RS256.
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - PS256
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      assertionAudience:
+                                        description: Audience for the client assertion,
+                                          typically the token endpoint URL.
+                                        minLength: 1
+                                        type: string
+                                      certificateHeader:
+                                        description: JWS certificate header. Required
+                                          when certificateRef is set.
+                                        enum:
+                                        - x5c
+                                        - x5t#S256
+                                        type: string
+                                      certificateRef:
+                                        description: |-
+                                          PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                          leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                          but the token endpoint will reject the assertions. Required when
+                                          certificateHeader is set. The key defaults to `certificate`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                      kid:
+                                        description: Optional JWS key ID header.
+                                        type: string
+                                      signingKeyRef:
+                                        description: PEM-encoded RSA or EC private
+                                          key; key defaults to `signingKey`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                    required:
+                                    - assertionAudience
+                                    - signingKeyRef
+                                    type: object
+                                    x-kubernetes-validations:
+                                    - message: certificateRef and certificateHeader
+                                        must be set together
+                                      rule: has(self.certificateRef) == has(self.certificateHeader)
+                                  secretRef:
+                                    description: |-
+                                      Secret providing the `clientSecret` key by default; override via
+                                      `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                      is only valid with ClientSecretPost.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - clientId
+                                type: object
+                                x-kubernetes-validations:
+                                - message: privateKeyJwt settings require method PrivateKeyJwt
+                                  rule: has(self.privateKeyJwt) == (has(self.method)
+                                    && self.method == 'PrivateKeyJwt')
+                                - message: secretRef is not valid with method PrivateKeyJwt
+                                  rule: '!has(self.secretRef) || !has(self.method)
+                                    || self.method != ''PrivateKeyJwt'''
+                                - message: clientAuth without secretRef requires method
+                                    ClientSecretPost or PrivateKeyJwt
+                                  rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                    || (has(self.method) && self.method == 'ClientSecretPost')
+                              path:
+                                description: Token endpoint path; defaults to "/".
+                                  Must start with "/".
+                                pattern: ^/
+                                type: string
+                            required:
+                            - backendRef
+                            - clientAuth
+                            type: object
+                          resources:
+                            description: Resources sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          scopes:
+                            description: Scopes sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          subjectToken:
+                            description: |-
+                              Subject token sent to the identity provider. Defaults to an OpenID Connect
+                              ID token read from the Authorization Bearer header.
+                            properties:
+                              source:
+                                description: Where to read the subject token. Defaults
+                                  to the Authorization Bearer header.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                            type: object
+                        required:
+                        - audience
+                        - identityProvider
+                        - resourceAuthorizationServer
                         type: object
                       gcp:
                         description: |-
@@ -11324,23 +12844,27 @@ spec:
                             type: string
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing ADC-compatible Google credential JSON. When using
-                              the default Secret resolver, this must be stored in the `credentials.json`
-                              key. When omitted, ambient credentials are used.
+                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                              a Kubernetes `Secret`. By default, the value is read from
+                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                              ambient credentials are used.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              key:
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
+                                maxLength: 253
+                                minLength: 1
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -11379,7 +12903,7 @@ spec:
                         description: |-
                           Where backend credentials are inserted.
                           If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                          This applies to `key`, `secretRef`, and `passthrough`.
+                          This applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.
                         properties:
                           cookie:
                             properties:
@@ -11393,19 +12917,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11432,33 +12945,526 @@ spec:
                             cookie] must be set
                           rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                             == 1'
+                      oauthTokenExchange:
+                        description: OAuth 2.0 token exchange (RFC 8693) / jwt-bearer
+                          (RFC 7523) authentication.
+                        properties:
+                          actorToken:
+                            description: RFC 8693 delegation actor token. TokenExchange
+                              grant only.
+                            properties:
+                              mayAct:
+                                description: may_act claim validation mode. When omitted,
+                                  may_act is not enforced.
+                                enum:
+                                - Required
+                                type: string
+                              source:
+                                description: Where to read the actor token. Actor
+                                  tokens have no default source.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                              tokenType:
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for actor tokens.
+                                type: string
+                            required:
+                            - source
+                            type: object
+                            x-kubernetes-validations:
+                            - message: mayAct Required requires tokenType Jwt
+                              rule: '!has(self.mayAct) || self.mayAct != ''Required''
+                                || (has(self.tokenType) && self.tokenType == ''Jwt'')'
+                          additionalParams:
+                            additionalProperties:
+                              description: A Common Expression Language (CEL) expression.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                            description: Extra form params; values are CEL expressions
+                              over the incoming request.
+                            maxProperties: 64
+                            type: object
+                          audiences:
+                            description: Audiences sent to the token endpoint.
+                            items:
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          backendRef:
+                            description: RFC 8693 token endpoint backend.
+                            properties:
+                              group:
+                                default: ""
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Service
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                              port:
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                ? has(self.port) : true'
+                          cache:
+                            description: Response cache configuration.
+                            properties:
+                              inMemory:
+                                properties:
+                                  defaultTtl:
+                                    description: TTL used when the token endpoint
+                                      omits expires_in. Default 300s.
+                                    type: string
+                                  maxEntries:
+                                    description: Default 8192; 0 disables the cache.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          clientAuth:
+                            description: Client authentication for the token endpoint.
+                              When unset, none is sent.
+                            properties:
+                              clientId:
+                                description: Client ID sent to the token endpoint.
+                                minLength: 1
+                                type: string
+                              method:
+                                description: Client authentication method. Defaults
+                                  to ClientSecretBasic.
+                                enum:
+                                - ClientSecretBasic
+                                - ClientSecretPost
+                                - PrivateKeyJwt
+                                type: string
+                              privateKeyJwt:
+                                description: Client assertion settings. Required when
+                                  method is PrivateKeyJwt.
+                                properties:
+                                  alg:
+                                    description: JWS signing algorithm. Defaults to
+                                      RS256.
+                                    enum:
+                                    - ES256
+                                    - ES384
+                                    - PS256
+                                    - RS256
+                                    - RS384
+                                    - RS512
+                                    type: string
+                                  assertionAudience:
+                                    description: Audience for the client assertion,
+                                      typically the token endpoint URL.
+                                    minLength: 1
+                                    type: string
+                                  certificateHeader:
+                                    description: JWS certificate header. Required
+                                      when certificateRef is set.
+                                    enum:
+                                    - x5c
+                                    - x5t#S256
+                                    type: string
+                                  certificateRef:
+                                    description: |-
+                                      PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                      leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                      but the token endpoint will reject the assertions. Required when
+                                      certificateHeader is set. The key defaults to `certificate`.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                  kid:
+                                    description: Optional JWS key ID header.
+                                    type: string
+                                  signingKeyRef:
+                                    description: PEM-encoded RSA or EC private key;
+                                      key defaults to `signingKey`.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - assertionAudience
+                                - signingKeyRef
+                                type: object
+                                x-kubernetes-validations:
+                                - message: certificateRef and certificateHeader must
+                                    be set together
+                                  rule: has(self.certificateRef) == has(self.certificateHeader)
+                              secretRef:
+                                description: |-
+                                  Secret providing the `clientSecret` key by default; override via
+                                  `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                  is only valid with ClientSecretPost.
+                                properties:
+                                  group:
+                                    description: API group of the referenced credential;
+                                      empty selects the core API group
+                                    type: string
+                                  key:
+                                    description: Key in the referenced Secret. If
+                                      omitted, a location-specific default is used
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  kind:
+                                    description: Kind of the referenced credential;
+                                      empty defaults to `Secret`
+                                    type: string
+                                  name:
+                                    description: Name of the referenced credential
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                                x-kubernetes-validations:
+                                - message: custom credential refs must set both group
+                                    and kind
+                                  rule: '(!has(self.group) || size(self.group) ==
+                                    0) ? (!has(self.kind) || size(self.kind) == 0
+                                    || self.kind == ''Secret'') : (has(self.kind)
+                                    && size(self.kind) > 0)'
+                            required:
+                            - clientId
+                            type: object
+                            x-kubernetes-validations:
+                            - message: privateKeyJwt settings require method PrivateKeyJwt
+                              rule: has(self.privateKeyJwt) == (has(self.method) &&
+                                self.method == 'PrivateKeyJwt')
+                            - message: secretRef is not valid with method PrivateKeyJwt
+                              rule: '!has(self.secretRef) || !has(self.method) ||
+                                self.method != ''PrivateKeyJwt'''
+                            - message: clientAuth without secretRef requires method
+                                ClientSecretPost or PrivateKeyJwt
+                              rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                || (has(self.method) && self.method == 'ClientSecretPost')
+                          grantType:
+                            description: RFC followed by the request. Defaults to
+                              TokenExchange (RFC 8693).
+                            enum:
+                            - JwtBearer
+                            - TokenExchange
+                            type: string
+                          location:
+                            description: |-
+                              Where the exchanged token is written to the backend request.
+                              Defaults to Authorization: Bearer.
+                            properties:
+                              cookie:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              header:
+                                properties:
+                                  name:
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  prefix:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              queryParameter:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of the fields in [header queryParameter
+                                cookie] must be set
+                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                == 1'
+                          path:
+                            description: Token endpoint path; defaults to "/". Must
+                              start with "/".
+                            pattern: ^/
+                            type: string
+                          requestedTokenType:
+                            description: |-
+                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                              built-in values may be requested; custom URIs are not supported here.
+                            enum:
+                            - AccessToken
+                            - Jwt
+                            - IdToken
+                            - IdJag
+                            type: string
+                          resources:
+                            description: Resources sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          scopes:
+                            description: Scopes sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          subjectToken:
+                            description: |-
+                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                              The token type may be a built-in value or a custom absolute URI for providers
+                              that support custom token exchange profiles.
+                            properties:
+                              source:
+                                description: Where to read the token. CEL `expression`
+                                  variant is permitted.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                              tokenType:
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for subject tokens.
+                                type: string
+                            type: object
+                        required:
+                        - backendRef
+                        type: object
+                        x-kubernetes-validations:
+                        - message: actorToken is only valid with TokenExchange grantType
+                          rule: '!(has(self.actorToken) && has(self.grantType) &&
+                            self.grantType == ''JwtBearer'')'
+                        - message: requestedTokenType is only valid with TokenExchange
+                            grantType
+                          rule: '!(has(self.requestedTokenType) && has(self.grantType)
+                            && self.grantType == ''JwtBearer'')'
+                        - message: requestedTokenType IdJag is only supported by crossAppAccess
+                          rule: '!has(self.requestedTokenType) || self.requestedTokenType
+                            != ''IdJag'''
                       passthrough:
                         description: |-
-                          Passes through an existing token that has been sent by the
-                          client and validated. Other policies, like JWT and API key
-                          authentication, will strip the original client credentials. Passthrough backend authentication
-                          causes the original token to be added back into the request. If there are no client authentication policies on the
-                          request, the original token would be unchanged, so this would have no effect.
+                          Reuses a client token already validated by another policy. Those policies
+                          may strip client credentials; passthrough adds the original token back to
+                          the backend request. Without client auth policies, this has no effect.
                         type: object
                       secretRef:
                         description: |-
-                          Credential source, defaulting to a Kubernetes
-                          `Secret`, storing the key to use as the authorization value. When using
-                          the default Secret resolver, this must be stored in the `Authorization`
-                          key.
+                          Credential source for the authorization value, defaulting to a Kubernetes
+                          `Secret`. By default, the value is read from the `Authorization` key; set
+                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                          the default `Authorization` key.
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
+                            type: string
+                          key:
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
+                            maxLength: 253
+                            minLength: 1
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -11474,13 +13480,19 @@ spec:
                             (has(self.kind) && size(self.kind) > 0)'
                     type: object
                     x-kubernetes-validations:
-                    - message: location may only be set for key or passthrough auth
+                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                        (credentials may be combined with a primary auth kind)
+                      rule: has(self.credentials) || has(self.key) || has(self.secretRef)
+                        || has(self.passthrough) || has(self.aws) || has(self.azure)
+                        || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                    - message: location may only be set for key, secretRef, or passthrough
+                        auth
                       rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
                         || has(self.passthrough) : true'
-                    - message: exactly one of the fields in [key secretRef passthrough
-                        aws azure gcp] must be set
-                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
-                        == 1'
+                    - message: at most one of the fields in [key secretRef passthrough
+                        aws azure gcp oauthTokenExchange crossAppAccess] may be set
+                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                        <= 1'
                   extAuth:
                     description: |-
                       External authentication configuration for requests
@@ -11494,29 +13506,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -11527,27 +13525,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -11561,7 +13548,7 @@ spec:
                             ? has(self.port) : true'
                       cache:
                         description: |-
-                          Caches gRPC authorization results.
+                          Caches authorization results.
 
                           WARNING: the safety of this feature depends on the cache key accurately
                           capturing every request property that the authorization service uses to
@@ -11710,6 +13697,13 @@ spec:
                               type: string
                             maxItems: 64
                             type: array
+                          body:
+                            description: |-
+                              Body is a CEL expression that produces the HTTP authorization request body.
+                              Strings and bytes are used directly; other values are JSON-encoded.
+                            maxLength: 16384
+                            minLength: 1
+                            type: string
                           path:
                             description: |-
                               Path to send to the authorization server. If
@@ -11745,8 +13739,8 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-validations:
-                    - message: cache requires grpc
-                      rule: '!has(self.cache) || has(self.grpc)'
+                    - message: forwardBody cannot be used with http.body
+                      rule: '!(has(self.forwardBody) && has(self.http) && has(self.http.body))'
                   health:
                     description: Settings for passive and active health checking.
                     properties:
@@ -11770,6 +13764,7 @@ spec:
                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                               rather than failing entirely.
                               If unset, defaults to `3s`.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -11778,13 +13773,12 @@ spec:
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
-                              EWMA health score threshold, expressed as 0 to 100.
-                              When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-                              For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-                              Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-                              so a single success in a stream of failures can delay eviction.
-                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-                              When neither is set, a single unhealthy response triggers eviction.
+                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                              only if its computed health drops below this value after an unhealthy
+                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                              consecutiveFailures, this sliding-window average lets a single success delay
+                              eviction. If both are set, either condition evicts; if neither, a single
+                              unhealthy response evicts.
                             format: int32
                             maximum: 100
                             minimum: 0
@@ -11813,10 +13807,11 @@ spec:
                         type: string
                     type: object
                   http:
-                    description: Settings for managing HTTP requests to the backend.
+                    description: Settings for managing HTTP requests to the backend
                     properties:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -11825,17 +13820,10 @@ spec:
                           rule: duration(self) >= duration('1ms')
                       version:
                         description: |-
-                          HTTP protocol version to use when connecting to
-                          the backend.
-                          If not specified, the version is automatically determined:
-                          * `Service` types can specify it with `appProtocol` on the `Service`
-                            port.
-                          * If traffic is identified as gRPC, `HTTP2` is used.
-                          * If the incoming traffic was plaintext HTTP, the original protocol will
-                            be used.
-                          * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                            because most clients will transparently upgrade HTTPS traffic to
-                            `HTTP2`, even if the backend doesn't support it.
+                          HTTP protocol version for backend connections. If unset, it is inferred:
+                          `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                          plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                          to HTTP/2 even when the backend does not support it.
                         enum:
                         - HTTP1
                         - HTTP2
@@ -11869,6 +13857,44 @@ spec:
                               Client ID to use for short-circuiting Dynamic Client Registration.
                               If set, the gateway will not proxy registration requests to the IDP and instead return this client ID.
                             type: string
+                          clientSecretRef:
+                            description: |-
+                              Reference to a Kubernetes Secret holding the OAuth client secret of the app
+                              registration identified by `clientId` (for example Entra ID confidential clients,
+                              which require the secret at the token endpoint). The gateway injects it into the
+                              token requests it proxies to the provider. Defaults to the `clientSecret` key;
+                              override via `clientSecretRef.key`.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              key:
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
                           issuer:
                             description: |-
                               IdP that issued the JWT. This corresponds to the
@@ -11891,29 +13917,16 @@ spec:
                                 properties:
                                   group:
                                     default: ""
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   kind:
                                     default: Service
-                                    description: |-
-                                      Kind is the Kubernetes resource kind of the referent. For example
-                                      "Service".
-
-                                      Defaults to "Service" when not specified.
-
-                                      ExternalName services can refer to CNAME DNS records that may live
-                                      outside of the cluster and as such are difficult to reason about in
-                                      terms of conformance. They also may not be safe to forward to (see
-                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                      support ExternalName Services.
-
-                                      Support: Core (Services with a type other than ExternalName)
-
-                                      Support: Implementation-specific (Services with type ExternalName)
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -11924,27 +13937,16 @@ spec:
                                     minLength: 1
                                     type: string
                                   namespace:
-                                    description: |-
-                                      Namespace is the namespace of the backend. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   port:
-                                    description: |-
-                                      Port specifies the destination port number to use for this resource.
-                                      Port is required when the referent is a Kubernetes Service. In this
-                                      case, the port number is the service port number, not the target port.
-                                      For other resources, destination port might be derived from the referent
-                                      resource or this field.
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -11958,6 +13960,7 @@ spec:
                                     ? has(self.port) : true'
                               cacheDuration:
                                 default: 5m
+                                maxLength: 32
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid duration value
@@ -11987,6 +13990,9 @@ spec:
                             description: Identity provider to use for authentication.
                             enum:
                             - Auth0
+                            - Authentik
+                            - Descope
+                            - Entra
                             - Keycloak
                             - Okta
                             type: string
@@ -12029,8 +14035,8 @@ spec:
                               * `Require`: every require rule must match for the request to be allowed.
                               * `Deny`: any matching deny rule denies the request.
 
-                              A CEL expression that fails to evaluate does not match. Prefer `Require`
-                              for deny-by-default behavior.
+                              `Deny` is not recommended because expression failures fail to deny; prefer
+                              `Allow` or `Require`. If used, design expressions defensively against evaluation errors.
 
                               If at least one `Allow` rule is configured, requests are denied unless at
                               least one allow rule matches.
@@ -12123,29 +14129,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -12156,27 +14150,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -12254,12 +14238,13 @@ spec:
                       rule: '[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size()
                         >= 1'
                   tcp:
-                    description: Settings for managing TCP connections to the backend.
+                    description: Settings for managing TCP connections to the backend
                     properties:
                       connectTimeout:
                         description: |-
                           Deadline for establishing a connection to
                           the destination.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -12275,6 +14260,7 @@ spec:
                             description: |-
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -12293,6 +14279,7 @@ spec:
                             description: |-
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -12303,10 +14290,10 @@ spec:
                     type: object
                   tls:
                     description: |-
-                      Settings for managing TLS connections to the backend.
+                      Settings for managing TLS connections to the backend
 
-                      If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                      validate the server, and the SNI will automatically be set based on the destination.
+                      When set, TLS is originated to the backend using the system trusted CA
+                      certificates, and SNI is inferred from the destination.
                     properties:
                       alpnProtocols:
                         description: |-
@@ -12333,12 +14320,7 @@ spec:
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -12347,15 +14329,13 @@ spec:
                         x-kubernetes-list-type: atomic
                       insecureSkipVerify:
                         description: |-
-                          Originates TLS but skips verification of the backend's certificate.
-                          WARNING: This is an insecure option that should only be used if the risks are understood.
+                          Originates TLS but skips verification of the backend's certificate
+                          WARNING: insecure; only use if the risks are understood
 
-                          There are two modes:
-                          * `All` disables all TLS verification.
-                          * `Hostname` verifies the CA certificate is trusted, but ignores any
-                            mismatch of hostname or SANs. Note that this method is still insecure;
-                            prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                            if possible.
+                          Modes:
+                          * `All` disables all TLS verification
+                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                            Still insecure; prefer `verifySubjectAltNames` where possible.
                         enum:
                         - All
                         - Hostname
@@ -12374,32 +14354,26 @@ spec:
                         type: array
                       mtlsCertificateRef:
                         description: |-
-                          Enables mutual TLS to the backend, using the
-                          specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                          credential source, defaulting to a Kubernetes `Secret`.
-
-                          An optional `ca.cert` field, if present, will be used to verify the
-                          server certificate. If `caCertificateRefs` is also specified, the
-                          `caCertificateRefs` field takes priority.
-
-                          If unspecified, no client certificate will be used.
+                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                          optional `ca.cert`, if present, verifies the server certificate, but
+                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                          is used.
                         items:
                           description: |-
-                            References a same-namespace credential.
-                            Set only `name` to reference a Kubernetes Secret.
+                            References a same-namespace credential
+                            Set only `name` for a Kubernetes Secret
                           properties:
                             group:
-                              description: |-
-                                The API group of the referenced credential.
-                                Empty selects the core API group.
+                              description: API group of the referenced credential;
+                                empty selects the core API group
                               type: string
                             kind:
-                              description: |-
-                                The kind of the referenced credential.
-                                Empty defaults to `Secret`.
+                              description: Kind of the referenced credential; empty
+                                defaults to `Secret`
                               type: string
                             name:
-                              description: The name of the referenced credential.
+                              description: Name of the referenced credential
                               maxLength: 253
                               minLength: 1
                               type: string
@@ -12688,8 +14662,8 @@ spec:
                       rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
                         >= 1'
                   tunnel:
-                    description: Settings for managing tunnel connections, with behavior
-                      like `HTTPS_PROXY`, to the backend.
+                    description: Settings for managing tunnel connections to the backend,
+                      like `HTTPS_PROXY`
                     properties:
                       backendRef:
                         description: |-
@@ -12698,29 +14672,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -12731,27 +14691,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -1,0 +1,5066 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app: agentgateway
+    app.kubernetes.io/name: agentgateway
+  name: agentgatewaymodels.agentgateway.dev
+spec:
+  group: agentgateway.dev
+  names:
+    categories:
+    - agentgateway
+    kind: AgentgatewayModel
+    listKind: AgentgatewayModelList
+    plural: agentgatewaymodels
+    shortNames:
+    - agmodel
+    singular: agentgatewaymodel
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Model name matched from client requests
+      jsonPath: .spec.match.model
+      name: Model Match
+      type: string
+    - description: The age of the model.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired model configuration.
+            properties:
+              azure:
+                description: Provider-specific settings for Azure AI.
+                properties:
+                  apiVersion:
+                    description: |-
+                      The version of the Azure OpenAI API to use.
+                      If unset, defaults to `v1`.
+                    maxLength: 64
+                    minLength: 1
+                    type: string
+                  projectName:
+                    description: |-
+                      The Foundry project name, required when `resourceType` is `Foundry`.
+                      Used to construct paths: /api/projects/{projectName}/openai/v1/...
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  resourceName:
+                    description: |-
+                      The Azure resource name used to construct the endpoint host.
+                      For OpenAI: {resourceName}.openai.azure.com
+                      For Foundry: {resourceName}.services.ai.azure.com
+                      Note: when the Azure portal "Foundry legacy" template was used, the
+                      generated resource name may end in "-resource" (e.g. "myproject-resource");
+                      that suffix is part of the resource name as the user configured it, not
+                      part of the hostname suffix agentgateway should append.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  resourceType:
+                    description: The type of Azure endpoint. Determines the host suffix.
+                    enum:
+                    - Foundry
+                    - OpenAI
+                    type: string
+                required:
+                - resourceName
+                - resourceType
+                type: object
+                x-kubernetes-validations:
+                - message: projectName is required when resourceType is Foundry
+                  rule: self.resourceType != 'Foundry' || has(self.projectName)
+              baseURL:
+                description: |-
+                  BaseURL overrides the provider address and base path prefix. It must use the
+                  http or https scheme. Backend policies may override the default TLS
+                  configuration. Query parameters, fragments, and user info are not supported.
+                format: uri
+                maxLength: 1024
+                minLength: 1
+                type: string
+              bedrock:
+                description: Provider-specific settings for Amazon Bedrock.
+                properties:
+                  guardrail:
+                    description: |-
+                      Guardrail policy to use for the backend. See
+                      <https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html>.
+                      If not specified, the AWS Guardrail policy will not be used.
+                    properties:
+                      identifier:
+                        description: Identifier of the Guardrail policy to use for
+                          the backend.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      version:
+                        description: Version of the Guardrail policy to use for the
+                          backend.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - identifier
+                    - version
+                    type: object
+                  region:
+                    default: us-east-1
+                    description: |-
+                      AWS region to use for the backend.
+                      Defaults to `us-east-1` if not specified.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9-]+$
+                    type: string
+                type: object
+              custom:
+                description: Provider-specific settings for a custom provider.
+                properties:
+                  backendRef:
+                    description: |-
+                      Kubernetes backend that serves this provider.
+                      `backendRef` may target only a namespace-local Service or InferencePool.
+                      If unset, host and port must be set on the parent provider.
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          API group of the referenced resource. For example, `gateway.networking.k8s.io`.
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Service
+                        description: |-
+                          Kind of the referenced resource. For example, `Service`.
+                          Defaults to "Service" when not specified.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name of the referenced resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      port:
+                        description: |-
+                          Destination port number to use for this resource.
+                          Required when the referenced resource is a Kubernetes Service.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Must have port for Service reference
+                      rule: '(size(self.group) == 0 && self.kind == ''Service'') ?
+                        has(self.port) : true'
+                  formats:
+                    description: Provider-native API formats this provider supports.
+                    items:
+                      description: Provider-native LLM API format settings.
+                      properties:
+                        path:
+                          description: |-
+                            Default upstream path override for this format.
+                            If unset, agentgateway uses the default path for the format.
+                          maxLength: 1024
+                          minLength: 1
+                          type: string
+                        type:
+                          description: Provider-native API format.
+                          enum:
+                          - AnthropicTokenCount
+                          - Completions
+                          - Embeddings
+                          - Messages
+                          - Realtime
+                          - Rerank
+                          - Responses
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: path must start with /
+                        rule: '!has(self.path) || self.path.startsWith(''/'')'
+                    maxItems: 6
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                required:
+                - formats
+                type: object
+                x-kubernetes-validations:
+                - message: custom provider backendRef may target only Service or InferencePool
+                  rule: '!has(self.backendRef) || (((!has(self.backendRef.group) ||
+                    self.backendRef.group == "") && (!has(self.backendRef.kind) ||
+                    self.backendRef.kind == ''Service'')) || (has(self.backendRef.group)
+                    && self.backendRef.group == ''inference.networking.k8s.io'' &&
+                    has(self.backendRef.kind) && self.backendRef.kind == ''InferencePool''))'
+              match:
+                description: Conditions for selecting this model from client requests.
+                properties:
+                  model:
+                    description: |-
+                      Model name matched against client requests. It may be exact, a suffix
+                      wildcard such as `gpt-*`, a prefix wildcard such as `*-latest`, or `*`.
+                      When omitted, the model matches metadata.name exactly.
+                    maxLength: 1024
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: model wildcards must be '*', a suffix like 'gpt-*',
+                        or a prefix like '*-latest'
+                      rule: '!self.contains(''*'') || (self.indexOf(''*'') == self.lastIndexOf(''*'')
+                        && (self.indexOf(''*'') == 0 || self.indexOf(''*'') == size(self)
+                        - 1))'
+                type: object
+              parentRefs:
+                description: Gateways and listeners to which this model attaches.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. Defaults to the Route''s
+                        local namespace. Cross-namespace references must be explicitly
+                        allowed, for example via ReferenceGrant. Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port this Route targets on the parent, interpreted
+                        per parent kind (for example a Gateway listener port or Service
+                        port). Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'Name of a section within the target resource,
+                        for example a Gateway Listener name or Service port name.
+                        Empty references the entire resource. Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              policies:
+                description: Policies applied to this concrete model.
+                properties:
+                  auth:
+                    description: Credentials used to authenticate requests to this
+                      model provider.
+                    properties:
+                      aws:
+                        description: |-
+                          Explicit AWS authentication method for the model provider. When omitted,
+                          default AWS SDK credential discovery is used.
+                        properties:
+                          assumeRole:
+                            description: |-
+                              AWS STS AssumeRole settings to use before signing backend requests.
+                              Ambient AWS credentials are used as the source credentials for STS.
+                            properties:
+                              roleArn:
+                                description: AWS IAM role ARN to assume.
+                                minLength: 1
+                                pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
+                                type: string
+                              sessionName:
+                                description: |-
+                                  SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                  Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                pattern: ^[\w+=,.@-]{2,64}$
+                                type: string
+                              sessionNameExpression:
+                                description: |-
+                                  SessionNameExpression is a CEL expression evaluated against each request
+                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                  session name at request time, the request is rejected.
+                                maxLength: 16384
+                                minLength: 1
+                                type: string
+                              tags:
+                                description: |-
+                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                  & Usage Report, once activated. STS allows at most 50 per role session.
+                                items:
+                                  description: |-
+                                    AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                    attribution. Exactly one of value and expression must be set.
+                                  properties:
+                                    expression:
+                                      description: |-
+                                        CEL expression evaluated against each request to produce the tag value,
+                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                        tag values are rejected.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                    key:
+                                      description: Key is the tag key.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value is a static tag value.
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: exactly one of value or expression must
+                                      be set
+                                    rule: has(self.value) != has(self.expression)
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                            required:
+                            - roleArn
+                            type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [sessionName sessionNameExpression]
+                                may be set
+                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                <= 1'
+                          region:
+                            description: |-
+                              AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                              target AWS service is in a different region than the gateway. If unset,
+                              typed AWS backends may provide this automatically; otherwise the ambient
+                              AWS region is used.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          secretRef:
+                            description: |-
+                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                              `sessionToken` keys.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
+                          serviceName:
+                            description: |-
+                              AWS SigV4 signing service name, for example
+                              `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
+                              backends may provide this automatically.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: secretRef and assumeRole are mutually exclusive
+                          rule: '!(has(self.secretRef) && has(self.assumeRole))'
+                      azure:
+                        description: Azure authentication method for the model provider.
+                        properties:
+                          managedIdentity:
+                            description: Managed identity authentication settings.
+                            properties:
+                              clientId:
+                                type: string
+                              objectId:
+                                type: string
+                              resourceId:
+                                type: string
+                            required:
+                            - clientId
+                            - objectId
+                            - resourceId
+                            type: object
+                          secretRef:
+                            description: |-
+                              Credential source for Azure credentials, defaulting to a Kubernetes
+                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                              `clientSecret` keys.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
+                          workloadIdentity:
+                            description: |-
+                              Workload identity authentication settings. Uses the federated token and
+                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                              Workload Identity enabled.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: at most one of the fields in [secretRef managedIdentity
+                            workloadIdentity] may be set
+                          rule: '[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size()
+                            <= 1'
+                      credentials:
+                        description: |-
+                          Credentials is a list of additional credentials to inject on the backend
+                          request. Each entry resolves a Secret key and writes its value to the
+                          entry's location. `credentials` is independent of the primary
+                          `key`/`secretRef`/`passthrough` mechanism and may be set on its own or
+                          alongside it.
+                        items:
+                          description: |-
+                            BackendAuthCredential specifies one additional credential to inject on the
+                            backend request.
+                          properties:
+                            location:
+                              description: Where the credential is inserted on the
+                                backend request.
+                              properties:
+                                cookie:
+                                  properties:
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                header:
+                                  properties:
+                                    name:
+                                      description: Name of an HTTP header. HTTP/2
+                                        pseudo-headers (names beginning with `:`)
+                                        are not supported
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    prefix:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryParameter:
+                                  properties:
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: exactly one of the fields in [header queryParameter
+                                  cookie] must be set
+                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                  == 1'
+                            secretRef:
+                              description: |-
+                                SecretRef references a Kubernetes Secret holding the credential value, and
+                                optionally overrides the key read from it. Defaults to `Authorization`,
+                                matching the key convention used by the top-level `secretRef`.
+                              properties:
+                                group:
+                                  description: API group of the referenced credential;
+                                    empty selects the core API group
+                                  type: string
+                                key:
+                                  description: Key in the referenced Secret. If omitted,
+                                    a location-specific default is used
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                kind:
+                                  description: Kind of the referenced credential;
+                                    empty defaults to `Secret`
+                                  type: string
+                                name:
+                                  description: Name of the referenced credential
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                              x-kubernetes-validations:
+                              - message: custom credential refs must set both group
+                                  and kind
+                                rule: '(!has(self.group) || size(self.group) == 0)
+                                  ? (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                  == ''Secret'') : (has(self.kind) && size(self.kind)
+                                  > 0)'
+                          required:
+                          - location
+                          - secretRef
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      gcp:
+                        description: |-
+                          Google authentication method for the model provider. When omitted,
+                          default Google credential discovery is used.
+                        properties:
+                          audience:
+                            description: |-
+                              Explicit `aud` value for the ID token. Only
+                              valid with `IdToken` type. If not set, the `aud` is automatically
+                              derived from the backend hostname.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          secretRef:
+                            description: |-
+                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                              a Kubernetes `Secret`. By default, the value is read from
+                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                              ambient credentials are used.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              key:
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
+                          type:
+                            description: |-
+                              The type of token to generate. To authenticate to GCP services,
+                              generally an `AccessToken` is used. To authenticate to Cloud Run, an
+                              `IdToken` is used.
+                            enum:
+                            - AccessToken
+                            - IdToken
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: audience is only valid with IdToken
+                          rule: 'has(self.audience) ? self.type == ''IdToken'' : true'
+                      key:
+                        description: |-
+                          Inline key to use as the value of the `Authorization` header. This option
+                          is the least secure; usage of a `Secret` is preferred.
+                        maxLength: 2048
+                        type: string
+                      location:
+                        description: |-
+                          Where backend credentials are inserted. If omitted, credentials are
+                          written to the `Authorization` header with the `Bearer ` prefix. This
+                          applies to `key`, `secretRef`, and `passthrough`. Entries in
+                          `credentials` carry their own location.
+                        properties:
+                          cookie:
+                            properties:
+                              name:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          header:
+                            properties:
+                              name:
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                type: string
+                              prefix:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          queryParameter:
+                            properties:
+                              name:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of the fields in [header queryParameter
+                            cookie] must be set
+                          rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                            == 1'
+                      oauthTokenExchange:
+                        description: |-
+                          OAuth 2.0 token exchange (RFC 8693) / jwt-bearer (RFC 7523)
+                          authentication.
+                        properties:
+                          actorToken:
+                            description: RFC 8693 delegation actor token. TokenExchange
+                              grant only.
+                            properties:
+                              mayAct:
+                                description: may_act claim validation mode. When omitted,
+                                  may_act is not enforced.
+                                enum:
+                                - Required
+                                type: string
+                              source:
+                                description: Where to read the actor token. Actor
+                                  tokens have no default source.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                              tokenType:
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for actor tokens.
+                                type: string
+                            required:
+                            - source
+                            type: object
+                            x-kubernetes-validations:
+                            - message: mayAct Required requires tokenType Jwt
+                              rule: '!has(self.mayAct) || self.mayAct != ''Required''
+                                || (has(self.tokenType) && self.tokenType == ''Jwt'')'
+                          additionalParams:
+                            additionalProperties:
+                              description: A Common Expression Language (CEL) expression.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                            description: Extra form params; values are CEL expressions
+                              over the incoming request.
+                            maxProperties: 64
+                            type: object
+                          audiences:
+                            description: Audiences sent to the token endpoint.
+                            items:
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          backendRef:
+                            description: RFC 8693 token endpoint backend.
+                            properties:
+                              group:
+                                default: ""
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Service
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                              port:
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                ? has(self.port) : true'
+                          cache:
+                            description: Response cache configuration.
+                            properties:
+                              inMemory:
+                                properties:
+                                  defaultTtl:
+                                    description: TTL used when the token endpoint
+                                      omits expires_in. Default 300s.
+                                    type: string
+                                  maxEntries:
+                                    description: Default 8192; 0 disables the cache.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          clientAuth:
+                            description: Client authentication for the token endpoint.
+                              When unset, none is sent.
+                            properties:
+                              clientId:
+                                description: Client ID sent to the token endpoint.
+                                minLength: 1
+                                type: string
+                              method:
+                                description: Client authentication method. Defaults
+                                  to ClientSecretBasic.
+                                enum:
+                                - ClientSecretBasic
+                                - ClientSecretPost
+                                - PrivateKeyJwt
+                                type: string
+                              privateKeyJwt:
+                                description: Client assertion settings. Required when
+                                  method is PrivateKeyJwt.
+                                properties:
+                                  alg:
+                                    description: JWS signing algorithm. Defaults to
+                                      RS256.
+                                    enum:
+                                    - ES256
+                                    - ES384
+                                    - PS256
+                                    - RS256
+                                    - RS384
+                                    - RS512
+                                    type: string
+                                  assertionAudience:
+                                    description: Audience for the client assertion,
+                                      typically the token endpoint URL.
+                                    minLength: 1
+                                    type: string
+                                  certificateHeader:
+                                    description: JWS certificate header. Required
+                                      when certificateRef is set.
+                                    enum:
+                                    - x5c
+                                    - x5t#S256
+                                    type: string
+                                  certificateRef:
+                                    description: |-
+                                      PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                      leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                      but the token endpoint will reject the assertions. Required when
+                                      certificateHeader is set. The key defaults to `certificate`.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                  kid:
+                                    description: Optional JWS key ID header.
+                                    type: string
+                                  signingKeyRef:
+                                    description: PEM-encoded RSA or EC private key;
+                                      key defaults to `signingKey`.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - assertionAudience
+                                - signingKeyRef
+                                type: object
+                                x-kubernetes-validations:
+                                - message: certificateRef and certificateHeader must
+                                    be set together
+                                  rule: has(self.certificateRef) == has(self.certificateHeader)
+                              secretRef:
+                                description: |-
+                                  Secret providing the `clientSecret` key by default; override via
+                                  `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                  is only valid with ClientSecretPost.
+                                properties:
+                                  group:
+                                    description: API group of the referenced credential;
+                                      empty selects the core API group
+                                    type: string
+                                  key:
+                                    description: Key in the referenced Secret. If
+                                      omitted, a location-specific default is used
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  kind:
+                                    description: Kind of the referenced credential;
+                                      empty defaults to `Secret`
+                                    type: string
+                                  name:
+                                    description: Name of the referenced credential
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                                x-kubernetes-validations:
+                                - message: custom credential refs must set both group
+                                    and kind
+                                  rule: '(!has(self.group) || size(self.group) ==
+                                    0) ? (!has(self.kind) || size(self.kind) == 0
+                                    || self.kind == ''Secret'') : (has(self.kind)
+                                    && size(self.kind) > 0)'
+                            required:
+                            - clientId
+                            type: object
+                            x-kubernetes-validations:
+                            - message: privateKeyJwt settings require method PrivateKeyJwt
+                              rule: has(self.privateKeyJwt) == (has(self.method) &&
+                                self.method == 'PrivateKeyJwt')
+                            - message: secretRef is not valid with method PrivateKeyJwt
+                              rule: '!has(self.secretRef) || !has(self.method) ||
+                                self.method != ''PrivateKeyJwt'''
+                            - message: clientAuth without secretRef requires method
+                                ClientSecretPost or PrivateKeyJwt
+                              rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                || (has(self.method) && self.method == 'ClientSecretPost')
+                          grantType:
+                            description: RFC followed by the request. Defaults to
+                              TokenExchange (RFC 8693).
+                            enum:
+                            - JwtBearer
+                            - TokenExchange
+                            type: string
+                          location:
+                            description: |-
+                              Where the exchanged token is written to the backend request.
+                              Defaults to Authorization: Bearer.
+                            properties:
+                              cookie:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              header:
+                                properties:
+                                  name:
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  prefix:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              queryParameter:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of the fields in [header queryParameter
+                                cookie] must be set
+                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                == 1'
+                          path:
+                            description: Token endpoint path; defaults to "/". Must
+                              start with "/".
+                            pattern: ^/
+                            type: string
+                          requestedTokenType:
+                            description: |-
+                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                              built-in values may be requested; custom URIs are not supported here.
+                            enum:
+                            - AccessToken
+                            - Jwt
+                            - IdToken
+                            - IdJag
+                            type: string
+                          resources:
+                            description: Resources sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          scopes:
+                            description: Scopes sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          subjectToken:
+                            description: |-
+                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                              The token type may be a built-in value or a custom absolute URI for providers
+                              that support custom token exchange profiles.
+                            properties:
+                              source:
+                                description: Where to read the token. CEL `expression`
+                                  variant is permitted.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                              tokenType:
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for subject tokens.
+                                type: string
+                            type: object
+                        required:
+                        - backendRef
+                        type: object
+                        x-kubernetes-validations:
+                        - message: actorToken is only valid with TokenExchange grantType
+                          rule: '!(has(self.actorToken) && has(self.grantType) &&
+                            self.grantType == ''JwtBearer'')'
+                        - message: requestedTokenType is only valid with TokenExchange
+                            grantType
+                          rule: '!(has(self.requestedTokenType) && has(self.grantType)
+                            && self.grantType == ''JwtBearer'')'
+                        - message: requestedTokenType IdJag is only supported by crossAppAccess
+                          rule: '!has(self.requestedTokenType) || self.requestedTokenType
+                            != ''IdJag'''
+                      passthrough:
+                        description: |-
+                          Reuses a client token already validated by another policy. Those policies
+                          may strip client credentials; passthrough adds the original token back to
+                          the backend request. Without client auth policies, this has no effect.
+                        type: object
+                      secretRef:
+                        description: |-
+                          Credential source for the authorization value, defaulting to a Kubernetes
+                          `Secret`. By default, the value is read from the `Authorization` key; set
+                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                          the default `Authorization` key.
+                        properties:
+                          group:
+                            description: API group of the referenced credential; empty
+                              selects the core API group
+                            type: string
+                          key:
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          kind:
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
+                            type: string
+                          name:
+                            description: Name of the referenced credential
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                        - message: custom credential refs must set both group and
+                            kind
+                          rule: '(!has(self.group) || size(self.group) == 0) ? (!has(self.kind)
+                            || size(self.kind) == 0 || self.kind == ''Secret'') :
+                            (has(self.kind) && size(self.kind) > 0)'
+                    type: object
+                    x-kubernetes-validations:
+                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange
+                        (credentials may be combined with a primary auth kind)
+                      rule: has(self.credentials) || has(self.key) || has(self.secretRef)
+                        || has(self.passthrough) || has(self.aws) || has(self.azure)
+                        || has(self.gcp) || has(self.oauthTokenExchange)
+                    - message: location may only be set for key, secretRef, or passthrough
+                        auth
+                      rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
+                        || has(self.passthrough) : true'
+                    - message: at most one of the fields in [key secretRef passthrough
+                        aws azure gcp oauthTokenExchange] may be set
+                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange)].filter(x,x==true).size()
+                        <= 1'
+                  authorization:
+                    description: Authorization rules that clients must satisfy to
+                      use this model.
+                    properties:
+                      action:
+                        default: Allow
+                        description: |-
+                          The effect of this rule when it matches.
+                          If unspecified, defaults to `Allow`.
+                          `Require` rules are cumulative: all require rules must match.
+                        enum:
+                        - Allow
+                        - Deny
+                        - Require
+                        type: string
+                      policy:
+                        description: |-
+                          The authorization rule to evaluate.
+
+                          * `Allow`: any matching allow rule allows the request.
+                          * `Require`: every require rule must match for the request to be allowed.
+                          * `Deny`: any matching deny rule denies the request.
+
+                          `Deny` is not recommended because expression failures fail to deny; prefer
+                          `Allow` or `Require`. If used, design expressions defensively against evaluation errors.
+
+                          If at least one `Allow` rule is configured, requests are denied unless at
+                          least one allow rule matches.
+                        properties:
+                          matchExpressions:
+                            description: CEL expressions that must all evaluate to
+                              true for the rule to match.
+                            items:
+                              description: A Common Expression Language (CEL) expression.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                            maxItems: 256
+                            minItems: 1
+                            type: array
+                        required:
+                        - matchExpressions
+                        type: object
+                    required:
+                    - policy
+                    type: object
+                  headers:
+                    description: Request and response header changes applied to provider
+                      traffic.
+                    properties:
+                      request:
+                        description: Header changes to apply before forwarding a request.
+                        properties:
+                          add:
+                            description: |-
+                              Add adds the given header(s) (name, value) to the request
+                              before the action. It appends to any existing values associated
+                              with the header name.
+
+                              Input:
+                                GET /foo HTTP/1.1
+                                my-header: foo
+
+                              Config:
+                                add:
+                                - name: "my-header"
+                                  value: "bar,baz"
+
+                              Output:
+                                GET /foo HTTP/1.1
+                                my-header: foo,bar,baz
+                            items:
+                              description: HTTPHeader represents an HTTP Header name
+                                and value as defined by RFC 7230.
+                              properties:
+                                name:
+                                  description: Name of the HTTP header, case-insensitive
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                value:
+                                  description: Value for the HTTP header
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          remove:
+                            description: |-
+                              Remove the given header(s) from the HTTP request before the action. The
+                              value of Remove is a list of HTTP header names. Note that the header
+                              names are case-insensitive (see
+                              https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                              Input:
+                                GET /foo HTTP/1.1
+                                my-header1: foo
+                                my-header2: bar
+                                my-header3: baz
+
+                              Config:
+                                remove: ["my-header1", "my-header3"]
+
+                              Output:
+                                GET /foo HTTP/1.1
+                                my-header2: bar
+                            items:
+                              type: string
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-type: set
+                          set:
+                            description: |-
+                              Set overwrites the request with the given header (name, value)
+                              before the action.
+
+                              Input:
+                                GET /foo HTTP/1.1
+                                my-header: foo
+
+                              Config:
+                                set:
+                                - name: "my-header"
+                                  value: "bar"
+
+                              Output:
+                                GET /foo HTTP/1.1
+                                my-header: bar
+                            items:
+                              description: HTTPHeader represents an HTTP Header name
+                                and value as defined by RFC 7230.
+                              properties:
+                                name:
+                                  description: Name of the HTTP header, case-insensitive
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                value:
+                                  description: Value for the HTTP header
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      response:
+                        description: Header changes to apply before returning a response.
+                        properties:
+                          add:
+                            description: |-
+                              Add adds the given header(s) (name, value) to the request
+                              before the action. It appends to any existing values associated
+                              with the header name.
+
+                              Input:
+                                GET /foo HTTP/1.1
+                                my-header: foo
+
+                              Config:
+                                add:
+                                - name: "my-header"
+                                  value: "bar,baz"
+
+                              Output:
+                                GET /foo HTTP/1.1
+                                my-header: foo,bar,baz
+                            items:
+                              description: HTTPHeader represents an HTTP Header name
+                                and value as defined by RFC 7230.
+                              properties:
+                                name:
+                                  description: Name of the HTTP header, case-insensitive
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                value:
+                                  description: Value for the HTTP header
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          remove:
+                            description: |-
+                              Remove the given header(s) from the HTTP request before the action. The
+                              value of Remove is a list of HTTP header names. Note that the header
+                              names are case-insensitive (see
+                              https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                              Input:
+                                GET /foo HTTP/1.1
+                                my-header1: foo
+                                my-header2: bar
+                                my-header3: baz
+
+                              Config:
+                                remove: ["my-header1", "my-header3"]
+
+                              Output:
+                                GET /foo HTTP/1.1
+                                my-header2: bar
+                            items:
+                              type: string
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-type: set
+                          set:
+                            description: |-
+                              Set overwrites the request with the given header (name, value)
+                              before the action.
+
+                              Input:
+                                GET /foo HTTP/1.1
+                                my-header: foo
+
+                              Config:
+                                set:
+                                - name: "my-header"
+                                  value: "bar"
+
+                              Output:
+                                GET /foo HTTP/1.1
+                                my-header: bar
+                            items:
+                              description: HTTPHeader represents an HTTP Header name
+                                and value as defined by RFC 7230.
+                              properties:
+                                name:
+                                  description: Name of the HTTP header, case-insensitive
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                value:
+                                  description: Value for the HTTP header
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of the fields in [request response] must
+                        be set
+                      rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
+                        >= 1'
+                  health:
+                    description: Health checking and eviction behavior for this model
+                      provider.
+                    properties:
+                      eviction:
+                        description: Settings for evicting unhealthy backends.
+                        properties:
+                          consecutiveFailures:
+                            description: |-
+                              Number of consecutive unhealthy responses required before the backend is evicted.
+                              For example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.
+                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
+                              When neither is set, a single unhealthy response can trigger eviction.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          duration:
+                            default: 3s
+                            description: |-
+                              Base time a backend should be evicted after being marked unhealthy.
+                              Subsequent evictions use multiplicative backoff (duration * times_evicted).
+                              If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
+                              rather than failing entirely.
+                              If unset, defaults to `3s`.
+                            maxLength: 32
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid duration value
+                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                            - message: evictionDuration must be at least 1 second
+                              rule: duration(self) >= duration('1s')
+                          healthThreshold:
+                            description: |-
+                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                              only if its computed health drops below this value after an unhealthy
+                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                              consecutiveFailures, this sliding-window average lets a single success delay
+                              eviction. If both are set, either condition evicts; if neither, a single
+                              unhealthy response evicts.
+                            format: int32
+                            maximum: 100
+                            minimum: 0
+                            type: integer
+                          restoreHealth:
+                            description: |-
+                              Health score from 0 to 100 assigned to a backend when it returns from eviction.
+                              For gradual recovery, set below 100; for full recovery immediately, set 100.
+                              If unset, the backend resumes with the health it had when evicted.
+                            format: int32
+                            maximum: 100
+                            minimum: 0
+                            type: integer
+                        type: object
+                      unhealthyCondition:
+                        description: |-
+                          CEL expression that determines whether a response indicates an unhealthy backend.
+                          When the expression evaluates to true, the backend is considered unhealthy and may be evicted.
+
+                          For example, to evict on 5xx responses: `response.code >= 500`.
+
+                          When unset, any 5xx response, or a connection failure, is treated as unhealthy.
+                          This default lowers the backend's health score but does not trigger eviction on its own.
+                        maxLength: 16384
+                        minLength: 1
+                        type: string
+                    type: object
+                  promptGuard:
+                    description: Guardrails for requests and responses sent to this
+                      model provider.
+                    properties:
+                      request:
+                        description: Prompt guards to apply to requests sent by the
+                          client.
+                        items:
+                          description: Prompt guards to apply to requests sent by
+                            the client.
+                          properties:
+                            bedrockGuardrails:
+                              description: |-
+                                AWS Bedrock Guardrails settings for prompt
+                                guarding.
+                              properties:
+                                identifier:
+                                  description: Identifier of the Guardrail policy
+                                    to use for the backend.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                policies:
+                                  description: Policies for communicating with AWS
+                                    Bedrock Guardrails.
+                                  properties:
+                                    auth:
+                                      description: Settings for authenticating to
+                                        AWS Bedrock Guardrails.
+                                      properties:
+                                        aws:
+                                          description: |-
+                                            AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                            default AWS SDK credential discovery.
+                                          properties:
+                                            assumeRole:
+                                              description: |-
+                                                AWS STS AssumeRole settings to use before signing backend requests.
+                                                Ambient AWS credentials are used as the source credentials for STS.
+                                              properties:
+                                                roleArn:
+                                                  description: AWS IAM role ARN to
+                                                    assume.
+                                                  minLength: 1
+                                                  pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
+                                                  type: string
+                                                sessionName:
+                                                  description: |-
+                                                    SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                    Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                  pattern: ^[\w+=,.@-]{2,64}$
+                                                  type: string
+                                                sessionNameExpression:
+                                                  description: |-
+                                                    SessionNameExpression is a CEL expression evaluated against each request
+                                                    to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                    `request.headers["x-team"]`. If the expression does not produce a valid
+                                                    session name at request time, the request is rejected.
+                                                  maxLength: 16384
+                                                  minLength: 1
+                                                  type: string
+                                                tags:
+                                                  description: |-
+                                                    Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                    & Usage Report, once activated. STS allows at most 50 per role session.
+                                                  items:
+                                                    description: |-
+                                                      AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                      attribution. Exactly one of value and expression must be set.
+                                                    properties:
+                                                      expression:
+                                                        description: |-
+                                                          CEL expression evaluated against each request to produce the tag value,
+                                                          for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                          tag values are rejected.
+                                                        maxLength: 16384
+                                                        minLength: 1
+                                                        type: string
+                                                      key:
+                                                        description: Key is the tag
+                                                          key.
+                                                        maxLength: 128
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        description: Value is a static
+                                                          tag value.
+                                                        maxLength: 256
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-validations:
+                                                    - message: exactly one of value
+                                                        or expression must be set
+                                                      rule: has(self.value) != has(self.expression)
+                                                  maxItems: 50
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - key
+                                                  x-kubernetes-list-type: map
+                                              required:
+                                              - roleArn
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: at most one of the fields
+                                                  in [sessionName sessionNameExpression]
+                                                  may be set
+                                                rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                  <= 1'
+                                            region:
+                                              description: |-
+                                                AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                target AWS service is in a different region than the gateway. If unset,
+                                                typed AWS backends may provide this automatically; otherwise the ambient
+                                                AWS region is used.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                            secretRef:
+                                              description: |-
+                                                Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                `sessionToken` keys.
+                                              properties:
+                                                group:
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
+                                                  type: string
+                                                name:
+                                                  description: Name of the referenced
+                                                    credential
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                              x-kubernetes-validations:
+                                              - message: custom credential refs must
+                                                  set both group and kind
+                                                rule: '(!has(self.group) || size(self.group)
+                                                  == 0) ? (!has(self.kind) || size(self.kind)
+                                                  == 0 || self.kind == ''Secret'')
+                                                  : (has(self.kind) && size(self.kind)
+                                                  > 0)'
+                                            serviceName:
+                                              description: |-
+                                                AWS SigV4 signing service name, for example
+                                                `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
+                                                backends may provide this automatically.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: secretRef and assumeRole are
+                                              mutually exclusive
+                                            rule: '!(has(self.secretRef) && has(self.assumeRole))'
+                                        key:
+                                          description: |-
+                                            Inline API key to use as the value of the `Authorization` header.
+                                            This option is the least secure; usage of a `Secret` is preferred.
+                                          maxLength: 2048
+                                          type: string
+                                        location:
+                                          description: |-
+                                            Where API keys are inserted. Defaults to the `Authorization` header with
+                                            the `Bearer ` prefix. Applies to `key` and `secretRef`.
+                                          properties:
+                                            cookie:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            header:
+                                              properties:
+                                                name:
+                                                  description: Name of an HTTP header.
+                                                    HTTP/2 pseudo-headers (names beginning
+                                                    with `:`) are not supported
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                  type: string
+                                                prefix:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            queryParameter:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [header queryParameter cookie] must
+                                              be set
+                                            rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                              == 1'
+                                        secretRef:
+                                          description: |-
+                                            Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                            By default, the value is read from the `Authorization` key; set
+                                            `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                            the default `Authorization` key.
+                                          properties:
+                                            group:
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
+                                              type: string
+                                            key:
+                                              description: Key in the referenced Secret.
+                                                If omitted, a location-specific default
+                                                is used
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            kind:
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
+                                              type: string
+                                            name:
+                                              description: Name of the referenced
+                                                credential
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                          x-kubernetes-validations:
+                                          - message: custom credential refs must set
+                                              both group and kind
+                                            rule: '(!has(self.group) || size(self.group)
+                                              == 0) ? (!has(self.kind) || size(self.kind)
+                                              == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                              && size(self.kind) > 0)'
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: location may only be set for key
+                                          or secretRef auth
+                                        rule: 'has(self.location) ? has(self.key)
+                                          || has(self.secretRef) : true'
+                                      - message: exactly one of the fields in [key
+                                          secretRef aws] must be set
+                                        rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
+                                          == 1'
+                                    http:
+                                      description: Settings for managing HTTP requests
+                                        to the backend
+                                      properties:
+                                        requestTimeout:
+                                          description: Deadline for receiving a response
+                                            from the backend.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: requestTimeout must be at least
+                                              1ms
+                                            rule: duration(self) >= duration('1ms')
+                                        version:
+                                          description: |-
+                                            HTTP protocol version for backend connections. If unset, it is inferred:
+                                            `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                            plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                            to HTTP/2 even when the backend does not support it.
+                                          enum:
+                                          - HTTP1
+                                          - HTTP2
+                                          type: string
+                                      type: object
+                                    tcp:
+                                      description: Settings for managing TCP connections
+                                        to the backend
+                                      properties:
+                                        connectTimeout:
+                                          description: |-
+                                            Deadline for establishing a connection to
+                                            the destination.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: connectTimeout must be at least
+                                              100ms
+                                            rule: duration(self) >= duration('100ms')
+                                        keepalive:
+                                          description: |-
+                                            Settings for enabling TCP keepalives on the
+                                            connection.
+                                          properties:
+                                            interval:
+                                              description: |-
+                                                Time between keepalive probes.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: interval must be at least
+                                                  1 second
+                                                rule: duration(self) >= duration('1s')
+                                            retries:
+                                              description: |-
+                                                Maximum number of keepalive probes to send before dropping the connection.
+                                                If unset, this defaults to 9.
+                                              format: int32
+                                              maximum: 64
+                                              minimum: 1
+                                              type: integer
+                                            time:
+                                              description: |-
+                                                Time a connection needs to be idle before keepalive probes start being sent.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: time must be at least 1 second
+                                                rule: duration(self) >= duration('1s')
+                                          type: object
+                                      type: object
+                                    tls:
+                                      description: |-
+                                        Settings for managing TLS connections to the backend
+
+                                        When set, TLS is originated to the backend using the system trusted CA
+                                        certificates, and SNI is inferred from the destination.
+                                      properties:
+                                        alpnProtocols:
+                                          description: |-
+                                            Application-Layer Protocol Negotiation (`ALPN`)
+                                            value to use in the TLS handshake.
+
+                                            If not present, defaults to `["h2", "http/1.1"]`.
+                                          items:
+                                            maxLength: 64
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                        caCertificateRefs:
+                                          description: |-
+                                            CA certificate `ConfigMap` to use to
+                                            verify the server certificate.
+                                            If unset, the system's trusted certificates are used.
+                                          items:
+                                            description: |-
+                                              LocalObjectReference contains enough information to let you locate the
+                                              referenced object inside the same namespace.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        insecureSkipVerify:
+                                          description: |-
+                                            Originates TLS but skips verification of the backend's certificate
+                                            WARNING: insecure; only use if the risks are understood
+
+                                            Modes:
+                                            * `All` disables all TLS verification
+                                            * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                              Still insecure; prefer `verifySubjectAltNames` where possible.
+                                          enum:
+                                          - All
+                                          - Hostname
+                                          type: string
+                                        keyExchangeGroups:
+                                          description: |-
+                                            Ordered list of key exchange groups for a TLS connection.
+                                            For example: `X25519_MLKEM768,X25519`.
+                                          items:
+                                            enum:
+                                            - P-256
+                                            - P-384
+                                            - X25519
+                                            - X25519_MLKEM768
+                                            type: string
+                                          type: array
+                                        mtlsCertificateRef:
+                                          description: |-
+                                            Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                            referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                            optional `ca.cert`, if present, verifies the server certificate, but
+                                            `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                            is used.
+                                          items:
+                                            description: |-
+                                              References a same-namespace credential
+                                              Set only `name` for a Kubernetes Secret
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        sni:
+                                          description: |-
+                                            Server Name Indicator (`SNI`) to use in the TLS
+                                            handshake. If unset, the `SNI` is automatically set based on the
+                                            destination hostname.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        verifySubjectAltNames:
+                                          description: |-
+                                            Subject Alternative Names (`SAN`)
+                                            to verify in the server certificate.
+                                            If not present, the destination hostname is automatically used.
+                                          items:
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: insecureSkipVerify All and caCertificateRefs
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) && self.insecureSkipVerify
+                                          == ''All'' ? !has(self.caCertificateRefs)
+                                          : true'
+                                      - message: insecureSkipVerify and verifySubjectAltNames
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
+                                          : true'
+                                      - message: at most one of the fields in [verifySubjectAltNames
+                                          insecureSkipVerify] may be set
+                                        rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
+                                          <= 1'
+                                    tunnel:
+                                      description: Settings for managing tunnel connections
+                                        to the backend, like `HTTPS_PROXY`
+                                      properties:
+                                        backendRef:
+                                          description: |-
+                                            Proxy server to reach.
+                                            Supported types: `Service` and `Backend`.
+                                          properties:
+                                            group:
+                                              default: ""
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              default: Service
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                            port:
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind
+                                              == ''Service'') ? has(self.port) : true'
+                                      required:
+                                      - backendRef
+                                      type: object
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: at least one of the fields in [auth http
+                                      tcp tls tunnel] must be set
+                                    rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                      >= 1'
+                                region:
+                                  description: |-
+                                    AWS region where the guardrail is deployed, for example
+                                    `us-west-2`).
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                version:
+                                  description: Version of the Guardrail policy to
+                                    use for the backend.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - identifier
+                              - region
+                              - version
+                              type: object
+                            googleModelArmor:
+                              description: Google Model Armor settings for prompt
+                                guarding.
+                              properties:
+                                location:
+                                  default: us-central1
+                                  description: |-
+                                    Google Cloud location, for example `us-central1`.
+                                    Defaults to `us-central1` if not specified.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                policies:
+                                  description: Policies for communicating with Google
+                                    Model Armor.
+                                  properties:
+                                    auth:
+                                      description: Settings for authenticating to
+                                        Google Model Armor.
+                                      properties:
+                                        gcp:
+                                          description: |-
+                                            Google authentication method for Model Armor. Use `gcp: {}` for default
+                                            Google credential discovery.
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                Explicit `aud` value for the ID token. Only
+                                                valid with `IdToken` type. If not set, the `aud` is automatically
+                                                derived from the backend hostname.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                            secretRef:
+                                              description: |-
+                                                Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                a Kubernetes `Secret`. By default, the value is read from
+                                                `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                ambient credentials are used.
+                                              properties:
+                                                group:
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
+                                                  type: string
+                                                name:
+                                                  description: Name of the referenced
+                                                    credential
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                              x-kubernetes-validations:
+                                              - message: custom credential refs must
+                                                  set both group and kind
+                                                rule: '(!has(self.group) || size(self.group)
+                                                  == 0) ? (!has(self.kind) || size(self.kind)
+                                                  == 0 || self.kind == ''Secret'')
+                                                  : (has(self.kind) && size(self.kind)
+                                                  > 0)'
+                                            type:
+                                              description: |-
+                                                The type of token to generate. To authenticate to GCP services,
+                                                generally an `AccessToken` is used. To authenticate to Cloud Run, an
+                                                `IdToken` is used.
+                                              enum:
+                                              - AccessToken
+                                              - IdToken
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: audience is only valid with IdToken
+                                            rule: 'has(self.audience) ? self.type
+                                              == ''IdToken'' : true'
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [gcp]
+                                          must be set
+                                        rule: '[has(self.gcp)].filter(x,x==true).size()
+                                          == 1'
+                                    http:
+                                      description: Settings for managing HTTP requests
+                                        to the backend
+                                      properties:
+                                        requestTimeout:
+                                          description: Deadline for receiving a response
+                                            from the backend.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: requestTimeout must be at least
+                                              1ms
+                                            rule: duration(self) >= duration('1ms')
+                                        version:
+                                          description: |-
+                                            HTTP protocol version for backend connections. If unset, it is inferred:
+                                            `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                            plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                            to HTTP/2 even when the backend does not support it.
+                                          enum:
+                                          - HTTP1
+                                          - HTTP2
+                                          type: string
+                                      type: object
+                                    tcp:
+                                      description: Settings for managing TCP connections
+                                        to the backend
+                                      properties:
+                                        connectTimeout:
+                                          description: |-
+                                            Deadline for establishing a connection to
+                                            the destination.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: connectTimeout must be at least
+                                              100ms
+                                            rule: duration(self) >= duration('100ms')
+                                        keepalive:
+                                          description: |-
+                                            Settings for enabling TCP keepalives on the
+                                            connection.
+                                          properties:
+                                            interval:
+                                              description: |-
+                                                Time between keepalive probes.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: interval must be at least
+                                                  1 second
+                                                rule: duration(self) >= duration('1s')
+                                            retries:
+                                              description: |-
+                                                Maximum number of keepalive probes to send before dropping the connection.
+                                                If unset, this defaults to 9.
+                                              format: int32
+                                              maximum: 64
+                                              minimum: 1
+                                              type: integer
+                                            time:
+                                              description: |-
+                                                Time a connection needs to be idle before keepalive probes start being sent.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: time must be at least 1 second
+                                                rule: duration(self) >= duration('1s')
+                                          type: object
+                                      type: object
+                                    tls:
+                                      description: |-
+                                        Settings for managing TLS connections to the backend
+
+                                        When set, TLS is originated to the backend using the system trusted CA
+                                        certificates, and SNI is inferred from the destination.
+                                      properties:
+                                        alpnProtocols:
+                                          description: |-
+                                            Application-Layer Protocol Negotiation (`ALPN`)
+                                            value to use in the TLS handshake.
+
+                                            If not present, defaults to `["h2", "http/1.1"]`.
+                                          items:
+                                            maxLength: 64
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                        caCertificateRefs:
+                                          description: |-
+                                            CA certificate `ConfigMap` to use to
+                                            verify the server certificate.
+                                            If unset, the system's trusted certificates are used.
+                                          items:
+                                            description: |-
+                                              LocalObjectReference contains enough information to let you locate the
+                                              referenced object inside the same namespace.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        insecureSkipVerify:
+                                          description: |-
+                                            Originates TLS but skips verification of the backend's certificate
+                                            WARNING: insecure; only use if the risks are understood
+
+                                            Modes:
+                                            * `All` disables all TLS verification
+                                            * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                              Still insecure; prefer `verifySubjectAltNames` where possible.
+                                          enum:
+                                          - All
+                                          - Hostname
+                                          type: string
+                                        keyExchangeGroups:
+                                          description: |-
+                                            Ordered list of key exchange groups for a TLS connection.
+                                            For example: `X25519_MLKEM768,X25519`.
+                                          items:
+                                            enum:
+                                            - P-256
+                                            - P-384
+                                            - X25519
+                                            - X25519_MLKEM768
+                                            type: string
+                                          type: array
+                                        mtlsCertificateRef:
+                                          description: |-
+                                            Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                            referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                            optional `ca.cert`, if present, verifies the server certificate, but
+                                            `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                            is used.
+                                          items:
+                                            description: |-
+                                              References a same-namespace credential
+                                              Set only `name` for a Kubernetes Secret
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        sni:
+                                          description: |-
+                                            Server Name Indicator (`SNI`) to use in the TLS
+                                            handshake. If unset, the `SNI` is automatically set based on the
+                                            destination hostname.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        verifySubjectAltNames:
+                                          description: |-
+                                            Subject Alternative Names (`SAN`)
+                                            to verify in the server certificate.
+                                            If not present, the destination hostname is automatically used.
+                                          items:
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: insecureSkipVerify All and caCertificateRefs
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) && self.insecureSkipVerify
+                                          == ''All'' ? !has(self.caCertificateRefs)
+                                          : true'
+                                      - message: insecureSkipVerify and verifySubjectAltNames
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
+                                          : true'
+                                      - message: at most one of the fields in [verifySubjectAltNames
+                                          insecureSkipVerify] may be set
+                                        rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
+                                          <= 1'
+                                    tunnel:
+                                      description: Settings for managing tunnel connections
+                                        to the backend, like `HTTPS_PROXY`
+                                      properties:
+                                        backendRef:
+                                          description: |-
+                                            Proxy server to reach.
+                                            Supported types: `Service` and `Backend`.
+                                          properties:
+                                            group:
+                                              default: ""
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              default: Service
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                            port:
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind
+                                              == ''Service'') ? has(self.port) : true'
+                                      required:
+                                      - backendRef
+                                      type: object
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: at least one of the fields in [auth http
+                                      tcp tls tunnel] must be set
+                                    rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                      >= 1'
+                                projectId:
+                                  description: Google Cloud project ID.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                templateId:
+                                  description: Template ID for Google Model Armor.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - projectId
+                              - templateId
+                              type: object
+                            openAIModeration:
+                              description: |-
+                                Passes prompt data through the OpenAI Moderations
+                                endpoint.
+                                See https://developers.openai.com/api/reference/resources/moderations for more information.
+                              properties:
+                                model:
+                                  description: |-
+                                    Moderation model to use. For example,
+                                    `omni-moderation`.
+                                  type: string
+                                policies:
+                                  description: Policies for communicating with OpenAI.
+                                  properties:
+                                    auth:
+                                      description: Settings for authenticating to
+                                        OpenAI.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            Inline key to use as the value of the
+                                            `Authorization` header. This option is the least secure; usage of a
+                                            `Secret` is preferred.
+                                          maxLength: 2048
+                                          type: string
+                                        location:
+                                          description: |-
+                                            Where backend credentials are inserted. Defaults to the `Authorization`
+                                            header with the `Bearer ` prefix. Applies to `key` and `secretRef`.
+                                          properties:
+                                            cookie:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            header:
+                                              properties:
+                                                name:
+                                                  description: Name of an HTTP header.
+                                                    HTTP/2 pseudo-headers (names beginning
+                                                    with `:`) are not supported
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                  type: string
+                                                prefix:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            queryParameter:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [header queryParameter cookie] must
+                                              be set
+                                            rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                              == 1'
+                                        secretRef:
+                                          description: |-
+                                            Credential source for the authorization value, defaulting to a Kubernetes
+                                            `Secret`. By default, the value is read from the `Authorization` key; set
+                                            `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                            the default `Authorization` key.
+                                          properties:
+                                            group:
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
+                                              type: string
+                                            key:
+                                              description: Key in the referenced Secret.
+                                                If omitted, a location-specific default
+                                                is used
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            kind:
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
+                                              type: string
+                                            name:
+                                              description: Name of the referenced
+                                                credential
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                          x-kubernetes-validations:
+                                          - message: custom credential refs must set
+                                              both group and kind
+                                            rule: '(!has(self.group) || size(self.group)
+                                              == 0) ? (!has(self.kind) || size(self.kind)
+                                              == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                              && size(self.kind) > 0)'
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [key
+                                          secretRef] must be set
+                                        rule: '[has(self.key),has(self.secretRef)].filter(x,x==true).size()
+                                          == 1'
+                                    http:
+                                      description: Settings for managing HTTP requests
+                                        to the backend
+                                      properties:
+                                        requestTimeout:
+                                          description: Deadline for receiving a response
+                                            from the backend.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: requestTimeout must be at least
+                                              1ms
+                                            rule: duration(self) >= duration('1ms')
+                                        version:
+                                          description: |-
+                                            HTTP protocol version for backend connections. If unset, it is inferred:
+                                            `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                            plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                            to HTTP/2 even when the backend does not support it.
+                                          enum:
+                                          - HTTP1
+                                          - HTTP2
+                                          type: string
+                                      type: object
+                                    tcp:
+                                      description: Settings for managing TCP connections
+                                        to the backend
+                                      properties:
+                                        connectTimeout:
+                                          description: |-
+                                            Deadline for establishing a connection to
+                                            the destination.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: connectTimeout must be at least
+                                              100ms
+                                            rule: duration(self) >= duration('100ms')
+                                        keepalive:
+                                          description: |-
+                                            Settings for enabling TCP keepalives on the
+                                            connection.
+                                          properties:
+                                            interval:
+                                              description: |-
+                                                Time between keepalive probes.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: interval must be at least
+                                                  1 second
+                                                rule: duration(self) >= duration('1s')
+                                            retries:
+                                              description: |-
+                                                Maximum number of keepalive probes to send before dropping the connection.
+                                                If unset, this defaults to 9.
+                                              format: int32
+                                              maximum: 64
+                                              minimum: 1
+                                              type: integer
+                                            time:
+                                              description: |-
+                                                Time a connection needs to be idle before keepalive probes start being sent.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: time must be at least 1 second
+                                                rule: duration(self) >= duration('1s')
+                                          type: object
+                                      type: object
+                                    tls:
+                                      description: |-
+                                        Settings for managing TLS connections to the backend
+
+                                        When set, TLS is originated to the backend using the system trusted CA
+                                        certificates, and SNI is inferred from the destination.
+                                      properties:
+                                        alpnProtocols:
+                                          description: |-
+                                            Application-Layer Protocol Negotiation (`ALPN`)
+                                            value to use in the TLS handshake.
+
+                                            If not present, defaults to `["h2", "http/1.1"]`.
+                                          items:
+                                            maxLength: 64
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                        caCertificateRefs:
+                                          description: |-
+                                            CA certificate `ConfigMap` to use to
+                                            verify the server certificate.
+                                            If unset, the system's trusted certificates are used.
+                                          items:
+                                            description: |-
+                                              LocalObjectReference contains enough information to let you locate the
+                                              referenced object inside the same namespace.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        insecureSkipVerify:
+                                          description: |-
+                                            Originates TLS but skips verification of the backend's certificate
+                                            WARNING: insecure; only use if the risks are understood
+
+                                            Modes:
+                                            * `All` disables all TLS verification
+                                            * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                              Still insecure; prefer `verifySubjectAltNames` where possible.
+                                          enum:
+                                          - All
+                                          - Hostname
+                                          type: string
+                                        keyExchangeGroups:
+                                          description: |-
+                                            Ordered list of key exchange groups for a TLS connection.
+                                            For example: `X25519_MLKEM768,X25519`.
+                                          items:
+                                            enum:
+                                            - P-256
+                                            - P-384
+                                            - X25519
+                                            - X25519_MLKEM768
+                                            type: string
+                                          type: array
+                                        mtlsCertificateRef:
+                                          description: |-
+                                            Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                            referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                            optional `ca.cert`, if present, verifies the server certificate, but
+                                            `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                            is used.
+                                          items:
+                                            description: |-
+                                              References a same-namespace credential
+                                              Set only `name` for a Kubernetes Secret
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        sni:
+                                          description: |-
+                                            Server Name Indicator (`SNI`) to use in the TLS
+                                            handshake. If unset, the `SNI` is automatically set based on the
+                                            destination hostname.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        verifySubjectAltNames:
+                                          description: |-
+                                            Subject Alternative Names (`SAN`)
+                                            to verify in the server certificate.
+                                            If not present, the destination hostname is automatically used.
+                                          items:
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: insecureSkipVerify All and caCertificateRefs
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) && self.insecureSkipVerify
+                                          == ''All'' ? !has(self.caCertificateRefs)
+                                          : true'
+                                      - message: insecureSkipVerify and verifySubjectAltNames
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
+                                          : true'
+                                      - message: at most one of the fields in [verifySubjectAltNames
+                                          insecureSkipVerify] may be set
+                                        rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
+                                          <= 1'
+                                    tunnel:
+                                      description: Settings for managing tunnel connections
+                                        to the backend, like `HTTPS_PROXY`
+                                      properties:
+                                        backendRef:
+                                          description: |-
+                                            Proxy server to reach.
+                                            Supported types: `Service` and `Backend`.
+                                          properties:
+                                            group:
+                                              default: ""
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              default: Service
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                            port:
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind
+                                              == ''Service'') ? has(self.port) : true'
+                                      required:
+                                      - backendRef
+                                      type: object
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: at least one of the fields in [auth http
+                                      tcp tls tunnel] must be set
+                                    rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                      >= 1'
+                              type: object
+                            regex:
+                              description: Regular expression (regex) matching for
+                                prompt guards and data masking.
+                              properties:
+                                action:
+                                  default: Mask
+                                  description: |-
+                                    The action to take if a regex pattern is matched in a request or response.
+                                    This setting applies only to request matches. `PromptguardResponse`
+                                    matches are always masked by default.
+                                    Defaults to `Mask`.
+                                  enum:
+                                  - Mask
+                                  - Reject
+                                  type: string
+                                builtins:
+                                  description: |-
+                                    Built-in regex patterns to match against the request or response.
+                                    Matches and built-ins are additive.
+                                  items:
+                                    description: |-
+                                      Built-in regex patterns for specific types of strings in prompts.
+                                      For example, if you specify `CreditCard`, any credit card numbers
+                                      in the request or response are matched.
+                                    enum:
+                                    - CaSin
+                                    - CreditCard
+                                    - Email
+                                    - PhoneNumber
+                                    - Ssn
+                                    type: string
+                                  type: array
+                                matches:
+                                  description: |-
+                                    Regex patterns to match against the request or response.
+                                    Matches and built-ins are additive.
+                                  items:
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                  type: array
+                              type: object
+                            response:
+                              description: |-
+                                Custom response message to return to the client. If not specified, defaults to
+                                `The request was rejected due to inappropriate content`.
+                              properties:
+                                message:
+                                  default: The request was rejected due to inappropriate
+                                    content
+                                  description: |-
+                                    Custom response message to return to the client. If not specified, defaults to
+                                    `The request was rejected due to inappropriate content`.
+                                  type: string
+                                statusCode:
+                                  default: 403
+                                  description: Status code to return to the client.
+                                    Defaults to 403.
+                                  format: int32
+                                  maximum: 599
+                                  minimum: 200
+                                  type: integer
+                              type: object
+                              x-kubernetes-validations:
+                              - message: at least one of the fields in [message statusCode]
+                                  must be set
+                                rule: '[has(self.message),has(self.statusCode)].filter(x,x==true).size()
+                                  >= 1'
+                            webhook:
+                              description: Webhook that receives requests for prompt
+                                guarding.
+                              properties:
+                                backendRef:
+                                  description: |-
+                                    Webhook server to reach.
+
+                                    Supported types: Service and Backend.
+                                  properties:
+                                    group:
+                                      default: ""
+                                      description: Group of the referent, for example
+                                        `gateway.networking.k8s.io`. Empty selects
+                                        the core API group
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      default: Service
+                                      description: Kubernetes resource kind of the
+                                        referent, for example `Service`. Defaults
+                                        to `Service`
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referent. Defaults
+                                        to the local namespace. A cross-namespace
+                                        reference requires a ReferenceGrant in the
+                                        referent namespace
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    port:
+                                      description: Destination port number. Required
+                                        when the referent is a Kubernetes `Service`
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Must have port for Service reference
+                                    rule: '(size(self.group) == 0 && self.kind ==
+                                      ''Service'') ? has(self.port) : true'
+                                failureMode:
+                                  description: |-
+                                    Behavior when the webhook guardrail is unavailable
+                                    or returns an error. `FailOpen` allows the request to continue.
+                                    `FailClosed` (default) rejects the request.
+                                  enum:
+                                  - FailClosed
+                                  - FailOpen
+                                  type: string
+                                forwardHeaderMatches:
+                                  description: |-
+                                    HTTP header matches used to select the headers to forward to the webhook.
+                                    Request headers are used when forwarding requests and response headers
+                                    are used when forwarding responses.
+                                    By default, no headers are forwarded.
+                                  items:
+                                    description: |-
+                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                      headers.
+                                    properties:
+                                      name:
+                                        description: Name of the HTTP header to match,
+                                          case-insensitive. When names are equivalent,
+                                          only the first matching entry is used
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      type:
+                                        default: Exact
+                                        description: 'How to match against the header
+                                          value: `Exact` (default) or `RegularExpression`.
+                                          The regex dialect is implementation-specific'
+                                        enum:
+                                        - Exact
+                                        - RegularExpression
+                                        type: string
+                                      value:
+                                        description: Value of the HTTP header to match
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                headers:
+                                  additionalProperties:
+                                    description: A Common Expression Language (CEL)
+                                      expression.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  description: CEL-computed headers to include in
+                                    webhook requests.
+                                  maxProperties: 64
+                                  type: object
+                              required:
+                              - backendRef
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [regex webhook openAIModeration
+                              bedrockGuardrails googleModelArmor] must be set
+                            rule: '[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size()
+                              == 1'
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                      response:
+                        description: Prompt guards to apply to responses returned
+                          by the LLM provider.
+                        items:
+                          description: Prompt guards to apply to responses returned
+                            by the LLM provider.
+                          properties:
+                            bedrockGuardrails:
+                              description: |-
+                                AWS Bedrock Guardrails settings for prompt
+                                guarding.
+                              properties:
+                                identifier:
+                                  description: Identifier of the Guardrail policy
+                                    to use for the backend.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                policies:
+                                  description: Policies for communicating with AWS
+                                    Bedrock Guardrails.
+                                  properties:
+                                    auth:
+                                      description: Settings for authenticating to
+                                        AWS Bedrock Guardrails.
+                                      properties:
+                                        aws:
+                                          description: |-
+                                            AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                            default AWS SDK credential discovery.
+                                          properties:
+                                            assumeRole:
+                                              description: |-
+                                                AWS STS AssumeRole settings to use before signing backend requests.
+                                                Ambient AWS credentials are used as the source credentials for STS.
+                                              properties:
+                                                roleArn:
+                                                  description: AWS IAM role ARN to
+                                                    assume.
+                                                  minLength: 1
+                                                  pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
+                                                  type: string
+                                                sessionName:
+                                                  description: |-
+                                                    SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                    Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                  pattern: ^[\w+=,.@-]{2,64}$
+                                                  type: string
+                                                sessionNameExpression:
+                                                  description: |-
+                                                    SessionNameExpression is a CEL expression evaluated against each request
+                                                    to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                    `request.headers["x-team"]`. If the expression does not produce a valid
+                                                    session name at request time, the request is rejected.
+                                                  maxLength: 16384
+                                                  minLength: 1
+                                                  type: string
+                                                tags:
+                                                  description: |-
+                                                    Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                    & Usage Report, once activated. STS allows at most 50 per role session.
+                                                  items:
+                                                    description: |-
+                                                      AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                      attribution. Exactly one of value and expression must be set.
+                                                    properties:
+                                                      expression:
+                                                        description: |-
+                                                          CEL expression evaluated against each request to produce the tag value,
+                                                          for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                          tag values are rejected.
+                                                        maxLength: 16384
+                                                        minLength: 1
+                                                        type: string
+                                                      key:
+                                                        description: Key is the tag
+                                                          key.
+                                                        maxLength: 128
+                                                        minLength: 1
+                                                        type: string
+                                                      value:
+                                                        description: Value is a static
+                                                          tag value.
+                                                        maxLength: 256
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-validations:
+                                                    - message: exactly one of value
+                                                        or expression must be set
+                                                      rule: has(self.value) != has(self.expression)
+                                                  maxItems: 50
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - key
+                                                  x-kubernetes-list-type: map
+                                              required:
+                                              - roleArn
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: at most one of the fields
+                                                  in [sessionName sessionNameExpression]
+                                                  may be set
+                                                rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                  <= 1'
+                                            region:
+                                              description: |-
+                                                AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                target AWS service is in a different region than the gateway. If unset,
+                                                typed AWS backends may provide this automatically; otherwise the ambient
+                                                AWS region is used.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                            secretRef:
+                                              description: |-
+                                                Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                `sessionToken` keys.
+                                              properties:
+                                                group:
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
+                                                  type: string
+                                                name:
+                                                  description: Name of the referenced
+                                                    credential
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                              x-kubernetes-validations:
+                                              - message: custom credential refs must
+                                                  set both group and kind
+                                                rule: '(!has(self.group) || size(self.group)
+                                                  == 0) ? (!has(self.kind) || size(self.kind)
+                                                  == 0 || self.kind == ''Secret'')
+                                                  : (has(self.kind) && size(self.kind)
+                                                  > 0)'
+                                            serviceName:
+                                              description: |-
+                                                AWS SigV4 signing service name, for example
+                                                `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
+                                                backends may provide this automatically.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: secretRef and assumeRole are
+                                              mutually exclusive
+                                            rule: '!(has(self.secretRef) && has(self.assumeRole))'
+                                        key:
+                                          description: |-
+                                            Inline API key to use as the value of the `Authorization` header.
+                                            This option is the least secure; usage of a `Secret` is preferred.
+                                          maxLength: 2048
+                                          type: string
+                                        location:
+                                          description: |-
+                                            Where API keys are inserted. Defaults to the `Authorization` header with
+                                            the `Bearer ` prefix. Applies to `key` and `secretRef`.
+                                          properties:
+                                            cookie:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            header:
+                                              properties:
+                                                name:
+                                                  description: Name of an HTTP header.
+                                                    HTTP/2 pseudo-headers (names beginning
+                                                    with `:`) are not supported
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                  type: string
+                                                prefix:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            queryParameter:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [header queryParameter cookie] must
+                                              be set
+                                            rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                              == 1'
+                                        secretRef:
+                                          description: |-
+                                            Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                            By default, the value is read from the `Authorization` key; set
+                                            `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                            the default `Authorization` key.
+                                          properties:
+                                            group:
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
+                                              type: string
+                                            key:
+                                              description: Key in the referenced Secret.
+                                                If omitted, a location-specific default
+                                                is used
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            kind:
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
+                                              type: string
+                                            name:
+                                              description: Name of the referenced
+                                                credential
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                          x-kubernetes-validations:
+                                          - message: custom credential refs must set
+                                              both group and kind
+                                            rule: '(!has(self.group) || size(self.group)
+                                              == 0) ? (!has(self.kind) || size(self.kind)
+                                              == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                              && size(self.kind) > 0)'
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: location may only be set for key
+                                          or secretRef auth
+                                        rule: 'has(self.location) ? has(self.key)
+                                          || has(self.secretRef) : true'
+                                      - message: exactly one of the fields in [key
+                                          secretRef aws] must be set
+                                        rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
+                                          == 1'
+                                    http:
+                                      description: Settings for managing HTTP requests
+                                        to the backend
+                                      properties:
+                                        requestTimeout:
+                                          description: Deadline for receiving a response
+                                            from the backend.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: requestTimeout must be at least
+                                              1ms
+                                            rule: duration(self) >= duration('1ms')
+                                        version:
+                                          description: |-
+                                            HTTP protocol version for backend connections. If unset, it is inferred:
+                                            `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                            plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                            to HTTP/2 even when the backend does not support it.
+                                          enum:
+                                          - HTTP1
+                                          - HTTP2
+                                          type: string
+                                      type: object
+                                    tcp:
+                                      description: Settings for managing TCP connections
+                                        to the backend
+                                      properties:
+                                        connectTimeout:
+                                          description: |-
+                                            Deadline for establishing a connection to
+                                            the destination.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: connectTimeout must be at least
+                                              100ms
+                                            rule: duration(self) >= duration('100ms')
+                                        keepalive:
+                                          description: |-
+                                            Settings for enabling TCP keepalives on the
+                                            connection.
+                                          properties:
+                                            interval:
+                                              description: |-
+                                                Time between keepalive probes.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: interval must be at least
+                                                  1 second
+                                                rule: duration(self) >= duration('1s')
+                                            retries:
+                                              description: |-
+                                                Maximum number of keepalive probes to send before dropping the connection.
+                                                If unset, this defaults to 9.
+                                              format: int32
+                                              maximum: 64
+                                              minimum: 1
+                                              type: integer
+                                            time:
+                                              description: |-
+                                                Time a connection needs to be idle before keepalive probes start being sent.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: time must be at least 1 second
+                                                rule: duration(self) >= duration('1s')
+                                          type: object
+                                      type: object
+                                    tls:
+                                      description: |-
+                                        Settings for managing TLS connections to the backend
+
+                                        When set, TLS is originated to the backend using the system trusted CA
+                                        certificates, and SNI is inferred from the destination.
+                                      properties:
+                                        alpnProtocols:
+                                          description: |-
+                                            Application-Layer Protocol Negotiation (`ALPN`)
+                                            value to use in the TLS handshake.
+
+                                            If not present, defaults to `["h2", "http/1.1"]`.
+                                          items:
+                                            maxLength: 64
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                        caCertificateRefs:
+                                          description: |-
+                                            CA certificate `ConfigMap` to use to
+                                            verify the server certificate.
+                                            If unset, the system's trusted certificates are used.
+                                          items:
+                                            description: |-
+                                              LocalObjectReference contains enough information to let you locate the
+                                              referenced object inside the same namespace.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        insecureSkipVerify:
+                                          description: |-
+                                            Originates TLS but skips verification of the backend's certificate
+                                            WARNING: insecure; only use if the risks are understood
+
+                                            Modes:
+                                            * `All` disables all TLS verification
+                                            * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                              Still insecure; prefer `verifySubjectAltNames` where possible.
+                                          enum:
+                                          - All
+                                          - Hostname
+                                          type: string
+                                        keyExchangeGroups:
+                                          description: |-
+                                            Ordered list of key exchange groups for a TLS connection.
+                                            For example: `X25519_MLKEM768,X25519`.
+                                          items:
+                                            enum:
+                                            - P-256
+                                            - P-384
+                                            - X25519
+                                            - X25519_MLKEM768
+                                            type: string
+                                          type: array
+                                        mtlsCertificateRef:
+                                          description: |-
+                                            Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                            referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                            optional `ca.cert`, if present, verifies the server certificate, but
+                                            `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                            is used.
+                                          items:
+                                            description: |-
+                                              References a same-namespace credential
+                                              Set only `name` for a Kubernetes Secret
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        sni:
+                                          description: |-
+                                            Server Name Indicator (`SNI`) to use in the TLS
+                                            handshake. If unset, the `SNI` is automatically set based on the
+                                            destination hostname.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        verifySubjectAltNames:
+                                          description: |-
+                                            Subject Alternative Names (`SAN`)
+                                            to verify in the server certificate.
+                                            If not present, the destination hostname is automatically used.
+                                          items:
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: insecureSkipVerify All and caCertificateRefs
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) && self.insecureSkipVerify
+                                          == ''All'' ? !has(self.caCertificateRefs)
+                                          : true'
+                                      - message: insecureSkipVerify and verifySubjectAltNames
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
+                                          : true'
+                                      - message: at most one of the fields in [verifySubjectAltNames
+                                          insecureSkipVerify] may be set
+                                        rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
+                                          <= 1'
+                                    tunnel:
+                                      description: Settings for managing tunnel connections
+                                        to the backend, like `HTTPS_PROXY`
+                                      properties:
+                                        backendRef:
+                                          description: |-
+                                            Proxy server to reach.
+                                            Supported types: `Service` and `Backend`.
+                                          properties:
+                                            group:
+                                              default: ""
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              default: Service
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                            port:
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind
+                                              == ''Service'') ? has(self.port) : true'
+                                      required:
+                                      - backendRef
+                                      type: object
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: at least one of the fields in [auth http
+                                      tcp tls tunnel] must be set
+                                    rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                      >= 1'
+                                region:
+                                  description: |-
+                                    AWS region where the guardrail is deployed, for example
+                                    `us-west-2`).
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                version:
+                                  description: Version of the Guardrail policy to
+                                    use for the backend.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - identifier
+                              - region
+                              - version
+                              type: object
+                            googleModelArmor:
+                              description: Google Model Armor settings for prompt
+                                guarding.
+                              properties:
+                                location:
+                                  default: us-central1
+                                  description: |-
+                                    Google Cloud location, for example `us-central1`.
+                                    Defaults to `us-central1` if not specified.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                policies:
+                                  description: Policies for communicating with Google
+                                    Model Armor.
+                                  properties:
+                                    auth:
+                                      description: Settings for authenticating to
+                                        Google Model Armor.
+                                      properties:
+                                        gcp:
+                                          description: |-
+                                            Google authentication method for Model Armor. Use `gcp: {}` for default
+                                            Google credential discovery.
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                Explicit `aud` value for the ID token. Only
+                                                valid with `IdToken` type. If not set, the `aud` is automatically
+                                                derived from the backend hostname.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                            secretRef:
+                                              description: |-
+                                                Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                a Kubernetes `Secret`. By default, the value is read from
+                                                `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                ambient credentials are used.
+                                              properties:
+                                                group:
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                                kind:
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
+                                                  type: string
+                                                name:
+                                                  description: Name of the referenced
+                                                    credential
+                                                  maxLength: 253
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                              x-kubernetes-validations:
+                                              - message: custom credential refs must
+                                                  set both group and kind
+                                                rule: '(!has(self.group) || size(self.group)
+                                                  == 0) ? (!has(self.kind) || size(self.kind)
+                                                  == 0 || self.kind == ''Secret'')
+                                                  : (has(self.kind) && size(self.kind)
+                                                  > 0)'
+                                            type:
+                                              description: |-
+                                                The type of token to generate. To authenticate to GCP services,
+                                                generally an `AccessToken` is used. To authenticate to Cloud Run, an
+                                                `IdToken` is used.
+                                              enum:
+                                              - AccessToken
+                                              - IdToken
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: audience is only valid with IdToken
+                                            rule: 'has(self.audience) ? self.type
+                                              == ''IdToken'' : true'
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [gcp]
+                                          must be set
+                                        rule: '[has(self.gcp)].filter(x,x==true).size()
+                                          == 1'
+                                    http:
+                                      description: Settings for managing HTTP requests
+                                        to the backend
+                                      properties:
+                                        requestTimeout:
+                                          description: Deadline for receiving a response
+                                            from the backend.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: requestTimeout must be at least
+                                              1ms
+                                            rule: duration(self) >= duration('1ms')
+                                        version:
+                                          description: |-
+                                            HTTP protocol version for backend connections. If unset, it is inferred:
+                                            `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                            plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                            to HTTP/2 even when the backend does not support it.
+                                          enum:
+                                          - HTTP1
+                                          - HTTP2
+                                          type: string
+                                      type: object
+                                    tcp:
+                                      description: Settings for managing TCP connections
+                                        to the backend
+                                      properties:
+                                        connectTimeout:
+                                          description: |-
+                                            Deadline for establishing a connection to
+                                            the destination.
+                                          maxLength: 32
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: invalid duration value
+                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                          - message: connectTimeout must be at least
+                                              100ms
+                                            rule: duration(self) >= duration('100ms')
+                                        keepalive:
+                                          description: |-
+                                            Settings for enabling TCP keepalives on the
+                                            connection.
+                                          properties:
+                                            interval:
+                                              description: |-
+                                                Time between keepalive probes.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: interval must be at least
+                                                  1 second
+                                                rule: duration(self) >= duration('1s')
+                                            retries:
+                                              description: |-
+                                                Maximum number of keepalive probes to send before dropping the connection.
+                                                If unset, this defaults to 9.
+                                              format: int32
+                                              maximum: 64
+                                              minimum: 1
+                                              type: integer
+                                            time:
+                                              description: |-
+                                                Time a connection needs to be idle before keepalive probes start being sent.
+                                                If unset, this defaults to 180s.
+                                              maxLength: 32
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: invalid duration value
+                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
+                                              - message: time must be at least 1 second
+                                                rule: duration(self) >= duration('1s')
+                                          type: object
+                                      type: object
+                                    tls:
+                                      description: |-
+                                        Settings for managing TLS connections to the backend
+
+                                        When set, TLS is originated to the backend using the system trusted CA
+                                        certificates, and SNI is inferred from the destination.
+                                      properties:
+                                        alpnProtocols:
+                                          description: |-
+                                            Application-Layer Protocol Negotiation (`ALPN`)
+                                            value to use in the TLS handshake.
+
+                                            If not present, defaults to `["h2", "http/1.1"]`.
+                                          items:
+                                            maxLength: 64
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                        caCertificateRefs:
+                                          description: |-
+                                            CA certificate `ConfigMap` to use to
+                                            verify the server certificate.
+                                            If unset, the system's trusted certificates are used.
+                                          items:
+                                            description: |-
+                                              LocalObjectReference contains enough information to let you locate the
+                                              referenced object inside the same namespace.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        insecureSkipVerify:
+                                          description: |-
+                                            Originates TLS but skips verification of the backend's certificate
+                                            WARNING: insecure; only use if the risks are understood
+
+                                            Modes:
+                                            * `All` disables all TLS verification
+                                            * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                              Still insecure; prefer `verifySubjectAltNames` where possible.
+                                          enum:
+                                          - All
+                                          - Hostname
+                                          type: string
+                                        keyExchangeGroups:
+                                          description: |-
+                                            Ordered list of key exchange groups for a TLS connection.
+                                            For example: `X25519_MLKEM768,X25519`.
+                                          items:
+                                            enum:
+                                            - P-256
+                                            - P-384
+                                            - X25519
+                                            - X25519_MLKEM768
+                                            type: string
+                                          type: array
+                                        mtlsCertificateRef:
+                                          description: |-
+                                            Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                            referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                            optional `ca.cert`, if present, verifies the server certificate, but
+                                            `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                            is used.
+                                          items:
+                                            description: |-
+                                              References a same-namespace credential
+                                              Set only `name` for a Kubernetes Secret
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                          maxItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        sni:
+                                          description: |-
+                                            Server Name Indicator (`SNI`) to use in the TLS
+                                            handshake. If unset, the `SNI` is automatically set based on the
+                                            destination hostname.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        verifySubjectAltNames:
+                                          description: |-
+                                            Subject Alternative Names (`SAN`)
+                                            to verify in the server certificate.
+                                            If not present, the destination hostname is automatically used.
+                                          items:
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: insecureSkipVerify All and caCertificateRefs
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) && self.insecureSkipVerify
+                                          == ''All'' ? !has(self.caCertificateRefs)
+                                          : true'
+                                      - message: insecureSkipVerify and verifySubjectAltNames
+                                          may not be set together
+                                        rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
+                                          : true'
+                                      - message: at most one of the fields in [verifySubjectAltNames
+                                          insecureSkipVerify] may be set
+                                        rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
+                                          <= 1'
+                                    tunnel:
+                                      description: Settings for managing tunnel connections
+                                        to the backend, like `HTTPS_PROXY`
+                                      properties:
+                                        backendRef:
+                                          description: |-
+                                            Proxy server to reach.
+                                            Supported types: `Service` and `Backend`.
+                                          properties:
+                                            group:
+                                              default: ""
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              default: Service
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                            port:
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind
+                                              == ''Service'') ? has(self.port) : true'
+                                      required:
+                                      - backendRef
+                                      type: object
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: at least one of the fields in [auth http
+                                      tcp tls tunnel] must be set
+                                    rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                      >= 1'
+                                projectId:
+                                  description: Google Cloud project ID.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                templateId:
+                                  description: Template ID for Google Model Armor.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - projectId
+                              - templateId
+                              type: object
+                            regex:
+                              description: Regular expression (regex) matching for
+                                prompt guards and data masking.
+                              properties:
+                                action:
+                                  default: Mask
+                                  description: |-
+                                    The action to take if a regex pattern is matched in a request or response.
+                                    This setting applies only to request matches. `PromptguardResponse`
+                                    matches are always masked by default.
+                                    Defaults to `Mask`.
+                                  enum:
+                                  - Mask
+                                  - Reject
+                                  type: string
+                                builtins:
+                                  description: |-
+                                    Built-in regex patterns to match against the request or response.
+                                    Matches and built-ins are additive.
+                                  items:
+                                    description: |-
+                                      Built-in regex patterns for specific types of strings in prompts.
+                                      For example, if you specify `CreditCard`, any credit card numbers
+                                      in the request or response are matched.
+                                    enum:
+                                    - CaSin
+                                    - CreditCard
+                                    - Email
+                                    - PhoneNumber
+                                    - Ssn
+                                    type: string
+                                  type: array
+                                matches:
+                                  description: |-
+                                    Regex patterns to match against the request or response.
+                                    Matches and built-ins are additive.
+                                  items:
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                  type: array
+                              type: object
+                            response:
+                              description: |-
+                                Custom response message to return to the client. If not specified, defaults to
+                                `The response was rejected due to inappropriate content`.
+                              properties:
+                                message:
+                                  default: The request was rejected due to inappropriate
+                                    content
+                                  description: |-
+                                    Custom response message to return to the client. If not specified, defaults to
+                                    `The request was rejected due to inappropriate content`.
+                                  type: string
+                                statusCode:
+                                  default: 403
+                                  description: Status code to return to the client.
+                                    Defaults to 403.
+                                  format: int32
+                                  maximum: 599
+                                  minimum: 200
+                                  type: integer
+                              type: object
+                              x-kubernetes-validations:
+                              - message: at least one of the fields in [message statusCode]
+                                  must be set
+                                rule: '[has(self.message),has(self.statusCode)].filter(x,x==true).size()
+                                  >= 1'
+                            webhook:
+                              description: Webhook that receives responses for prompt
+                                guarding.
+                              properties:
+                                backendRef:
+                                  description: |-
+                                    Webhook server to reach.
+
+                                    Supported types: Service and Backend.
+                                  properties:
+                                    group:
+                                      default: ""
+                                      description: Group of the referent, for example
+                                        `gateway.networking.k8s.io`. Empty selects
+                                        the core API group
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      default: Service
+                                      description: Kubernetes resource kind of the
+                                        referent, for example `Service`. Defaults
+                                        to `Service`
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referent. Defaults
+                                        to the local namespace. A cross-namespace
+                                        reference requires a ReferenceGrant in the
+                                        referent namespace
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    port:
+                                      description: Destination port number. Required
+                                        when the referent is a Kubernetes `Service`
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Must have port for Service reference
+                                    rule: '(size(self.group) == 0 && self.kind ==
+                                      ''Service'') ? has(self.port) : true'
+                                failureMode:
+                                  description: |-
+                                    Behavior when the webhook guardrail is unavailable
+                                    or returns an error. `FailOpen` allows the request to continue.
+                                    `FailClosed` (default) rejects the request.
+                                  enum:
+                                  - FailClosed
+                                  - FailOpen
+                                  type: string
+                                forwardHeaderMatches:
+                                  description: |-
+                                    HTTP header matches used to select the headers to forward to the webhook.
+                                    Request headers are used when forwarding requests and response headers
+                                    are used when forwarding responses.
+                                    By default, no headers are forwarded.
+                                  items:
+                                    description: |-
+                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                      headers.
+                                    properties:
+                                      name:
+                                        description: Name of the HTTP header to match,
+                                          case-insensitive. When names are equivalent,
+                                          only the first matching entry is used
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      type:
+                                        default: Exact
+                                        description: 'How to match against the header
+                                          value: `Exact` (default) or `RegularExpression`.
+                                          The regex dialect is implementation-specific'
+                                        enum:
+                                        - Exact
+                                        - RegularExpression
+                                        type: string
+                                      value:
+                                        description: Value of the HTTP header to match
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                headers:
+                                  additionalProperties:
+                                    description: A Common Expression Language (CEL)
+                                      expression.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  description: CEL-computed headers to include in
+                                    webhook requests.
+                                  maxProperties: 64
+                                  type: object
+                              required:
+                              - backendRef
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [regex webhook bedrockGuardrails
+                              googleModelArmor] must be set
+                            rule: '[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size()
+                              == 1'
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                      streaming:
+                        description: |-
+                          Apply prompt guards to streaming responses and realtime websocket messages.
+                          Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+                        enum:
+                        - Enabled
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of the fields in [request response] must
+                        be set
+                      rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
+                        >= 1'
+                  tls:
+                    description: TLS settings for connections to this model provider.
+                    properties:
+                      alpnProtocols:
+                        description: |-
+                          Application-Layer Protocol Negotiation (`ALPN`)
+                          value to use in the TLS handshake.
+
+                          If not present, defaults to `["h2", "http/1.1"]`.
+                        items:
+                          maxLength: 64
+                          minLength: 1
+                          type: string
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                      caCertificateRefs:
+                        description: |-
+                          CA certificate `ConfigMap` to use to
+                          verify the server certificate.
+                          If unset, the system's trusted certificates are used.
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: Name of the referent
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      insecureSkipVerify:
+                        description: |-
+                          Originates TLS but skips verification of the backend's certificate
+                          WARNING: insecure; only use if the risks are understood
+
+                          Modes:
+                          * `All` disables all TLS verification
+                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                            Still insecure; prefer `verifySubjectAltNames` where possible.
+                        enum:
+                        - All
+                        - Hostname
+                        type: string
+                      keyExchangeGroups:
+                        description: |-
+                          Ordered list of key exchange groups for a TLS connection.
+                          For example: `X25519_MLKEM768,X25519`.
+                        items:
+                          enum:
+                          - P-256
+                          - P-384
+                          - X25519
+                          - X25519_MLKEM768
+                          type: string
+                        type: array
+                      mtlsCertificateRef:
+                        description: |-
+                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                          optional `ca.cert`, if present, verifies the server certificate, but
+                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                          is used.
+                        items:
+                          description: |-
+                            References a same-namespace credential
+                            Set only `name` for a Kubernetes Secret
+                          properties:
+                            group:
+                              description: API group of the referenced credential;
+                                empty selects the core API group
+                              type: string
+                            kind:
+                              description: Kind of the referenced credential; empty
+                                defaults to `Secret`
+                              type: string
+                            name:
+                              description: Name of the referenced credential
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - message: custom credential refs must set both group and
+                              kind
+                            rule: '(!has(self.group) || size(self.group) == 0) ? (!has(self.kind)
+                              || size(self.kind) == 0 || self.kind == ''Secret'')
+                              : (has(self.kind) && size(self.kind) > 0)'
+                        maxItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      sni:
+                        description: |-
+                          Server Name Indicator (`SNI`) to use in the TLS
+                          handshake. If unset, the `SNI` is automatically set based on the
+                          destination hostname.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      verifySubjectAltNames:
+                        description: |-
+                          Subject Alternative Names (`SAN`)
+                          to verify in the server certificate.
+                          If not present, the destination hostname is automatically used.
+                        items:
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                    type: object
+                    x-kubernetes-validations:
+                    - message: insecureSkipVerify All and caCertificateRefs may not
+                        be set together
+                      rule: 'has(self.insecureSkipVerify) && self.insecureSkipVerify
+                        == ''All'' ? !has(self.caCertificateRefs) : true'
+                    - message: insecureSkipVerify and verifySubjectAltNames may not
+                        be set together
+                      rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
+                        : true'
+                    - message: at most one of the fields in [verifySubjectAltNames
+                        insecureSkipVerify] may be set
+                      rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
+                        <= 1'
+                  transformations:
+                    description: CEL transformations applied to fields in the provider
+                      request body.
+                    items:
+                      description: |-
+                        Maps a request JSON field to a CEL expression.
+                        The expression is evaluated against the current request body and its result
+                        is assigned to the configured field.
+                      properties:
+                        expression:
+                          description: CEL expression used to compute the field value.
+                          maxLength: 16384
+                          minLength: 1
+                          type: string
+                        field:
+                          description: Name of the field to set.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                      required:
+                      - expression
+                      - field
+                      type: object
+                    maxItems: 64
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - field
+                    x-kubernetes-list-type: map
+                  tunnel:
+                    description: Proxy tunnel used to reach this model provider.
+                    properties:
+                      backendRef:
+                        description: |-
+                          Proxy server to reach.
+                          Supported types: `Service` and `Backend`.
+                        properties:
+                          group:
+                            default: ""
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                    required:
+                    - backendRef
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of the fields in [auth authorization headers
+                    health promptGuard tls transformations tunnel] must be set
+                  rule: '[has(self.auth),has(self.authorization),has(self.headers),has(self.health),has(self.promptGuard),has(self.tls),has(self.transformations),has(self.tunnel)].filter(x,x==true).size()
+                    >= 1'
+              provider:
+                description: |-
+                  Provider serving this concrete model. Provider-specific configuration is
+                  set by the corresponding field below when needed.
+                enum:
+                - Anthropic
+                - Azure
+                - Baseten
+                - Bedrock
+                - Cerebras
+                - Cohere
+                - Custom
+                - Deepinfra
+                - Deepseek
+                - Fireworks
+                - Gemini
+                - Groq
+                - Huggingface
+                - Mistral
+                - Ollama
+                - OpenAI
+                - Openrouter
+                - TogetherAI
+                - VertexAI
+                - XAI
+                type: string
+              vertexai:
+                description: Provider-specific settings for Vertex AI.
+                properties:
+                  projectId:
+                    description: The ID of the Google Cloud Project that you use for
+                      the Vertex AI.
+                    maxLength: 64
+                    minLength: 1
+                    type: string
+                  region:
+                    default: global
+                    description: |-
+                      The location of the Google Cloud Project that you use for the Vertex AI.
+                      Special values: `global` uses the global endpoint, while `us` and `eu` use restricted
+                      multi-region endpoints. Other values are treated as regional locations.
+                      Defaults to `global` if not specified.
+                    maxLength: 64
+                    minLength: 1
+                    type: string
+                required:
+                - projectId
+                type: object
+              virtualModel:
+                description: Request-time routing among concrete AgentgatewayModel
+                  resources.
+                properties:
+                  conditional:
+                    description: Ordered condition-based model selection.
+                    properties:
+                      targets:
+                        description: |-
+                          Concrete model targets evaluated in order. The first matching condition is
+                          selected. One final target may omit when to act as the fallback.
+                        items:
+                          properties:
+                            model:
+                              description: |-
+                                Concrete model name selected through the referenced model. It is required
+                                when modelRef points to a wildcard match.model. When omitted, the referenced
+                                model's exact effective match.model is used.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                            modelRef:
+                              description: Same-namespace AgentgatewayModel resource
+                                selected by this target.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: Name of the referent
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            when:
+                              description: |-
+                                CEL expression that must evaluate to true for this target to be selected.
+                                Omit only on the final fallback target.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                          required:
+                          - modelRef
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-validations:
+                        - message: conditional targets without when must be last
+                          rule: self.filter(e, !has(e.when)).size() <= 1 && (!self.exists(e,
+                            !has(e.when)) || !has(self[size(self) - 1].when))
+                    required:
+                    - targets
+                    type: object
+                  failover:
+                    description: Priority-based model selection with failover between
+                      priority groups.
+                    properties:
+                      targets:
+                        description: Concrete model targets grouped by priority. Lower
+                          values are preferred.
+                        items:
+                          properties:
+                            model:
+                              description: |-
+                                Concrete model name selected through the referenced model. It is required
+                                when modelRef points to a wildcard match.model. When omitted, the referenced
+                                model's exact effective match.model is used.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                            modelRef:
+                              description: Same-namespace AgentgatewayModel resource
+                                selected by this target.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: Name of the referent
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            priority:
+                              description: |-
+                                Priority of this target. Lower values are preferred. Targets at the same
+                                priority are selected using a score that considers health and latency. The
+                                next priority is used only when every target at this priority is degraded.
+                                Configure policies.health on concrete target models to customize
+                                degradation and eviction behavior.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
+                          required:
+                          - modelRef
+                          - priority
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                    required:
+                    - targets
+                    type: object
+                  weighted:
+                    description: Weight-based model selection.
+                    properties:
+                      targets:
+                        description: Concrete model targets and their relative weights.
+                        items:
+                          properties:
+                            model:
+                              description: |-
+                                Concrete model name selected through the referenced model. It is required
+                                when modelRef points to a wildcard match.model. When omitted, the referenced
+                                model's exact effective match.model is used.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                            modelRef:
+                              description: Same-namespace AgentgatewayModel resource
+                                selected by this target.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: Name of the referent
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              default: 1
+                              description: Relative traffic weight. Defaults to 1.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 1
+                              type: integer
+                          required:
+                          - modelRef
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                    required:
+                    - targets
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of the fields in [weighted failover conditional]
+                    must be set
+                  rule: '[has(self.weighted),has(self.failover),has(self.conditional)].filter(x,x==true).size()
+                    == 1'
+              visibility:
+                default: Public
+                description: |-
+                  Controls whether clients can request this model directly. Internal models
+                  can only be selected by virtual models. Defaults to Public.
+                enum:
+                - Internal
+                - Public
+                type: string
+            required:
+            - parentRefs
+            type: object
+            x-kubernetes-validations:
+            - message: baseURL requires provider
+              rule: has(self.provider) || !has(self.baseURL)
+            - message: policies cannot be used with virtualModel
+              rule: '!has(self.virtualModel) || !has(self.policies)'
+            - message: virtual models must be public
+              rule: '!has(self.virtualModel) || self.visibility != ''Internal'''
+            - message: virtual model match.model must be an exact name
+              rule: '!has(self.virtualModel) || !has(self.match) || !has(self.match.model)
+                || !self.match.model.contains(''*'')'
+            - message: ollama requires baseURL
+              rule: '!has(self.provider) || self.provider != ''Ollama'' || has(self.baseURL)'
+            - message: baseURL must be an absolute http or https URL with a host
+              rule: '!has(self.baseURL) || (isURL(self.baseURL) && (url(self.baseURL).getScheme()
+                == ''http'' || url(self.baseURL).getScheme() == ''https'') && url(self.baseURL).getHostname()
+                != "")'
+            - message: baseURL cannot target localhost, loopback, or link-local addresses
+              rule: '!has(self.baseURL) || !self.baseURL.matches("(?i)^https?://(localhost|[^/]+\\.localhost)(:[0-9]+)?(/|$)")'
+            - message: baseURL cannot target localhost, loopback, or link-local addresses
+              rule: '!has(self.baseURL) || !self.baseURL.matches("^https?://127(\\.[0-9]{1,3}){0,3}(:[0-9]+)?(/|$)")'
+            - message: baseURL cannot target localhost, loopback, or link-local addresses
+              rule: '!has(self.baseURL) || !self.baseURL.matches("^https?://169\\.254\\.[0-9]{1,3}\\.[0-9]{1,3}(:[0-9]+)?(/|$)")'
+            - message: baseURL cannot target localhost, loopback, or link-local addresses
+              rule: '!has(self.baseURL) || !self.baseURL.matches("(?i)^https?://\\[(::1|fe[89ab][0-9a-f:]*)\\](:[0-9]+)?(/|$)")'
+            - message: azure must be set if and only if provider is Azure
+              rule: has(self.azure) == (has(self.provider) && self.provider == 'Azure')
+            - message: vertexai must be set if and only if provider is VertexAI
+              rule: has(self.vertexai) == (has(self.provider) && self.provider ==
+                'VertexAI')
+            - message: bedrock must be set if and only if provider is Bedrock
+              rule: has(self.bedrock) == (has(self.provider) && self.provider == 'Bedrock')
+            - message: custom must be set if and only if provider is Custom
+              rule: has(self.custom) == (has(self.provider) && self.provider == 'Custom')
+            - message: exactly one of the fields in [provider virtualModel] must be
+                set
+              rule: '[has(self.provider),has(self.virtualModel)].filter(x,x==true).size()
+                == 1'
+          status:
+            description: Current model attachment status.
+            properties:
+              parents:
+                description: Status for each Gateway parent to which this model is
+                  attached.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+
+                        <gateway:util:excludeFromCRD>
+
+                        Notes for implementors:
+
+                        Conditions are a listType `map`, which means that they function like a
+                        map with a key of the `type` field _in the k8s apiserver_.
+
+                        This means that implementations must obey some rules when updating this
+                        section.
+
+                        * Implementations MUST perform a read-modify-write cycle on this field
+                          before modifying it. That is, when modifying this field, implementations
+                          must be confident they have fetched the most recent version of this field,
+                          and ensure that changes they make are on that recent version.
+                        * Implementations MUST NOT remove or reorder Conditions that they are not
+                          directly responsible for. For example, if an implementation sees a Condition
+                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
+                          Condition.
+                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
+                          rather than creating more than one Condition of the same Type.
+                        * Implementations MUST always update the `observedGeneration` field of the
+                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
+                        * If the `observedGeneration` of a Condition is _greater than_ the value the
+                          implementation knows about, then it MUST NOT perform the update on that Condition,
+                          but must wait for a future reconciliation and status update. (The assumption is that
+                          the implementation's copy of the object is stale and an update will be re-triggered
+                          if relevant.)
+
+                        </gateway:util:excludeFromCRD>
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. Defaults to the
+                            Route''s local namespace. Cross-namespace references must
+                            be explicitly allowed, for example via ReferenceGrant.
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port this Route targets on the parent, interpreted
+                            per parent kind (for example a Gateway listener port or
+                            Service port). Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'Name of a section within the target resource,
+                            for example a Gateway Listener name or Service port name.
+                            Empty references the entire resource. Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
@@ -55,6 +55,91 @@ spec:
           spec:
             description: Desired data plane provisioning settings.
             properties:
+              daemonSet:
+                description: |-
+                  Overrides for the generated
+                  `DaemonSet` resource.
+                properties:
+                  metadata:
+                    description: |-
+                      `metadata` defines a subset of object metadata to be customized.
+                      `labels` and `annotations` are merged with existing values. If both
+                      `GatewayClass` and `Gateway` parameters define the same label or
+                      annotation key, the `Gateway` value takes precedence (applied second).
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: "`spec` provides an opaque mechanism to configure
+                      the resource spec.\nThis field accepts a complete or partial
+                      Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`,
+                      and will be merged with the generated\nconfiguration using **Strategic
+                      Merge Patch** semantics.\n\n# Application Order\n\nOverlays
+                      are applied after all typed configuration fields from both levels.\nThe
+                      full merge order is:\n\n 1. `GatewayClass` typed configuration
+                      fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass`
+                      overlays\n 4. `Gateway` overlays (can override all previous
+                      values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis
+                      merge strategy allows you to override individual fields, merge
+                      lists, or delete items\nwithout needing to provide the entire
+                      resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple
+                      fields (strings, integers, booleans) in your config will overwrite
+                      the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists
+                      with \"merge keys\", like `containers` which merges on `name`,
+                      or\n`tolerations` which merges on `key`,\nwill append your items
+                      to the generated list, or update existing items if keys match.\n\n**3.
+                      Deleting Fields or List Items ($patch: delete):**\nTo remove
+                      a field or list item from the generated resource, use the\n`$patch:
+                      delete` directive. This works for both map fields and list items,\nand
+                      is the recommended approach because it works with both client-side\nand
+                      server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t
+                      \     # Delete pod-level securityContext\n\t      securityContext:\n\t
+                      \       $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t
+                      \       $patch: delete\n\t      containers:\n\t      # Be sure
+                      to use the correct proxy name here or you will add a\n\t      #
+                      container instead of modifying a container.\n\t      - name:
+                      proxy-name\n\t        # Delete container-level securityContext\n\t
+                      \       securityContext:\n\t          $patch: delete\n\n**4.
+                      Null Values (server-side apply only):**\nSetting a field to
+                      `null` can also remove it, but this ONLY works with\n`kubectl
+                      apply --server-side` or equivalent. With regular client-side\n`kubectl
+                      apply`, null values are stripped by kubectl before reaching\nthe
+                      API server, so the deletion won't occur. Prefer `$patch: delete`\nfor
+                      consistent behavior across both apply modes.\n\n\tspec:\n\t
+                      \ template:\n\t    spec:\n\t      nodeSelector: null  # Removes
+                      nodeSelector (server-side apply only!)\n\n**5. Replacing Maps
+                      Entirely ($patch: replace):**\nTo replace an entire map with
+                      your values (instead of merging), use `$patch: replace`.\nThis
+                      removes all existing keys and replaces them with only your specified
+                      keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t
+                      \       $patch: replace\n\t        custom-key: custom-value\n\n**6.
+                      Replacing Lists Entirely ($patch: replace):**\nIf you want to
+                      strictly define a list and ignore all generated defaults, use
+                      `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t
+                      \   - $patch: replace\n\t    - name: http\n\t      port: 80\n\t
+                      \     targetPort: 8080\n\t      protocol: TCP\n\t    - name:
+                      https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol:
+                      TCP"
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
               deployment:
                 description: |-
                   Overrides for the generated
@@ -187,12 +272,7 @@ spec:
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -289,12 +369,7 @@ spec:
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must
@@ -312,9 +387,9 @@ spec:
               horizontalPodAutoscaler:
                 description: |-
                   Creates a `HorizontalPodAutoscaler`
-                  for the agentgateway proxy. If absent, no HPA is created. If present, an
-                  HPA is created with its `scaleTargetRef` automatically configured to
-                  target the agentgateway proxy `Deployment`. The `metadata` and `spec`
+                  for Deployment-backed agentgateway proxies. If absent, no HPA is created.
+                  If present, an HPA is created with its `scaleTargetRef` automatically
+                  configured to target the generated `Deployment`. The `metadata` and `spec`
                   fields from this overlay are applied to the generated HPA.
                 properties:
                   metadata:
@@ -507,9 +582,9 @@ spec:
                 description: |-
                   Creates a `PodDisruptionBudget` for the
                   agentgateway proxy. If absent, no PDB is created. If present, a PDB is
-                  created with its selector automatically configured to target the
-                  agentgateway proxy `Deployment`. The `metadata` and `spec` fields from
-                  this overlay are applied to the generated PDB.
+                  created with its selector automatically configured to target the selected
+                  generated workload. The `metadata` and `spec` fields from this overlay are
+                  applied to the generated PDB.
                 properties:
                   metadata:
                     description: |-
@@ -871,7 +946,32 @@ spec:
                 - message: The 'min' value must be less than or equal to the 'max'
                     value.
                   rule: self.min <= self.max
+              workload:
+                description: |-
+                  `workload` selects the Kubernetes workload kind for the managed Gateway
+                  data plane. If unset, Deployment is used.
+                properties:
+                  kind:
+                    description: Kind selects the Kubernetes workload kind. When unset,
+                      Deployment is used.
+                    enum:
+                    - DaemonSet
+                    - Deployment
+                    type: string
+                type: object
             type: object
+            x-kubernetes-validations:
+            - message: deployment overlays are only valid when workload.kind is Deployment
+                or unset
+              rule: '!has(self.deployment) || !has(self.workload) || !has(self.workload.kind)
+                || self.workload.kind == ''Deployment'''
+            - message: daemonSet overlays are only valid when workload.kind is DaemonSet
+              rule: '!has(self.daemonSet) || (has(self.workload) && has(self.workload.kind)
+                && self.workload.kind == ''DaemonSet'')'
+            - message: horizontalPodAutoscaler is not valid when workload.kind is
+                DaemonSet
+              rule: '!has(self.horizontalPodAutoscaler) || !has(self.workload) ||
+                !has(self.workload.kind) || self.workload.kind != ''DaemonSet'''
           status:
             description: Current status for these provisioning settings.
             type: object

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -109,11 +109,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -160,11 +158,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -292,13 +288,13 @@ spec:
                                         AWS Bedrock Guardrails.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to AWS Bedrock Guardrails.
                                           properties:
                                             aws:
                                               description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
+                                                AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                                default AWS SDK credential discovery.
                                               properties:
                                                 assumeRole:
                                                   description: |-
@@ -311,29 +307,100 @@ spec:
                                                       minLength: 1
                                                       pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                       type: string
+                                                    sessionName:
+                                                      description: |-
+                                                        SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                        Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                      pattern: ^[\w+=,.@-]{2,64}$
+                                                      type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
+                                                    tags:
+                                                      description: |-
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
+                                                      items:
+                                                        description: |-
+                                                          AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                          attribution. Exactly one of value and expression must be set.
+                                                        properties:
+                                                          expression:
+                                                            description: |-
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
+                                                            maxLength: 16384
+                                                            minLength: 1
+                                                            type: string
+                                                          key:
+                                                            description: Key is the
+                                                              tag key.
+                                                            maxLength: 128
+                                                            minLength: 1
+                                                            type: string
+                                                          value:
+                                                            description: Value is
+                                                              a static tag value.
+                                                            maxLength: 256
+                                                            type: string
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                        x-kubernetes-validations:
+                                                        - message: exactly one of
+                                                            value or expression must
+                                                            be set
+                                                          rule: has(self.value) !=
+                                                            has(self.expression)
+                                                      maxItems: 50
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                      - key
+                                                      x-kubernetes-list-type: map
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
+                                                region:
+                                                  description: |-
+                                                    AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                    target AWS service is in a different region than the gateway. If unset,
+                                                    typed AWS backends may provide this automatically; otherwise the ambient
+                                                    AWS region is used.
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -362,136 +429,16 @@ spec:
                                               - message: secretRef and assumeRole
                                                   are mutually exclusive
                                                 rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
-                                            gcp:
-                                              description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
-                                              properties:
-                                                audience:
-                                                  description: |-
-                                                    Explicit `aud` value for the ID token. Only
-                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                    derived from the backend hostname.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                type:
-                                                  description: |-
-                                                    The type of token to generate. To authenticate to GCP services,
-                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                    `IdToken` is used.
-                                                  enum:
-                                                  - AccessToken
-                                                  - IdToken
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: audience is only valid with
-                                                  IdToken
-                                                rule: 'has(self.audience) ? self.type
-                                                  == ''IdToken'' : true'
                                             key:
                                               description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
+                                                Inline API key to use as the value of the `Authorization` header.
+                                                This option is the least secure; usage of a `Secret` is preferred.
                                               maxLength: 2048
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where API keys are inserted. Defaults to the `Authorization` header with
+                                                the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -505,19 +452,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -545,34 +483,33 @@ spec:
                                                   must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                   == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
+                                                Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                                By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -591,22 +528,21 @@ spec:
                                           type: object
                                           x-kubernetes-validations:
                                           - message: location may only be set for
-                                              key or passthrough auth
+                                              key or secretRef auth
                                             rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
+                                              || has(self.secretRef) : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [key secretRef aws] must be set
+                                            rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -616,17 +552,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -634,12 +563,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -656,6 +586,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -675,6 +606,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -686,10 +618,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -716,12 +648,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -730,15 +657,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -757,33 +682,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -841,8 +762,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -851,29 +771,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -885,27 +793,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -923,6 +823,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     region:
                                       description: |-
                                         AWS region where the guardrail is deployed, for example
@@ -958,135 +863,13 @@ spec:
                                         Google Model Armor.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to Google Model Armor.
                                           properties:
-                                            aws:
-                                              description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
-                                              properties:
-                                                assumeRole:
-                                                  description: |-
-                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                  properties:
-                                                    roleArn:
-                                                      description: AWS IAM role ARN
-                                                        to assume.
-                                                      minLength: 1
-                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                      type: string
-                                                  required:
-                                                  - roleArn
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                serviceName:
-                                                  description: |-
-                                                    AWS SigV4 signing service name, for example
-                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                    backends may provide this automatically.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: secretRef and assumeRole
-                                                  are mutually exclusive
-                                                rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
                                             gcp:
                                               description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
+                                                Google authentication method for Model Armor. Use `gcp: {}` for default
+                                                Google credential discovery.
                                               properties:
                                                 audience:
                                                   description: |-
@@ -1098,24 +881,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -1146,133 +936,20 @@ spec:
                                                   IdToken
                                                 rule: 'has(self.audience) ? self.type
                                                   == ''IdToken'' : true'
-                                            key:
-                                              description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
-                                              maxLength: 2048
-                                              type: string
-                                            location:
-                                              description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
-                                              properties:
-                                                cookie:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                header:
-                                                  properties:
-                                                    name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                                      type: string
-                                                    prefix:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                queryParameter:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: exactly one of the fields
-                                                  in [header queryParameter cookie]
-                                                  must be set
-                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
-                                                  == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
-                                            secretRef:
-                                              description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
-                                              properties:
-                                                group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
-                                                  type: string
-                                                kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
-                                                  type: string
-                                                name:
-                                                  description: The name of the referenced
-                                                    credential.
-                                                  maxLength: 253
-                                                  minLength: 1
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                              x-kubernetes-validations:
-                                              - message: custom credential refs must
-                                                  set both group and kind
-                                                rule: '(!has(self.group) || size(self.group)
-                                                  == 0) ? (!has(self.kind) || size(self.kind)
-                                                  == 0 || self.kind == ''Secret'')
-                                                  : (has(self.kind) && size(self.kind)
-                                                  > 0)'
                                           type: object
                                           x-kubernetes-validations:
-                                          - message: location may only be set for
-                                              key or passthrough auth
-                                            rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [gcp] must be set
+                                            rule: '[has(self.gcp)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1282,17 +959,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -1300,12 +970,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1322,6 +993,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -1341,6 +1013,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -1352,10 +1025,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -1382,12 +1055,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -1396,15 +1064,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -1423,33 +1089,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -1507,8 +1169,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -1517,29 +1178,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1551,27 +1200,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -1589,6 +1230,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     projectId:
                                       description: Google Cloud project ID.
                                       maxLength: 256
@@ -1619,194 +1265,9 @@ spec:
                                         OpenAI.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to OpenAI.
                                           properties:
-                                            aws:
-                                              description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
-                                              properties:
-                                                assumeRole:
-                                                  description: |-
-                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                  properties:
-                                                    roleArn:
-                                                      description: AWS IAM role ARN
-                                                        to assume.
-                                                      minLength: 1
-                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                      type: string
-                                                  required:
-                                                  - roleArn
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                serviceName:
-                                                  description: |-
-                                                    AWS SigV4 signing service name, for example
-                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                    backends may provide this automatically.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: secretRef and assumeRole
-                                                  are mutually exclusive
-                                                rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
-                                            gcp:
-                                              description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
-                                              properties:
-                                                audience:
-                                                  description: |-
-                                                    Explicit `aud` value for the ID token. Only
-                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                    derived from the backend hostname.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                type:
-                                                  description: |-
-                                                    The type of token to generate. To authenticate to GCP services,
-                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                    `IdToken` is used.
-                                                  enum:
-                                                  - AccessToken
-                                                  - IdToken
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: audience is only valid with
-                                                  IdToken
-                                                rule: 'has(self.audience) ? self.type
-                                                  == ''IdToken'' : true'
                                             key:
                                               description: |-
                                                 Inline key to use as the value of the
@@ -1816,9 +1277,8 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -1832,19 +1292,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1872,34 +1323,33 @@ spec:
                                                   must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                   == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -1917,23 +1367,18 @@ spec:
                                                   > 0)'
                                           type: object
                                           x-kubernetes-validations:
-                                          - message: location may only be set for
-                                              key or passthrough auth
-                                            rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [key secretRef] must be set
+                                            rule: '[has(self.key),has(self.secretRef)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1943,17 +1388,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -1961,12 +1399,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1983,6 +1422,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2002,6 +1442,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2013,10 +1454,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -2043,12 +1484,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -2057,15 +1493,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -2084,33 +1518,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -2168,8 +1598,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -2178,29 +1607,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2212,27 +1629,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -2250,6 +1659,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                   type: object
                                 regex:
                                   description: Regular expression (regex) matching
@@ -2331,29 +1745,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2364,27 +1766,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -2417,51 +1809,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -2470,6 +1837,17 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                    headers:
+                                      additionalProperties:
+                                        description: A Common Expression Language
+                                          (CEL) expression.
+                                        maxLength: 16384
+                                        minLength: 1
+                                        type: string
+                                      description: CEL-computed headers to include
+                                        in webhook requests.
+                                      maxProperties: 64
+                                      type: object
                                   required:
                                   - backendRef
                                   type: object
@@ -2506,13 +1884,13 @@ spec:
                                         AWS Bedrock Guardrails.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to AWS Bedrock Guardrails.
                                           properties:
                                             aws:
                                               description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
+                                                AWS authentication method for Bedrock Guardrails. Use `aws: {}` for
+                                                default AWS SDK credential discovery.
                                               properties:
                                                 assumeRole:
                                                   description: |-
@@ -2525,29 +1903,100 @@ spec:
                                                       minLength: 1
                                                       pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                                       type: string
+                                                    sessionName:
+                                                      description: |-
+                                                        SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                                        Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                                      pattern: ^[\w+=,.@-]{2,64}$
+                                                      type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
+                                                    tags:
+                                                      description: |-
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
+                                                      items:
+                                                        description: |-
+                                                          AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                                          attribution. Exactly one of value and expression must be set.
+                                                        properties:
+                                                          expression:
+                                                            description: |-
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
+                                                            maxLength: 16384
+                                                            minLength: 1
+                                                            type: string
+                                                          key:
+                                                            description: Key is the
+                                                              tag key.
+                                                            maxLength: 128
+                                                            minLength: 1
+                                                            type: string
+                                                          value:
+                                                            description: Value is
+                                                              a static tag value.
+                                                            maxLength: 256
+                                                            type: string
+                                                        required:
+                                                        - key
+                                                        type: object
+                                                        x-kubernetes-validations:
+                                                        - message: exactly one of
+                                                            value or expression must
+                                                            be set
+                                                          rule: has(self.value) !=
+                                                            has(self.expression)
+                                                      maxItems: 50
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                      - key
+                                                      x-kubernetes-list-type: map
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
+                                                region:
+                                                  description: |-
+                                                    AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                                                    target AWS service is in a different region than the gateway. If unset,
+                                                    typed AWS backends may provide this automatically; otherwise the ambient
+                                                    AWS region is used.
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -2576,136 +2025,16 @@ spec:
                                               - message: secretRef and assumeRole
                                                   are mutually exclusive
                                                 rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
-                                            gcp:
-                                              description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
-                                              properties:
-                                                audience:
-                                                  description: |-
-                                                    Explicit `aud` value for the ID token. Only
-                                                    valid with `IdToken` type. If not set, the `aud` is automatically
-                                                    derived from the backend hostname.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                type:
-                                                  description: |-
-                                                    The type of token to generate. To authenticate to GCP services,
-                                                    generally an `AccessToken` is used. To authenticate to Cloud Run, an
-                                                    `IdToken` is used.
-                                                  enum:
-                                                  - AccessToken
-                                                  - IdToken
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: audience is only valid with
-                                                  IdToken
-                                                rule: 'has(self.audience) ? self.type
-                                                  == ''IdToken'' : true'
                                             key:
                                               description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
+                                                Inline API key to use as the value of the `Authorization` header.
+                                                This option is the least secure; usage of a `Secret` is preferred.
                                               maxLength: 2048
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where API keys are inserted. Defaults to the `Authorization` header with
+                                                the `Bearer ` prefix. Applies to `key` and `secretRef`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -2719,19 +2048,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2759,34 +2079,33 @@ spec:
                                                   must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                                                   == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
+                                                Credential source for the API key, defaulting to a Kubernetes `Secret`.
+                                                By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
+                                                  type: string
+                                                key:
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
+                                                  maxLength: 253
+                                                  minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -2805,22 +2124,21 @@ spec:
                                           type: object
                                           x-kubernetes-validations:
                                           - message: location may only be set for
-                                              key or passthrough auth
+                                              key or secretRef auth
                                             rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
+                                              || has(self.secretRef) : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [key secretRef aws] must be set
+                                            rule: '[has(self.key),has(self.secretRef),has(self.aws)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2830,17 +2148,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -2848,12 +2159,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2870,6 +2182,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2889,6 +2202,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2900,10 +2214,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -2930,12 +2244,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -2944,15 +2253,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -2971,33 +2278,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -3055,8 +2358,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -3065,29 +2367,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3099,27 +2389,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -3137,6 +2419,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     region:
                                       description: |-
                                         AWS region where the guardrail is deployed, for example
@@ -3172,135 +2459,13 @@ spec:
                                         Google Model Armor.
                                       properties:
                                         auth:
-                                          description: Settings for managing authentication
-                                            to the backend.
+                                          description: Settings for authenticating
+                                            to Google Model Armor.
                                           properties:
-                                            aws:
-                                              description: |-
-                                                Explicit AWS authentication method for the backend.
-                                                When omitted, default AWS SDK credential discovery is used.
-                                              properties:
-                                                assumeRole:
-                                                  description: |-
-                                                    AWS STS AssumeRole settings to use before signing backend requests.
-                                                    Ambient AWS credentials are used as the source credentials for STS.
-                                                  properties:
-                                                    roleArn:
-                                                      description: AWS IAM role ARN
-                                                        to assume.
-                                                      minLength: 1
-                                                      pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
-                                                      type: string
-                                                  required:
-                                                  - roleArn
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                                serviceName:
-                                                  description: |-
-                                                    AWS SigV4 signing service name, for example
-                                                    `bedrock`, `bedrock-agentcore`, or `execute-api`). If unset, typed AWS
-                                                    backends may provide this automatically.
-                                                  maxLength: 256
-                                                  minLength: 1
-                                                  type: string
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: secretRef and assumeRole
-                                                  are mutually exclusive
-                                                rule: '!(has(self.secretRef) && has(self.assumeRole))'
-                                            azure:
-                                              description: Azure authentication method
-                                                for the backend.
-                                              properties:
-                                                managedIdentity:
-                                                  description: Managed identity authentication
-                                                    settings.
-                                                  properties:
-                                                    clientId:
-                                                      type: string
-                                                    objectId:
-                                                      type: string
-                                                    resourceId:
-                                                      type: string
-                                                  required:
-                                                  - clientId
-                                                  - objectId
-                                                  - resourceId
-                                                  type: object
-                                                secretRef:
-                                                  description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
-                                                  properties:
-                                                    group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
-                                                      type: string
-                                                    kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
-                                                      type: string
-                                                    name:
-                                                      description: The name of the
-                                                        referenced credential.
-                                                      maxLength: 253
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                  x-kubernetes-validations:
-                                                  - message: custom credential refs
-                                                      must set both group and kind
-                                                    rule: '(!has(self.group) || size(self.group)
-                                                      == 0) ? (!has(self.kind) ||
-                                                      size(self.kind) == 0 || self.kind
-                                                      == ''Secret'') : (has(self.kind)
-                                                      && size(self.kind) > 0)'
-                                              type: object
                                             gcp:
                                               description: |-
-                                                Google authentication method for the backend.
-                                                When omitted, default Google credential discovery is used.
+                                                Google authentication method for Model Armor. Use `gcp: {}` for default
+                                                Google credential discovery.
                                               properties:
                                                 audience:
                                                   description: |-
@@ -3312,24 +2477,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key. When omitted, ambient credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
+                                                      type: string
+                                                    key:
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
+                                                      maxLength: 253
+                                                      minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -3360,133 +2532,20 @@ spec:
                                                   IdToken
                                                 rule: 'has(self.audience) ? self.type
                                                   == ''IdToken'' : true'
-                                            key:
-                                              description: |-
-                                                Inline key to use as the value of the
-                                                `Authorization` header. This option is the least secure; usage of a
-                                                `Secret` is preferred.
-                                              maxLength: 2048
-                                              type: string
-                                            location:
-                                              description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
-                                              properties:
-                                                cookie:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                header:
-                                                  properties:
-                                                    name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
-                                                      type: string
-                                                    prefix:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                                queryParameter:
-                                                  properties:
-                                                    name:
-                                                      maxLength: 256
-                                                      minLength: 1
-                                                      type: string
-                                                  required:
-                                                  - name
-                                                  type: object
-                                              type: object
-                                              x-kubernetes-validations:
-                                              - message: exactly one of the fields
-                                                  in [header queryParameter cookie]
-                                                  must be set
-                                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
-                                                  == 1'
-                                            passthrough:
-                                              description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
-                                              type: object
-                                            secretRef:
-                                              description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key.
-                                              properties:
-                                                group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
-                                                  type: string
-                                                kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
-                                                  type: string
-                                                name:
-                                                  description: The name of the referenced
-                                                    credential.
-                                                  maxLength: 253
-                                                  minLength: 1
-                                                  type: string
-                                              required:
-                                              - name
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                              x-kubernetes-validations:
-                                              - message: custom credential refs must
-                                                  set both group and kind
-                                                rule: '(!has(self.group) || size(self.group)
-                                                  == 0) ? (!has(self.kind) || size(self.kind)
-                                                  == 0 || self.kind == ''Secret'')
-                                                  : (has(self.kind) && size(self.kind)
-                                                  > 0)'
                                           type: object
                                           x-kubernetes-validations:
-                                          - message: location may only be set for
-                                              key or passthrough auth
-                                            rule: 'has(self.location) ? has(self.key)
-                                              || has(self.secretRef) || has(self.passthrough)
-                                              : true'
                                           - message: exactly one of the fields in
-                                              [key secretRef passthrough aws azure
-                                              gcp] must be set
-                                            rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
+                                              [gcp] must be set
+                                            rule: '[has(self.gcp)].filter(x,x==true).size()
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -3496,17 +2555,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -3514,12 +2566,13 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -3536,6 +2589,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -3555,6 +2609,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -3566,10 +2621,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -3596,12 +2651,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -3610,15 +2660,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -3637,33 +2685,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -3721,8 +2765,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -3731,29 +2774,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3765,27 +2796,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -3803,6 +2826,11 @@ spec:
                                           - backendRef
                                           type: object
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [auth
+                                          http tcp tls tunnel] must be set
+                                        rule: '[has(self.auth),has(self.http),has(self.tcp),has(self.tls),has(self.tunnel)].filter(x,x==true).size()
+                                          >= 1'
                                     projectId:
                                       description: Google Cloud project ID.
                                       maxLength: 256
@@ -3897,29 +2925,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3930,27 +2946,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -3983,51 +2989,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4036,6 +3017,17 @@ spec:
                                         - value
                                         type: object
                                       type: array
+                                    headers:
+                                      additionalProperties:
+                                        description: A Common Expression Language
+                                          (CEL) expression.
+                                        maxLength: 16384
+                                        minLength: 1
+                                        type: string
+                                      description: CEL-computed headers to include
+                                        in webhook requests.
+                                      maxProperties: 64
+                                      type: object
                                   required:
                                   - backendRef
                                   type: object
@@ -4104,11 +3096,9 @@ spec:
                               minLength: 1
                               type: string
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field to set.
                               maxLength: 256
+                              minLength: 1
                               type: string
                           required:
                           - expression
@@ -4125,7 +3115,7 @@ spec:
                       rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                         >= 1'
                   auth:
-                    description: Settings for managing authentication to the backend.
+                    description: Settings for managing authentication to the backend
                     properties:
                       aws:
                         description: |-
@@ -4142,28 +3132,92 @@ spec:
                                 minLength: 1
                                 pattern: ^arn:aws[a-z-]*:iam::[0-9]{12}:role/.+$
                                 type: string
+                              sessionName:
+                                description: |-
+                                  SessionName is a custom session name (RoleSessionName) for CloudTrail and
+                                  Cost & Usage Report attribution. If unset, AWS generates a random name.
+                                pattern: ^[\w+=,.@-]{2,64}$
+                                type: string
+                              sessionNameExpression:
+                                description: |-
+                                  SessionNameExpression is a CEL expression evaluated against each request
+                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                  session name at request time, the request is rejected.
+                                maxLength: 16384
+                                minLength: 1
+                                type: string
+                              tags:
+                                description: |-
+                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                  & Usage Report, once activated. STS allows at most 50 per role session.
+                                items:
+                                  description: |-
+                                    AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
+                                    attribution. Exactly one of value and expression must be set.
+                                  properties:
+                                    expression:
+                                      description: |-
+                                        CEL expression evaluated against each request to produce the tag value,
+                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                        tag values are rejected.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                    key:
+                                      description: Key is the tag key.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value is a static tag value.
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: exactly one of value or expression must
+                                      be set
+                                    rule: has(self.value) != has(self.expression)
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
                             required:
                             - roleArn
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [sessionName sessionNameExpression]
+                                may be set
+                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                <= 1'
+                          region:
+                            description: |-
+                              AWS SigV4 signing region, for example `us-east-1`. Set this when the
+                              target AWS service is in a different region than the gateway. If unset,
+                              typed AWS backends may provide this automatically; otherwise the ambient
+                              AWS region is used.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the AWS credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                              optionally `sessionToken`.
+                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                              `sessionToken` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -4209,23 +3263,20 @@ spec:
                             type: object
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the Azure credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                              `clientSecret`.
+                              Credential source for Azure credentials, defaulting to a Kubernetes
+                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                              `clientSecret` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -4240,6 +3291,695 @@ spec:
                                 (!has(self.kind) || size(self.kind) == 0 || self.kind
                                 == ''Secret'') : (has(self.kind) && size(self.kind)
                                 > 0)'
+                          workloadIdentity:
+                            description: |-
+                              Workload identity authentication settings. Uses the federated token and
+                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                              Workload Identity enabled.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: at most one of the fields in [secretRef managedIdentity
+                            workloadIdentity] may be set
+                          rule: '[has(self.secretRef),has(self.managedIdentity),has(self.workloadIdentity)].filter(x,x==true).size()
+                            <= 1'
+                      credentials:
+                        description: |-
+                          Credentials is a list of additional credentials to inject on the
+                          backend request. Each entry resolves a Secret key and writes its value
+                          to the entry's location. `credentials` is independent of the primary
+                          `key`/`secretRef`/`passthrough` mechanism and may be set on its own or
+                          alongside it.
+                        items:
+                          description: |-
+                            BackendAuthCredential specifies one additional credential to inject on the
+                            backend request.
+                          properties:
+                            location:
+                              description: Where the credential is inserted on the
+                                backend request.
+                              properties:
+                                cookie:
+                                  properties:
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                header:
+                                  properties:
+                                    name:
+                                      description: Name of an HTTP header. HTTP/2
+                                        pseudo-headers (names beginning with `:`)
+                                        are not supported
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    prefix:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryParameter:
+                                  properties:
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: exactly one of the fields in [header queryParameter
+                                  cookie] must be set
+                                rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                  == 1'
+                            secretRef:
+                              description: |-
+                                SecretRef references a Kubernetes Secret holding the credential value, and
+                                optionally overrides the key read from it. Defaults to `Authorization`,
+                                matching the key convention used by the top-level `secretRef`.
+                              properties:
+                                group:
+                                  description: API group of the referenced credential;
+                                    empty selects the core API group
+                                  type: string
+                                key:
+                                  description: Key in the referenced Secret. If omitted,
+                                    a location-specific default is used
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                kind:
+                                  description: Kind of the referenced credential;
+                                    empty defaults to `Secret`
+                                  type: string
+                                name:
+                                  description: Name of the referenced credential
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                              x-kubernetes-validations:
+                              - message: custom credential refs must set both group
+                                  and kind
+                                rule: '(!has(self.group) || size(self.group) == 0)
+                                  ? (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                  == ''Secret'') : (has(self.kind) && size(self.kind)
+                                  > 0)'
+                          required:
+                          - location
+                          - secretRef
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      crossAppAccess:
+                        description: Cross App Access (Identity Assertion / ID-JAG)
+                          authentication.
+                        properties:
+                          audience:
+                            description: Identifier of the resource authorization
+                              server. The issued ID-JAG is bound to this audience.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          cache:
+                            description: Response cache configuration.
+                            properties:
+                              inMemory:
+                                properties:
+                                  defaultTtl:
+                                    description: TTL used when the token endpoint
+                                      omits expires_in. Default 300s.
+                                    type: string
+                                  maxEntries:
+                                    description: Default 8192; 0 disables the cache.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          identityProvider:
+                            description: User identity provider authorization server,
+                              used for the RFC 8693 ID-JAG exchange.
+                            properties:
+                              backendRef:
+                                description: Token endpoint backend.
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              clientAuth:
+                                description: Client authentication for the token endpoint.
+                                properties:
+                                  clientId:
+                                    description: Client ID sent to the token endpoint.
+                                    minLength: 1
+                                    type: string
+                                  method:
+                                    description: Client authentication method. Defaults
+                                      to ClientSecretBasic.
+                                    enum:
+                                    - ClientSecretBasic
+                                    - ClientSecretPost
+                                    - PrivateKeyJwt
+                                    type: string
+                                  privateKeyJwt:
+                                    description: Client assertion settings. Required
+                                      when method is PrivateKeyJwt.
+                                    properties:
+                                      alg:
+                                        description: JWS signing algorithm. Defaults
+                                          to RS256.
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - PS256
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      assertionAudience:
+                                        description: Audience for the client assertion,
+                                          typically the token endpoint URL.
+                                        minLength: 1
+                                        type: string
+                                      certificateHeader:
+                                        description: JWS certificate header. Required
+                                          when certificateRef is set.
+                                        enum:
+                                        - x5c
+                                        - x5t#S256
+                                        type: string
+                                      certificateRef:
+                                        description: |-
+                                          PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                          leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                          but the token endpoint will reject the assertions. Required when
+                                          certificateHeader is set. The key defaults to `certificate`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                      kid:
+                                        description: Optional JWS key ID header.
+                                        type: string
+                                      signingKeyRef:
+                                        description: PEM-encoded RSA or EC private
+                                          key; key defaults to `signingKey`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                    required:
+                                    - assertionAudience
+                                    - signingKeyRef
+                                    type: object
+                                    x-kubernetes-validations:
+                                    - message: certificateRef and certificateHeader
+                                        must be set together
+                                      rule: has(self.certificateRef) == has(self.certificateHeader)
+                                  secretRef:
+                                    description: |-
+                                      Secret providing the `clientSecret` key by default; override via
+                                      `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                      is only valid with ClientSecretPost.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - clientId
+                                type: object
+                                x-kubernetes-validations:
+                                - message: privateKeyJwt settings require method PrivateKeyJwt
+                                  rule: has(self.privateKeyJwt) == (has(self.method)
+                                    && self.method == 'PrivateKeyJwt')
+                                - message: secretRef is not valid with method PrivateKeyJwt
+                                  rule: '!has(self.secretRef) || !has(self.method)
+                                    || self.method != ''PrivateKeyJwt'''
+                                - message: clientAuth without secretRef requires method
+                                    ClientSecretPost or PrivateKeyJwt
+                                  rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                    || (has(self.method) && self.method == 'ClientSecretPost')
+                              path:
+                                description: Token endpoint path; defaults to "/".
+                                  Must start with "/".
+                                pattern: ^/
+                                type: string
+                            required:
+                            - backendRef
+                            - clientAuth
+                            type: object
+                          resourceAuthorizationServer:
+                            description: Resource authorization server, used for the
+                              RFC 7523 jwt-bearer exchange.
+                            properties:
+                              backendRef:
+                                description: Token endpoint backend.
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              clientAuth:
+                                description: Client authentication for the token endpoint.
+                                properties:
+                                  clientId:
+                                    description: Client ID sent to the token endpoint.
+                                    minLength: 1
+                                    type: string
+                                  method:
+                                    description: Client authentication method. Defaults
+                                      to ClientSecretBasic.
+                                    enum:
+                                    - ClientSecretBasic
+                                    - ClientSecretPost
+                                    - PrivateKeyJwt
+                                    type: string
+                                  privateKeyJwt:
+                                    description: Client assertion settings. Required
+                                      when method is PrivateKeyJwt.
+                                    properties:
+                                      alg:
+                                        description: JWS signing algorithm. Defaults
+                                          to RS256.
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - PS256
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      assertionAudience:
+                                        description: Audience for the client assertion,
+                                          typically the token endpoint URL.
+                                        minLength: 1
+                                        type: string
+                                      certificateHeader:
+                                        description: JWS certificate header. Required
+                                          when certificateRef is set.
+                                        enum:
+                                        - x5c
+                                        - x5t#S256
+                                        type: string
+                                      certificateRef:
+                                        description: |-
+                                          PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                          leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                          but the token endpoint will reject the assertions. Required when
+                                          certificateHeader is set. The key defaults to `certificate`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                      kid:
+                                        description: Optional JWS key ID header.
+                                        type: string
+                                      signingKeyRef:
+                                        description: PEM-encoded RSA or EC private
+                                          key; key defaults to `signingKey`.
+                                        properties:
+                                          group:
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
+                                            type: string
+                                          key:
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          kind:
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
+                                            type: string
+                                          name:
+                                            description: Name of the referenced credential
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                        x-kubernetes-validations:
+                                        - message: custom credential refs must set
+                                            both group and kind
+                                          rule: '(!has(self.group) || size(self.group)
+                                            == 0) ? (!has(self.kind) || size(self.kind)
+                                            == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                            && size(self.kind) > 0)'
+                                    required:
+                                    - assertionAudience
+                                    - signingKeyRef
+                                    type: object
+                                    x-kubernetes-validations:
+                                    - message: certificateRef and certificateHeader
+                                        must be set together
+                                      rule: has(self.certificateRef) == has(self.certificateHeader)
+                                  secretRef:
+                                    description: |-
+                                      Secret providing the `clientSecret` key by default; override via
+                                      `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                      is only valid with ClientSecretPost.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - clientId
+                                type: object
+                                x-kubernetes-validations:
+                                - message: privateKeyJwt settings require method PrivateKeyJwt
+                                  rule: has(self.privateKeyJwt) == (has(self.method)
+                                    && self.method == 'PrivateKeyJwt')
+                                - message: secretRef is not valid with method PrivateKeyJwt
+                                  rule: '!has(self.secretRef) || !has(self.method)
+                                    || self.method != ''PrivateKeyJwt'''
+                                - message: clientAuth without secretRef requires method
+                                    ClientSecretPost or PrivateKeyJwt
+                                  rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                    || (has(self.method) && self.method == 'ClientSecretPost')
+                              path:
+                                description: Token endpoint path; defaults to "/".
+                                  Must start with "/".
+                                pattern: ^/
+                                type: string
+                            required:
+                            - backendRef
+                            - clientAuth
+                            type: object
+                          resources:
+                            description: Resources sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          scopes:
+                            description: Scopes sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          subjectToken:
+                            description: |-
+                              Subject token sent to the identity provider. Defaults to an OpenID Connect
+                              ID token read from the Authorization Bearer header.
+                            properties:
+                              source:
+                                description: Where to read the subject token. Defaults
+                                  to the Authorization Bearer header.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                            type: object
+                        required:
+                        - audience
+                        - identityProvider
+                        - resourceAuthorizationServer
                         type: object
                       gcp:
                         description: |-
@@ -4256,23 +3996,27 @@ spec:
                             type: string
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing ADC-compatible Google credential JSON. When using
-                              the default Secret resolver, this must be stored in the `credentials.json`
-                              key. When omitted, ambient credentials are used.
+                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                              a Kubernetes `Secret`. By default, the value is read from
+                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                              ambient credentials are used.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              key:
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
+                                maxLength: 253
+                                minLength: 1
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -4311,7 +4055,7 @@ spec:
                         description: |-
                           Where backend credentials are inserted.
                           If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                          This applies to `key`, `secretRef`, and `passthrough`.
+                          This applies to `key`, `secretRef`, and `passthrough`. Entries in `credentials` carry their own location.
                         properties:
                           cookie:
                             properties:
@@ -4325,19 +4069,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4364,33 +4097,526 @@ spec:
                             cookie] must be set
                           rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
                             == 1'
+                      oauthTokenExchange:
+                        description: OAuth 2.0 token exchange (RFC 8693) / jwt-bearer
+                          (RFC 7523) authentication.
+                        properties:
+                          actorToken:
+                            description: RFC 8693 delegation actor token. TokenExchange
+                              grant only.
+                            properties:
+                              mayAct:
+                                description: may_act claim validation mode. When omitted,
+                                  may_act is not enforced.
+                                enum:
+                                - Required
+                                type: string
+                              source:
+                                description: Where to read the actor token. Actor
+                                  tokens have no default source.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                              tokenType:
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for actor tokens.
+                                type: string
+                            required:
+                            - source
+                            type: object
+                            x-kubernetes-validations:
+                            - message: mayAct Required requires tokenType Jwt
+                              rule: '!has(self.mayAct) || self.mayAct != ''Required''
+                                || (has(self.tokenType) && self.tokenType == ''Jwt'')'
+                          additionalParams:
+                            additionalProperties:
+                              description: A Common Expression Language (CEL) expression.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                            description: Extra form params; values are CEL expressions
+                              over the incoming request.
+                            maxProperties: 64
+                            type: object
+                          audiences:
+                            description: Audiences sent to the token endpoint.
+                            items:
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          backendRef:
+                            description: RFC 8693 token endpoint backend.
+                            properties:
+                              group:
+                                default: ""
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Service
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                              port:
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                ? has(self.port) : true'
+                          cache:
+                            description: Response cache configuration.
+                            properties:
+                              inMemory:
+                                properties:
+                                  defaultTtl:
+                                    description: TTL used when the token endpoint
+                                      omits expires_in. Default 300s.
+                                    type: string
+                                  maxEntries:
+                                    description: Default 8192; 0 disables the cache.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          clientAuth:
+                            description: Client authentication for the token endpoint.
+                              When unset, none is sent.
+                            properties:
+                              clientId:
+                                description: Client ID sent to the token endpoint.
+                                minLength: 1
+                                type: string
+                              method:
+                                description: Client authentication method. Defaults
+                                  to ClientSecretBasic.
+                                enum:
+                                - ClientSecretBasic
+                                - ClientSecretPost
+                                - PrivateKeyJwt
+                                type: string
+                              privateKeyJwt:
+                                description: Client assertion settings. Required when
+                                  method is PrivateKeyJwt.
+                                properties:
+                                  alg:
+                                    description: JWS signing algorithm. Defaults to
+                                      RS256.
+                                    enum:
+                                    - ES256
+                                    - ES384
+                                    - PS256
+                                    - RS256
+                                    - RS384
+                                    - RS512
+                                    type: string
+                                  assertionAudience:
+                                    description: Audience for the client assertion,
+                                      typically the token endpoint URL.
+                                    minLength: 1
+                                    type: string
+                                  certificateHeader:
+                                    description: JWS certificate header. Required
+                                      when certificateRef is set.
+                                    enum:
+                                    - x5c
+                                    - x5t#S256
+                                    type: string
+                                  certificateRef:
+                                    description: |-
+                                      PEM-encoded X.509 certificate chain, leaf first, for certificateHeader. The
+                                      leaf public key should match signingKeyRef; a mismatch only logs a warning
+                                      but the token endpoint will reject the assertions. Required when
+                                      certificateHeader is set. The key defaults to `certificate`.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                  kid:
+                                    description: Optional JWS key ID header.
+                                    type: string
+                                  signingKeyRef:
+                                    description: PEM-encoded RSA or EC private key;
+                                      key defaults to `signingKey`.
+                                    properties:
+                                      group:
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
+                                        type: string
+                                      key:
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      kind:
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
+                                        type: string
+                                      name:
+                                        description: Name of the referenced credential
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                    x-kubernetes-validations:
+                                    - message: custom credential refs must set both
+                                        group and kind
+                                      rule: '(!has(self.group) || size(self.group)
+                                        == 0) ? (!has(self.kind) || size(self.kind)
+                                        == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                        && size(self.kind) > 0)'
+                                required:
+                                - assertionAudience
+                                - signingKeyRef
+                                type: object
+                                x-kubernetes-validations:
+                                - message: certificateRef and certificateHeader must
+                                    be set together
+                                  rule: has(self.certificateRef) == has(self.certificateHeader)
+                              secretRef:
+                                description: |-
+                                  Secret providing the `clientSecret` key by default; override via
+                                  `secretRef.key`. When omitted, client_id is sent without a secret, which
+                                  is only valid with ClientSecretPost.
+                                properties:
+                                  group:
+                                    description: API group of the referenced credential;
+                                      empty selects the core API group
+                                    type: string
+                                  key:
+                                    description: Key in the referenced Secret. If
+                                      omitted, a location-specific default is used
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  kind:
+                                    description: Kind of the referenced credential;
+                                      empty defaults to `Secret`
+                                    type: string
+                                  name:
+                                    description: Name of the referenced credential
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                                x-kubernetes-validations:
+                                - message: custom credential refs must set both group
+                                    and kind
+                                  rule: '(!has(self.group) || size(self.group) ==
+                                    0) ? (!has(self.kind) || size(self.kind) == 0
+                                    || self.kind == ''Secret'') : (has(self.kind)
+                                    && size(self.kind) > 0)'
+                            required:
+                            - clientId
+                            type: object
+                            x-kubernetes-validations:
+                            - message: privateKeyJwt settings require method PrivateKeyJwt
+                              rule: has(self.privateKeyJwt) == (has(self.method) &&
+                                self.method == 'PrivateKeyJwt')
+                            - message: secretRef is not valid with method PrivateKeyJwt
+                              rule: '!has(self.secretRef) || !has(self.method) ||
+                                self.method != ''PrivateKeyJwt'''
+                            - message: clientAuth without secretRef requires method
+                                ClientSecretPost or PrivateKeyJwt
+                              rule: has(self.secretRef) || has(self.privateKeyJwt)
+                                || (has(self.method) && self.method == 'ClientSecretPost')
+                          grantType:
+                            description: RFC followed by the request. Defaults to
+                              TokenExchange (RFC 8693).
+                            enum:
+                            - JwtBearer
+                            - TokenExchange
+                            type: string
+                          location:
+                            description: |-
+                              Where the exchanged token is written to the backend request.
+                              Defaults to Authorization: Bearer.
+                            properties:
+                              cookie:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              header:
+                                properties:
+                                  name:
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  prefix:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              queryParameter:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of the fields in [header queryParameter
+                                cookie] must be set
+                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                == 1'
+                          path:
+                            description: Token endpoint path; defaults to "/". Must
+                              start with "/".
+                            pattern: ^/
+                            type: string
+                          requestedTokenType:
+                            description: |-
+                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                              built-in values may be requested; custom URIs are not supported here.
+                            enum:
+                            - AccessToken
+                            - Jwt
+                            - IdToken
+                            - IdJag
+                            type: string
+                          resources:
+                            description: Resources sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          scopes:
+                            description: Scopes sent to the token endpoint.
+                            items:
+                              type: string
+                            maxItems: 64
+                            minItems: 1
+                            type: array
+                          subjectToken:
+                            description: |-
+                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                              The token type may be a built-in value or a custom absolute URI for providers
+                              that support custom token exchange profiles.
+                            properties:
+                              source:
+                                description: Where to read the token. CEL `expression`
+                                  variant is permitted.
+                                properties:
+                                  cookie:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  expression:
+                                    description: CEL expression that extracts the
+                                      credential from the request.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  header:
+                                    properties:
+                                      name:
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      prefix:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  queryParameter:
+                                    properties:
+                                      name:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                type: object
+                                x-kubernetes-validations:
+                                - message: exactly one of the fields in [header queryParameter
+                                    cookie expression] must be set
+                                  rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
+                                    == 1'
+                              tokenType:
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for subject tokens.
+                                type: string
+                            type: object
+                        required:
+                        - backendRef
+                        type: object
+                        x-kubernetes-validations:
+                        - message: actorToken is only valid with TokenExchange grantType
+                          rule: '!(has(self.actorToken) && has(self.grantType) &&
+                            self.grantType == ''JwtBearer'')'
+                        - message: requestedTokenType is only valid with TokenExchange
+                            grantType
+                          rule: '!(has(self.requestedTokenType) && has(self.grantType)
+                            && self.grantType == ''JwtBearer'')'
+                        - message: requestedTokenType IdJag is only supported by crossAppAccess
+                          rule: '!has(self.requestedTokenType) || self.requestedTokenType
+                            != ''IdJag'''
                       passthrough:
                         description: |-
-                          Passes through an existing token that has been sent by the
-                          client and validated. Other policies, like JWT and API key
-                          authentication, will strip the original client credentials. Passthrough backend authentication
-                          causes the original token to be added back into the request. If there are no client authentication policies on the
-                          request, the original token would be unchanged, so this would have no effect.
+                          Reuses a client token already validated by another policy. Those policies
+                          may strip client credentials; passthrough adds the original token back to
+                          the backend request. Without client auth policies, this has no effect.
                         type: object
                       secretRef:
                         description: |-
-                          Credential source, defaulting to a Kubernetes
-                          `Secret`, storing the key to use as the authorization value. When using
-                          the default Secret resolver, this must be stored in the `Authorization`
-                          key.
+                          Credential source for the authorization value, defaulting to a Kubernetes
+                          `Secret`. By default, the value is read from the `Authorization` key; set
+                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                          the default `Authorization` key.
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
+                            type: string
+                          key:
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
+                            maxLength: 253
+                            minLength: 1
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -4406,13 +4632,19 @@ spec:
                             (has(self.kind) && size(self.kind) > 0)'
                     type: object
                     x-kubernetes-validations:
-                    - message: location may only be set for key or passthrough auth
+                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                        (credentials may be combined with a primary auth kind)
+                      rule: has(self.credentials) || has(self.key) || has(self.secretRef)
+                        || has(self.passthrough) || has(self.aws) || has(self.azure)
+                        || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                    - message: location may only be set for key, secretRef, or passthrough
+                        auth
                       rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
                         || has(self.passthrough) : true'
-                    - message: exactly one of the fields in [key secretRef passthrough
-                        aws azure gcp] must be set
-                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size()
-                        == 1'
+                    - message: at most one of the fields in [key secretRef passthrough
+                        aws azure gcp oauthTokenExchange crossAppAccess] may be set
+                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                        <= 1'
                   extAuth:
                     description: |-
                       External authentication configuration for requests
@@ -4426,29 +4658,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4459,27 +4677,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -4493,7 +4700,7 @@ spec:
                             ? has(self.port) : true'
                       cache:
                         description: |-
-                          Caches gRPC authorization results.
+                          Caches authorization results.
 
                           WARNING: the safety of this feature depends on the cache key accurately
                           capturing every request property that the authorization service uses to
@@ -4642,6 +4849,13 @@ spec:
                               type: string
                             maxItems: 64
                             type: array
+                          body:
+                            description: |-
+                              Body is a CEL expression that produces the HTTP authorization request body.
+                              Strings and bytes are used directly; other values are JSON-encoded.
+                            maxLength: 16384
+                            minLength: 1
+                            type: string
                           path:
                             description: |-
                               Path to send to the authorization server. If
@@ -4677,8 +4891,8 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-validations:
-                    - message: cache requires grpc
-                      rule: '!has(self.cache) || has(self.grpc)'
+                    - message: forwardBody cannot be used with http.body
+                      rule: '!(has(self.forwardBody) && has(self.http) && has(self.http.body))'
                   health:
                     description: Settings for passive and active health checking.
                     properties:
@@ -4702,6 +4916,7 @@ spec:
                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                               rather than failing entirely.
                               If unset, defaults to `3s`.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -4710,13 +4925,12 @@ spec:
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
-                              EWMA health score threshold, expressed as 0 to 100.
-                              When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-                              For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-                              Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-                              so a single success in a stream of failures can delay eviction.
-                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-                              When neither is set, a single unhealthy response triggers eviction.
+                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                              only if its computed health drops below this value after an unhealthy
+                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                              consecutiveFailures, this sliding-window average lets a single success delay
+                              eviction. If both are set, either condition evicts; if neither, a single
+                              unhealthy response evicts.
                             format: int32
                             maximum: 100
                             minimum: 0
@@ -4745,10 +4959,11 @@ spec:
                         type: string
                     type: object
                   http:
-                    description: Settings for managing HTTP requests to the backend.
+                    description: Settings for managing HTTP requests to the backend
                     properties:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -4757,17 +4972,10 @@ spec:
                           rule: duration(self) >= duration('1ms')
                       version:
                         description: |-
-                          HTTP protocol version to use when connecting to
-                          the backend.
-                          If not specified, the version is automatically determined:
-                          * `Service` types can specify it with `appProtocol` on the `Service`
-                            port.
-                          * If traffic is identified as gRPC, `HTTP2` is used.
-                          * If the incoming traffic was plaintext HTTP, the original protocol will
-                            be used.
-                          * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                            because most clients will transparently upgrade HTTPS traffic to
-                            `HTTP2`, even if the backend doesn't support it.
+                          HTTP protocol version for backend connections. If unset, it is inferred:
+                          `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                          plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                          to HTTP/2 even when the backend does not support it.
                         enum:
                         - HTTP1
                         - HTTP2
@@ -4801,6 +5009,44 @@ spec:
                               Client ID to use for short-circuiting Dynamic Client Registration.
                               If set, the gateway will not proxy registration requests to the IDP and instead return this client ID.
                             type: string
+                          clientSecretRef:
+                            description: |-
+                              Reference to a Kubernetes Secret holding the OAuth client secret of the app
+                              registration identified by `clientId` (for example Entra ID confidential clients,
+                              which require the secret at the token endpoint). The gateway injects it into the
+                              token requests it proxies to the provider. Defaults to the `clientSecret` key;
+                              override via `clientSecretRef.key`.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              key:
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
                           issuer:
                             description: |-
                               IdP that issued the JWT. This corresponds to the
@@ -4823,29 +5069,16 @@ spec:
                                 properties:
                                   group:
                                     default: ""
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   kind:
                                     default: Service
-                                    description: |-
-                                      Kind is the Kubernetes resource kind of the referent. For example
-                                      "Service".
-
-                                      Defaults to "Service" when not specified.
-
-                                      ExternalName services can refer to CNAME DNS records that may live
-                                      outside of the cluster and as such are difficult to reason about in
-                                      terms of conformance. They also may not be safe to forward to (see
-                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                      support ExternalName Services.
-
-                                      Support: Core (Services with a type other than ExternalName)
-
-                                      Support: Implementation-specific (Services with type ExternalName)
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4856,27 +5089,16 @@ spec:
                                     minLength: 1
                                     type: string
                                   namespace:
-                                    description: |-
-                                      Namespace is the namespace of the backend. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   port:
-                                    description: |-
-                                      Port specifies the destination port number to use for this resource.
-                                      Port is required when the referent is a Kubernetes Service. In this
-                                      case, the port number is the service port number, not the target port.
-                                      For other resources, destination port might be derived from the referent
-                                      resource or this field.
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -4890,6 +5112,7 @@ spec:
                                     ? has(self.port) : true'
                               cacheDuration:
                                 default: 5m
+                                maxLength: 32
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid duration value
@@ -4919,6 +5142,9 @@ spec:
                             description: Identity provider to use for authentication.
                             enum:
                             - Auth0
+                            - Authentik
+                            - Descope
+                            - Entra
                             - Keycloak
                             - Okta
                             type: string
@@ -4961,8 +5187,8 @@ spec:
                               * `Require`: every require rule must match for the request to be allowed.
                               * `Deny`: any matching deny rule denies the request.
 
-                              A CEL expression that fails to evaluate does not match. Prefer `Require`
-                              for deny-by-default behavior.
+                              `Deny` is not recommended because expression failures fail to deny; prefer
+                              `Allow` or `Require`. If used, design expressions defensively against evaluation errors.
 
                               If at least one `Allow` rule is configured, requests are denied unless at
                               least one allow rule matches.
@@ -5055,29 +5281,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5088,27 +5302,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -5186,12 +5390,13 @@ spec:
                       rule: '[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size()
                         >= 1'
                   tcp:
-                    description: Settings for managing TCP connections to the backend.
+                    description: Settings for managing TCP connections to the backend
                     properties:
                       connectTimeout:
                         description: |-
                           Deadline for establishing a connection to
                           the destination.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -5207,6 +5412,7 @@ spec:
                             description: |-
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -5225,6 +5431,7 @@ spec:
                             description: |-
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -5235,10 +5442,10 @@ spec:
                     type: object
                   tls:
                     description: |-
-                      Settings for managing TLS connections to the backend.
+                      Settings for managing TLS connections to the backend
 
-                      If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                      validate the server, and the SNI will automatically be set based on the destination.
+                      When set, TLS is originated to the backend using the system trusted CA
+                      certificates, and SNI is inferred from the destination.
                     properties:
                       alpnProtocols:
                         description: |-
@@ -5265,12 +5472,7 @@ spec:
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -5279,15 +5481,13 @@ spec:
                         x-kubernetes-list-type: atomic
                       insecureSkipVerify:
                         description: |-
-                          Originates TLS but skips verification of the backend's certificate.
-                          WARNING: This is an insecure option that should only be used if the risks are understood.
+                          Originates TLS but skips verification of the backend's certificate
+                          WARNING: insecure; only use if the risks are understood
 
-                          There are two modes:
-                          * `All` disables all TLS verification.
-                          * `Hostname` verifies the CA certificate is trusted, but ignores any
-                            mismatch of hostname or SANs. Note that this method is still insecure;
-                            prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                            if possible.
+                          Modes:
+                          * `All` disables all TLS verification
+                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                            Still insecure; prefer `verifySubjectAltNames` where possible.
                         enum:
                         - All
                         - Hostname
@@ -5306,32 +5506,26 @@ spec:
                         type: array
                       mtlsCertificateRef:
                         description: |-
-                          Enables mutual TLS to the backend, using the
-                          specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                          credential source, defaulting to a Kubernetes `Secret`.
-
-                          An optional `ca.cert` field, if present, will be used to verify the
-                          server certificate. If `caCertificateRefs` is also specified, the
-                          `caCertificateRefs` field takes priority.
-
-                          If unspecified, no client certificate will be used.
+                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                          optional `ca.cert`, if present, verifies the server certificate, but
+                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                          is used.
                         items:
                           description: |-
-                            References a same-namespace credential.
-                            Set only `name` to reference a Kubernetes Secret.
+                            References a same-namespace credential
+                            Set only `name` for a Kubernetes Secret
                           properties:
                             group:
-                              description: |-
-                                The API group of the referenced credential.
-                                Empty selects the core API group.
+                              description: API group of the referenced credential;
+                                empty selects the core API group
                               type: string
                             kind:
-                              description: |-
-                                The kind of the referenced credential.
-                                Empty defaults to `Secret`.
+                              description: Kind of the referenced credential; empty
+                                defaults to `Secret`
                               type: string
                             name:
-                              description: The name of the referenced credential.
+                              description: Name of the referenced credential
                               maxLength: 253
                               minLength: 1
                               type: string
@@ -5620,8 +5814,8 @@ spec:
                       rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
                         >= 1'
                   tunnel:
-                    description: Settings for managing tunnel connections, with behavior
-                      like `HTTPS_PROXY`, to the backend.
+                    description: Settings for managing tunnel connections to the backend,
+                      like `HTTPS_PROXY`
                     properties:
                       backendRef:
                         description: |-
@@ -5630,29 +5824,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5663,27 +5843,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -5776,6 +5945,51 @@ spec:
                           OTLP access log export to an
                           OpenTelemetry-compatible backend.
                         properties:
+                          attributes:
+                            description: |-
+                              Customizations to the key-value pairs exported over OTLP.
+                              If unset, the parent access log attributes are used.
+                            properties:
+                              add:
+                                description: |-
+                                  Additional key-value pairs to add to each entry.
+                                  The value is a CEL expression. If the CEL expression fails to evaluate,
+                                  the pair will be excluded.
+                                items:
+                                  properties:
+                                    expression:
+                                      description: A Common Expression Language (CEL)
+                                        expression.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - expression
+                                  - name
+                                  type: object
+                                minItems: 1
+                                type: array
+                              remove:
+                                description: |-
+                                  Default fields to remove. For example,
+                                  `http.method`.
+                                items:
+                                  maxLength: 64
+                                  minLength: 1
+                                  type: string
+                                maxItems: 32
+                                minItems: 1
+                                type: array
+                            type: object
+                            x-kubernetes-validations:
+                            - message: at least one of the fields in [add remove]
+                                must be set
+                              rule: '[has(self.add),has(self.remove)].filter(x,x==true).size()
+                                >= 1'
                           backendRef:
                             description: |-
                               OTLP server to send access logs to.
@@ -5783,29 +5997,15 @@ spec:
                             properties:
                               group:
                                 default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 default: Service
-                                description: |-
-                                  Kind is the Kubernetes resource kind of the referent. For example
-                                  "Service".
-
-                                  Defaults to "Service" when not specified.
-
-                                  ExternalName services can refer to CNAME DNS records that may live
-                                  outside of the cluster and as such are difficult to reason about in
-                                  terms of conformance. They also may not be safe to forward to (see
-                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                  support ExternalName Services.
-
-                                  Support: Core (Services with a type other than ExternalName)
-
-                                  Support: Implementation-specific (Services with type ExternalName)
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5816,27 +6016,16 @@ spec:
                                 minLength: 1
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of the backend. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               port:
-                                description: |-
-                                  Port specifies the destination port number to use for this resource.
-                                  Port is required when the referent is a Kubernetes Service. In this
-                                  case, the port number is the service port number, not the target port.
-                                  For other resources, destination port might be derived from the referent
-                                  resource or this field.
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -5848,6 +6037,14 @@ spec:
                             - message: Must have port for Service reference
                               rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                 ? has(self.port) : true'
+                          filter:
+                            description: |-
+                              CEL expression used to filter OTLP logs. A log
+                              will only be exported if the expression evaluates to `true`.
+                              If unset, the parent access log filter is used.
+                            maxLength: 16384
+                            minLength: 1
+                            type: string
                           path:
                             description: |-
                               OTLP/HTTP path to use. This is only applicable
@@ -5907,6 +6104,7 @@ spec:
                           Timeout before an unused connection is
                           closed.
                           If unset, this defaults to 10 minutes.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -5957,6 +6155,7 @@ spec:
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2KeepaliveInterval:
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -5964,6 +6163,7 @@ spec:
                         - message: http2KeepaliveInterval must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http2KeepaliveTimeout:
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -6023,6 +6223,7 @@ spec:
                           Maximum time a connection is allowed to remain open.
                           After this duration, the connection is gracefully closed after the current in-flight request completes.
                           Useful for ensuring even traffic distribution behind load balancers during scaling events.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -6113,8 +6314,8 @@ spec:
                           * `Require`: every require rule must match for the request to be allowed.
                           * `Deny`: any matching deny rule denies the request.
 
-                          A CEL expression that fails to evaluate does not match. Prefer `Require`
-                          for deny-by-default behavior.
+                          `Deny` is not recommended because expression failures fail to deny; prefer
+                          `Allow` or `Require`. If used, design expressions defensively against evaluation errors.
 
                           If at least one `Allow` rule is configured, requests are denied unless at
                           least one allow rule matches.
@@ -6176,6 +6377,7 @@ spec:
                             description: |-
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -6194,6 +6396,7 @@ spec:
                             description: |-
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -6244,6 +6447,7 @@ spec:
                         description: |-
                           Deadline for a TLS handshake to
                           complete. If unset, this defaults to `15s`.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -6336,29 +6540,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -6369,27 +6559,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -6408,6 +6587,14 @@ spec:
                           span if the incoming request does have a trace already. This should
                           evaluate to a float between `0.0` and `1.0`, or a boolean (`true` or
                           `false`). If unspecified, client sampling is `100%` enabled.
+                        maxLength: 16384
+                        minLength: 1
+                        type: string
+                      filter:
+                        description: |-
+                          Expression that determines whether a sampled span is exported.
+                          This uses keep semantics: spans are exported only when the expression
+                          evaluates to `true`. If unspecified, all sampled spans are exported.
                         maxLength: 16384
                         minLength: 1
                         type: string
@@ -6507,7 +6694,7 @@ spec:
                 items:
                   description: |-
                     Selects one same-namespace object by `group`, `kind`, `name`, and,
-                    optionally, `sectionName`.
+                    optionally, `sectionName` or `port`.
                     The object must be in the same namespace as the policy.
                   properties:
                     group:
@@ -6529,6 +6716,15 @@ spec:
                       maxLength: 253
                       minLength: 1
                       type: string
+                    port:
+                      description: |-
+                        The port of the target resource this policy applies to.
+                        At most one of `sectionName` or `port` may be set.
+                        Only valid on frontend policies targeting a `Gateway`.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     sectionName:
                       description: The named section of the target resource.
                       maxLength: 253
@@ -6540,6 +6736,11 @@ spec:
                   - kind
                   - name
                   type: object
+                  x-kubernetes-validations:
+                  - message: at most one of the fields in [sectionName port] may be
+                      set
+                    rule: '[has(self.sectionName),has(self.port)].filter(x,x==true).size()
+                      <= 1'
                 maxItems: 16
                 minItems: 1
                 type: array
@@ -6587,6 +6788,15 @@ spec:
                       description: Labels that must be present on each selected target
                         resource.
                       type: object
+                    port:
+                      description: |-
+                        The port of each selected target resource this policy applies to.
+                        At most one of `sectionName` or `port` may be set.
+                        Only valid on frontend policies targeting a `Gateway`.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     sectionName:
                       description: The named section of each selected target resource.
                       maxLength: 253
@@ -6598,6 +6808,11 @@ spec:
                   - kind
                   - matchLabels
                   type: object
+                  x-kubernetes-validations:
+                  - message: at most one of the fields in [sectionName port] may be
+                      set
+                    rule: '[has(self.sectionName),has(self.port)].filter(x,x==true).size()
+                      <= 1'
                 maxItems: 16
                 minItems: 1
                 type: array
@@ -6631,6 +6846,35 @@ spec:
                       Authenticates users based on a configured API
                       key.
                     properties:
+                      configMapSelector:
+                        description: "Selects multiple Kubernetes `ConfigMap` resources\ncontaining
+                          API keys. It is ConfigMap-only; use `secretRef` or\n`secretSelector`
+                          for Secret-backed credentials. If the same key is\ndefined
+                          in multiple ConfigMaps, the behavior is undefined.\n\nBecause
+                          ConfigMaps are not confidential, every entry sourced from
+                          a\nConfigMap must use `keyHash`; a raw `key` value is rejected.\n\nEach
+                          entry in the `ConfigMap` data represents one API key. The
+                          key is\nan arbitrary identifier. The value must be a JSON
+                          object with\n`keyHash`, plus optional `metadata`. `keyHash`
+                          contains a hashed API\nkey in `sha256:<hex>` format. `metadata`
+                          contains arbitrary JSON\nmetadata associated with the key,
+                          which may be used by other\npolicies. For example, you may
+                          write an authorization policy allowing\n`apiKey.group ==
+                          'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: ConfigMap\n\tmetadata:\n\t
+                          \ name: api-key\n\tdata:\n\t  client1: |\n\t    {\n\t      \"keyHash\":
+                          \"sha256:efa299afb8c12a36e47a790cbbf929caa06d13285950410463fb759af17d0dad\",\n\t
+                          \     \"metadata\": {\n\t        \"group\": \"sales\"\n\t
+                          \     }\n\t    }"
+                        properties:
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: Labels that must be present on each selected
+                              ConfigMap.
+                            type: object
+                        required:
+                        - matchLabels
+                        type: object
                       location:
                         description: |-
                           Where API keys are read from.
@@ -6654,19 +6898,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6703,33 +6936,36 @@ spec:
                         type: string
                       secretRef:
                         description: "Credential source, defaulting to a Kubernetes\n`Secret`,
-                          storing a set of API keys. If there are many Secret-backed\nkeys,
-                          `secretSelector` can be used instead.\n\nEach entry in the
-                          credential data represents one API key. The key is an\narbitrary
-                          identifier. The value can either be:\n* A string representing
-                          the API key.\n* A JSON object with two fields, `key` and
-                          `metadata`. `key` contains\n  the API key. `metadata` contains
-                          arbitrary JSON metadata associated\n  with the key, which
-                          may be used by other policies. For example, you\n  may write
-                          an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion:
-                          v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t
-                          \ client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\":
-                          {\n\t        \"group\": \"sales\",\n\t        \"created_at\":
-                          \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2:
-                          \"k-456\""
+                          storing a set of API keys. If many keys are needed,\n`secretSelector`
+                          or `configMapSelector` can be used instead.\nNote that ConfigMap-backed
+                          API keys only support `keyHash`.\n\nEach entry in the credential
+                          data represents one API key. The key is an\narbitrary identifier.
+                          The value can either be:\n* A string representing the API
+                          key.\n* A JSON object with `key` or `keyHash`, plus optional
+                          `metadata`.\n  `key` contains the API key. `keyHash` contains
+                          a hashed API key in\n  `sha256:<hex>` format. `metadata`
+                          contains arbitrary JSON metadata\n  associated with the
+                          key, which may be used by other policies. For\n  example,
+                          you may write an authorization policy allowing\n  `apiKey.group
+                          == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t
+                          \ name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t
+                          \     \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\":
+                          \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t
+                          \     }\n\t    }\n\t  client2: \"k-456\"\n\t  client3: |\n\t
+                          \   {\n\t      \"keyHash\": \"sha256:efa299afb8c12a36e47a790cbbf929caa06d13285950410463fb759af17d0dad\",\n\t
+                          \     \"metadata\": {\n\t        \"group\": \"engineering\"\n\t
+                          \     }\n\t    }"
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -6750,11 +6986,12 @@ spec:
                           is undefined.\n\nEach entry in the `Secret` data represents
                           one API key. The key is an\narbitrary identifier. The value
                           can either be:\n* A string representing the API key.\n*
-                          A JSON object with two fields, `key` and `metadata`. `key`
-                          contains\n  the API key. `metadata` contains arbitrary JSON
-                          metadata associated\n  with the key, which may be used by
-                          other policies. For example, you\n  may write an authorization
-                          policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion:
+                          A JSON object with `key` or `keyHash`, plus optional `metadata`.\n
+                          \ `key` contains the API key. `keyHash` contains a hashed
+                          API key in\n  `sha256:<hex>` format. `metadata` contains
+                          arbitrary JSON metadata\n  associated with the key, which
+                          may be used by other policies. For\n  example, you may write
+                          an authorization policy allowing\n  `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion:
                           v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t
                           \ client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\":
                           {\n\t        \"group\": \"sales\",\n\t        \"created_at\":
@@ -6772,9 +7009,9 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-validations:
-                    - message: exactly one of the fields in [secretRef secretSelector]
-                        must be set
-                      rule: '[has(self.secretRef),has(self.secretSelector)].filter(x,x==true).size()
+                    - message: exactly one of the fields in [secretRef secretSelector
+                        configMapSelector] must be set
+                      rule: '[has(self.secretRef),has(self.secretSelector),has(self.configMapSelector)].filter(x,x==true).size()
                         == 1'
                   authorization:
                     description: |-
@@ -6802,8 +7039,8 @@ spec:
                           * `Require`: every require rule must match for the request to be allowed.
                           * `Deny`: any matching deny rule denies the request.
 
-                          A CEL expression that fails to evaluate does not match. Prefer `Require`
-                          for deny-by-default behavior.
+                          `Deny` is not recommended because expression failures fail to deny; prefer
+                          `Allow` or `Require`. If used, design expressions defensively against evaluation errors.
 
                           If at least one `Allow` rule is configured, requests are denied unless at
                           least one allow rule matches.
@@ -6854,19 +7091,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6909,27 +7135,31 @@ spec:
                       secretRef:
                         description: "Credential source, defaulting to a Kubernetes\n`Secret`,
                           storing the `.htaccess` file. When using the default Secret\nresolver,
-                          the `Secret` must have a key named `.htaccess`, and should\ncontain
-                          the complete `.htaccess` file.\n\nNote: passwords should
-                          be the hash of the password, not the raw password. Use the
-                          `htpasswd` or similar commands\nto generate a hash. MD5,
-                          bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tapiVersion:
+                          the `Secret` must have a key named `.htaccess` by default;\noverride
+                          via `secretRef.key`. The value should contain the complete\n`.htaccess`
+                          file.\n\nNote: passwords should be the hash of the password,
+                          not the raw password. Use the `htpasswd` or similar commands\nto
+                          generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tapiVersion:
                           v1\n\tkind: Secret\n\tmetadata:\n\t  name: basic-auth\n\tstringData:\n\t
                           \ .htaccess: |\n\t    alice:$apr1$3zSE0Abt$IuETi4l5yO87MuOrbSE4V.\n\t
                           \   bob:$apr1$Ukb5LgRD$EPY2lIfY.A54jzLELNIId/"
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
+                            type: string
+                          key:
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
+                            maxLength: 253
+                            minLength: 1
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -6972,6 +7202,14 @@ spec:
                       request:
                         description: Request body buffering settings.
                         properties:
+                          failureMode:
+                            description: |-
+                              Behavior when the request or response body exceeds the buffer limit.
+                              If unset, defaults to FailClosed, returning 413 for oversized requests and 502 for oversized responses.
+                            enum:
+                            - FailClosed
+                            - FailOpen
+                            type: string
                           maxBytes:
                             anyOf:
                             - type: integer
@@ -6992,6 +7230,14 @@ spec:
                       response:
                         description: Response body buffering settings.
                         properties:
+                          failureMode:
+                            description: |-
+                              Behavior when the request or response body exceeds the buffer limit.
+                              If unset, defaults to FailClosed, returning 413 for oversized requests and 502 for oversized responses.
+                            enum:
+                            - FailClosed
+                            - FailOpen
+                            type: string
                           maxBytes:
                             anyOf:
                             - type: integer
@@ -7033,59 +7279,12 @@ spec:
                           Support: Extended
                         type: boolean
                       allowHeaders:
-                        description: |-
-                          AllowHeaders indicates which HTTP request headers are supported for
-                          accessing the requested resource.
-
-                          Header names are not case-sensitive.
-
-                          Multiple header names in the value of the `Access-Control-Allow-Headers`
-                          response header are separated by a comma (",").
-
-                          When the `allowHeaders` field is configured with one or more headers, the
-                          gateway must return the `Access-Control-Allow-Headers` response header
-                          which value is present in the `allowHeaders` field.
-
-                          If any header name in the `Access-Control-Request-Headers` request header
-                          is not included in the list of header names specified by the response
-                          header `Access-Control-Allow-Headers`, it will present an error on the
-                          client side.
-
-                          If any header name in the `Access-Control-Allow-Headers` response header
-                          does not recognize by the client, it will also occur an error on the
-                          client side.
-
-                          A wildcard indicates that the requests with all HTTP headers are allowed.
-
-                          If the configuration contains the wildcard `*` in `allowHeaders` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
-                          response header may either contain the wildcard `*` or echo the value
-                          of the `Access-Control-Request-Headers` request header.
-
-                          If the configuration contains the wildcard `*` in `allowHeaders` and
-                          `allowCredentials` is set to `true`, the gateway must not return `*`
-                          in the `Access-Control-Allow-Headers` response header. Instead, it must
-                          return one or more header names matching the value of the
-                          `Access-Control-Request-Headers` request header.
-                          If the `Access-Control-Request-Headers` header is not present in the
-                          request, the gateway must omit the `Access-Control-Allow-Headers`
-                          response header.
-
-                          Support: Extended
+                        description: 'Request headers allowed when accessing the resource,
+                          or `*` for all. Sets `Access-Control-Allow-Headers`. Support:
+                          Extended'
                         items:
-                          description: |-
-                            HTTPHeaderName is the name of an HTTP header.
-
-                            Valid values include:
-
-                            * "Authorization"
-                            * "Set-Cookie"
-
-                            Invalid values include:
-
-                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                headers are not currently supported by this type.
-                              - "/invalid" - "/ " is an invalid character
+                          description: Name of an HTTP header. HTTP/2 pseudo-headers
+                            (names beginning with `:`) are not supported
                           maxLength: 256
                           minLength: 1
                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7098,47 +7297,10 @@ spec:
                             methods
                           rule: '!(''*'' in self && self.size() > 1)'
                       allowMethods:
-                        description: |-
-                          AllowMethods indicates which HTTP methods are supported for accessing the
-                          requested resource.
-
-                          Valid values are any method defined by RFC9110, along with the special
-                          value `*`, which represents all HTTP methods are allowed.
-
-                          Method names are case-sensitive, so these values are also case-sensitive.
-                          (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
-
-                          Multiple method names in the value of the `Access-Control-Allow-Methods`
-                          response header are separated by a comma (",").
-
-                          A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
-                          (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
-                          CORS-safelisted methods are always allowed, regardless of whether they
-                          are specified in the `allowMethods` field.
-
-                          When the `allowMethods` field is configured with one or more methods, the
-                          gateway must return the `Access-Control-Allow-Methods` response header
-                          which value is present in the `allowMethods` field.
-
-                          If the HTTP method of the `Access-Control-Request-Method` request header
-                          is not included in the list of methods specified by the response header
-                          `Access-Control-Allow-Methods`, it will present an error on the client
-                          side.
-
-                          If the configuration contains the wildcard `*` in `allowMethods` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
-                          response header may either contain the wildcard `*` or echo the value
-                          of the `Access-Control-Request-Method` request header.
-
-                          If the configuration contains the wildcard `*` in `allowMethods` and
-                          `allowCredentials` is set to `true`, the gateway must not return `*`
-                          in the `Access-Control-Allow-Methods` response header. Instead, it must
-                          return a single HTTP method matching the value of the
-                          `Access-Control-Request-Method` request header.
-                          If the `Access-Control-Request-Method` header is not present in the request,
-                          the gateway must omit the `Access-Control-Allow-Methods` response header.
-
-                          Support: Extended
+                        description: 'HTTP methods allowed for the resource, or `*`
+                          for all. CORS-safelisted methods (`GET`, `HEAD`, `POST`)
+                          are always allowed. Sets `Access-Control-Allow-Methods`.
+                          Support: Extended'
                         items:
                           enum:
                           - GET
@@ -7160,65 +7322,11 @@ spec:
                             methods
                           rule: '!(''*'' in self && self.size() > 1)'
                       allowOrigins:
-                        description: |-
-                          AllowOrigins indicates whether the response can be shared with requested
-                          resource from the given `Origin`.
-
-                          The `Origin` consists of a scheme and a host, with an optional port, and
-                          takes the form `<scheme>://<host>(:<port>)`.
-
-                          Valid values for scheme are: `http` and `https`.
-
-                          Valid values for port are any integer between 1 and 65535 (the list of
-                          available TCP/UDP ports). Note that, if not included, port `80` is
-                          assumed for `http` scheme origins, and port `443` is assumed for `https`
-                          origins. This may affect origin matching.
-
-                          The host part of the origin may contain the wildcard character `*`. These
-                          wildcard characters behave as follows:
-
-                          * `*` is a greedy match to the _left_, including any number of
-                            DNS labels to the left of its position. This also means that
-                            `*` will include any number of period `.` characters to the
-                            left of its position.
-                          * A wildcard by itself matches all hosts.
-
-                          An origin value that includes _only_ the `*` character indicates requests
-                          from all `Origin`s are allowed.
-
-                          When the `allowOrigins` field is configured with multiple origins, it
-                          means the server supports clients from multiple origins. If the request
-                          `Origin` matches the configured allowed origins, the gateway must return
-                          the given `Origin` and sets value of the header
-                          `Access-Control-Allow-Origin` same as the `Origin` header provided by the
-                          client.
-
-                          The status code of a successful response to a "preflight" request is
-                          always an OK status (i.e., 204 or 200).
-
-                          If the request `Origin` does not match the configured allowed origins,
-                          the gateway returns 204/200 response but doesn't set the relevant
-                          cross-origin response headers. Alternatively, the gateway responds with
-                          403 status to the "preflight" request is denied, coupled with omitting
-                          the CORS headers. The cross-origin request fails on the client side.
-                          Therefore, the client doesn't attempt the actual cross-origin request.
-
-                          Conversely, if the request `Origin` matches one of the configured
-                          allowed origins, the gateway sets the response header
-                          `Access-Control-Allow-Origin` to the same value as the `Origin`
-                          header provided by the client.
-
-                          If the configuration contains the wildcard `*` in `allowOrigins` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
-                          response header may either contain the wildcard `*` or echo the value
-                          of the `Origin` request header.
-
-                          If the configuration contains the wildcard `*` in `allowOrigins` and
-                          `allowCredentials` is set to `true`, the gateway must not return `*`
-                          in the `Access-Control-Allow-Origin` response header. Instead, it must
-                          return a single origin matching the value of the `Origin` request header.
-
-                          Support: Extended
+                        description: 'Origins allowed to share the response, each
+                          as `<scheme>://<host>(:<port>)`; the host may use the `*`
+                          wildcard, and a bare `*` allows all origins. Sets `Access-Control-Allow-Origin`.
+                          When credentials are allowed, a specific origin is echoed
+                          instead of `*`. Support: Extended'
                         items:
                           description: |-
                             The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
@@ -7238,58 +7346,12 @@ spec:
                             origins
                           rule: '!(''*'' in self && self.size() > 1)'
                       exposeHeaders:
-                        description: |-
-                          ExposeHeaders indicates which HTTP response headers can be exposed
-                          to client-side scripts in response to a cross-origin request.
-
-                          A CORS-safelisted response header is an HTTP header in a CORS response
-                          that it is considered safe to expose to the client scripts.
-                          The CORS-safelisted response headers include the following headers:
-                          `Cache-Control`
-                          `Content-Language`
-                          `Content-Length`
-                          `Content-Type`
-                          `Expires`
-                          `Last-Modified`
-                          `Pragma`
-                          (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
-                          The CORS-safelisted response headers are exposed to client by default.
-
-                          When an HTTP header name is specified using the `exposeHeaders` field,
-                          this additional header will be exposed as part of the response to the
-                          client.
-
-                          Header names are not case-sensitive.
-
-                          Multiple header names in the value of the `Access-Control-Expose-Headers`
-                          response header are separated by a comma (",").
-
-                          A wildcard indicates that the responses with all HTTP headers are exposed
-                          to clients.
-
-                          If the configuration contains the wildcard `*` in `exposeHeaders` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
-                          response header can contain the wildcard `*`.
-
-                          If the configuration contains the wildcard `*` in `exposeHeaders` and
-                          `allowCredentials` is set to `true`, the gateway cannot use the `*`
-                          in the `Access-Control-Expose-Headers` response header.
-
-                          Support: Extended
+                        description: 'Response headers exposed to client scripts,
+                          or `*` for all. Sets `Access-Control-Expose-Headers`. Support:
+                          Extended'
                         items:
-                          description: |-
-                            HTTPHeaderName is the name of an HTTP header.
-
-                            Valid values include:
-
-                            * "Authorization"
-                            * "Set-Cookie"
-
-                            Invalid values include:
-
-                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                headers are not currently supported by this type.
-                              - "/invalid" - "/ " is an invalid character
+                          description: Name of an HTTP header. HTTP/2 pseudo-headers
+                            (names beginning with `:`) are not supported
                           maxLength: 256
                           minLength: 1
                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7341,6 +7403,26 @@ spec:
                         maxItems: 16
                         minItems: 1
                         type: array
+                    type: object
+                  delay:
+                    description: |-
+                      Injects artificial latency before forwarding requests, for
+                      fault-injection testing.
+                    properties:
+                      duration:
+                        description: |-
+                          Latency to inject before forwarding the request to the backend. Either a duration string such
+                          as `2s`, or a CEL expression evaluated against the request that returns a duration (e.g.
+                          `duration("500ms")`) or a number interpreted as milliseconds (e.g. `random() < 0.1 ? 500 : 0`
+                          for probabilistic delay, or `int(random() * 500)` for jitter). A non-positive result injects
+                          no delay.
+
+                          The injected delay counts against the request timeout.
+                        maxLength: 16384
+                        minLength: 1
+                        type: string
+                    required:
+                    - duration
                     type: object
                   directResponse:
                     description: |-
@@ -7503,29 +7585,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7536,27 +7604,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -7570,7 +7627,7 @@ spec:
                             ? has(self.port) : true'
                       cache:
                         description: |-
-                          Caches gRPC authorization results.
+                          Caches authorization results.
 
                           WARNING: the safety of this feature depends on the cache key accurately
                           capturing every request property that the authorization service uses to
@@ -7640,29 +7697,17 @@ spec:
                                   properties:
                                     group:
                                       default: ""
-                                      description: |-
-                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                        When unspecified or empty string, core API group is inferred.
+                                      description: Group of the referent, for example
+                                        `gateway.networking.k8s.io`. Empty selects
+                                        the core API group
                                       maxLength: 253
                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     kind:
                                       default: Service
-                                      description: |-
-                                        Kind is the Kubernetes resource kind of the referent. For example
-                                        "Service".
-
-                                        Defaults to "Service" when not specified.
-
-                                        ExternalName services can refer to CNAME DNS records that may live
-                                        outside of the cluster and as such are difficult to reason about in
-                                        terms of conformance. They also may not be safe to forward to (see
-                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                        support ExternalName Services.
-
-                                        Support: Core (Services with a type other than ExternalName)
-
-                                        Support: Implementation-specific (Services with type ExternalName)
+                                      description: Kubernetes resource kind of the
+                                        referent, for example `Service`. Defaults
+                                        to `Service`
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7673,27 +7718,17 @@ spec:
                                       minLength: 1
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of the backend. When unspecified, the local
-                                        namespace is inferred.
-
-                                        Note that when a namespace different than the local namespace is specified,
-                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                        documentation for details.
-
-                                        Support: Core
+                                      description: Namespace of the referent. Defaults
+                                        to the local namespace. A cross-namespace
+                                        reference requires a ReferenceGrant in the
+                                        referent namespace
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                     port:
-                                      description: |-
-                                        Port specifies the destination port number to use for this resource.
-                                        Port is required when the referent is a Kubernetes Service. In this
-                                        case, the port number is the service port number, not the target port.
-                                        For other resources, destination port might be derived from the referent
-                                        resource or this field.
+                                      description: Destination port number. Required
+                                        when the referent is a Kubernetes `Service`
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -7707,7 +7742,7 @@ spec:
                                       ''Service'') ? has(self.port) : true'
                                 cache:
                                   description: |-
-                                    Caches gRPC authorization results.
+                                    Caches authorization results.
 
                                     WARNING: the safety of this feature depends on the cache key accurately
                                     capturing every request property that the authorization service uses to
@@ -7859,6 +7894,13 @@ spec:
                                         type: string
                                       maxItems: 64
                                       type: array
+                                    body:
+                                      description: |-
+                                        Body is a CEL expression that produces the HTTP authorization request body.
+                                        Strings and bytes are used directly; other values are JSON-encoded.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
                                     path:
                                       description: |-
                                         Path to send to the authorization server. If
@@ -7901,8 +7943,9 @@ spec:
                                   must be set
                                 rule: '[has(self.grpc),has(self.http)].filter(x,x==true).size()
                                   == 1'
-                              - message: cache requires grpc
-                                rule: '!has(self.cache) || has(self.grpc)'
+                              - message: forwardBody cannot be used with http.body
+                                rule: '!(has(self.forwardBody) && has(self.http) &&
+                                  has(self.http.body))'
                           required:
                           - policy
                           type: object
@@ -8017,6 +8060,13 @@ spec:
                               type: string
                             maxItems: 64
                             type: array
+                          body:
+                            description: |-
+                              Body is a CEL expression that produces the HTTP authorization request body.
+                              Strings and bytes are used directly; other values are JSON-encoded.
+                            maxLength: 16384
+                            minLength: 1
+                            type: string
                           path:
                             description: |-
                               Path to send to the authorization server. If
@@ -8055,8 +8105,8 @@ spec:
                     - message: exactly one of the fields in [grpc http] must be set
                       rule: has(self.conditional) || [has(self.grpc),has(self.http)].filter(x,x==true).size()
                         == 1
-                    - message: cache requires grpc
-                      rule: '!has(self.cache) || has(self.grpc)'
+                    - message: forwardBody cannot be used with http.body
+                      rule: '!(has(self.forwardBody) && has(self.http) && has(self.http.body))'
                     - message: conditional cannot be set with any other field
                       rule: 'has(self.conditional) ? [has(self.backendRef),has(self.cache),has(self.failureMode),has(self.forwardBody),has(self.grpc),has(self.http)].filter(x,x==true).size()
                         == 0 : true'
@@ -8072,29 +8122,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8105,27 +8141,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -8161,29 +8186,17 @@ spec:
                                   properties:
                                     group:
                                       default: ""
-                                      description: |-
-                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                        When unspecified or empty string, core API group is inferred.
+                                      description: Group of the referent, for example
+                                        `gateway.networking.k8s.io`. Empty selects
+                                        the core API group
                                       maxLength: 253
                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     kind:
                                       default: Service
-                                      description: |-
-                                        Kind is the Kubernetes resource kind of the referent. For example
-                                        "Service".
-
-                                        Defaults to "Service" when not specified.
-
-                                        ExternalName services can refer to CNAME DNS records that may live
-                                        outside of the cluster and as such are difficult to reason about in
-                                        terms of conformance. They also may not be safe to forward to (see
-                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                        support ExternalName Services.
-
-                                        Support: Core (Services with a type other than ExternalName)
-
-                                        Support: Implementation-specific (Services with type ExternalName)
+                                      description: Kubernetes resource kind of the
+                                        referent, for example `Service`. Defaults
+                                        to `Service`
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8194,27 +8207,17 @@ spec:
                                       minLength: 1
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of the backend. When unspecified, the local
-                                        namespace is inferred.
-
-                                        Note that when a namespace different than the local namespace is specified,
-                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                        documentation for details.
-
-                                        Support: Core
+                                      description: Namespace of the referent. Defaults
+                                        to the local namespace. A cross-namespace
+                                        reference requires a ReferenceGrant in the
+                                        referent namespace
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                     port:
-                                      description: |-
-                                        Port specifies the destination port number to use for this resource.
-                                        Port is required when the referent is a Kubernetes Service. In this
-                                        case, the port number is the service port number, not the target port.
-                                        For other resources, destination port might be derived from the referent
-                                        resource or this field.
+                                      description: Destination port number. Required
+                                        when the referent is a Kubernetes `Service`
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -8226,6 +8229,36 @@ spec:
                                   - message: Must have port for Service reference
                                     rule: '(size(self.group) == 0 && self.kind ==
                                       ''Service'') ? has(self.port) : true'
+                                failureMode:
+                                  description: |-
+                                    Behavior when the external processor is unavailable or returns an error.
+                                    "FailOpen" allows the request to continue, as long as the request body has not
+                                    been sent (or started streaming) to the ext_proc. Once the request body has
+                                    started streaming to the ext_proc, the request will fail closed on error.
+                                    "FailClosed" (default) rejects the request on any failure.
+                                  enum:
+                                  - FailClosed
+                                  - FailOpen
+                                  type: string
+                                metadataContext:
+                                  additionalProperties:
+                                    additionalProperties:
+                                      description: A Common Expression Language (CEL)
+                                        expression.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                    description: |-
+                                      NamespacedMetadataContext holds the CEL expressions for a single metadata
+                                      namespace, keyed by the metadata key within that namespace.
+                                    type: object
+                                  description: |-
+                                    Metadata to send to the external processor in the
+                                    `metadata_context.filter_metadata` field of the ProcessingRequest.
+                                    Keyed by metadata namespace, then by key within that namespace; values are
+                                    CEL expressions evaluated per request.
+                                  maxProperties: 64
+                                  type: object
                                 processingOptions:
                                   description: How request and response phases are
                                     sent to ext_proc.
@@ -8244,10 +8277,10 @@ spec:
                                         `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
                                         body exceeds that limit. Defaults to `FullDuplexStreamed`.
                                       enum:
-                                      - None
                                       - Buffered
                                       - BufferedPartial
                                       - FullDuplexStreamed
+                                      - None
                                       type: string
                                     requestHeaderMode:
                                       default: Send
@@ -8264,8 +8297,8 @@ spec:
                                         Whether request trailers are sent to the external processor.
                                         Defaults to `Send`.
                                       enum:
-                                      - Skip
                                       - Send
+                                      - Skip
                                       type: string
                                     responseBodyMode:
                                       default: FullDuplexStreamed
@@ -8275,10 +8308,10 @@ spec:
                                         `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
                                         body exceeds that limit. Defaults to `FullDuplexStreamed`.
                                       enum:
-                                      - None
                                       - Buffered
                                       - BufferedPartial
                                       - FullDuplexStreamed
+                                      - None
                                       type: string
                                     responseHeaderMode:
                                       default: Send
@@ -8295,9 +8328,35 @@ spec:
                                         Whether response trailers are sent to the external processor.
                                         Defaults to `Send`.
                                       enum:
-                                      - Skip
                                       - Send
+                                      - Skip
                                       type: string
+                                  type: object
+                                requestAttributes:
+                                  additionalProperties:
+                                    description: A Common Expression Language (CEL)
+                                      expression.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  description: |-
+                                    Request attributes to send to the external processor in the request
+                                    `attributes` field of the ProcessingRequest. Values are CEL expressions
+                                    evaluated per request.
+                                  maxProperties: 64
+                                  type: object
+                                responseAttributes:
+                                  additionalProperties:
+                                    description: A Common Expression Language (CEL)
+                                      expression.
+                                    maxLength: 16384
+                                    minLength: 1
+                                    type: string
+                                  description: |-
+                                    Response attributes to send to the external processor in the response
+                                    `attributes` field of the ProcessingRequest. Values are CEL expressions
+                                    evaluated per response.
+                                  maxProperties: 64
                                   type: object
                               type: object
                               x-kubernetes-validations:
@@ -8313,6 +8372,35 @@ spec:
                         - message: conditional entries without condition must be last
                           rule: self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e,
                             !has(e.condition)) || !has(self[size(self) - 1].condition))
+                      failureMode:
+                        description: |-
+                          Behavior when the external processor is unavailable or returns an error.
+                          "FailOpen" allows the request to continue, as long as the request body has not
+                          been sent (or started streaming) to the ext_proc. Once the request body has
+                          started streaming to the ext_proc, the request will fail closed on error.
+                          "FailClosed" (default) rejects the request on any failure.
+                        enum:
+                        - FailClosed
+                        - FailOpen
+                        type: string
+                      metadataContext:
+                        additionalProperties:
+                          additionalProperties:
+                            description: A Common Expression Language (CEL) expression.
+                            maxLength: 16384
+                            minLength: 1
+                            type: string
+                          description: |-
+                            NamespacedMetadataContext holds the CEL expressions for a single metadata
+                            namespace, keyed by the metadata key within that namespace.
+                          type: object
+                        description: |-
+                          Metadata to send to the external processor in the
+                          `metadata_context.filter_metadata` field of the ProcessingRequest.
+                          Keyed by metadata namespace, then by key within that namespace; values are
+                          CEL expressions evaluated per request.
+                        maxProperties: 64
+                        type: object
                       processingOptions:
                         description: How request and response phases are sent to ext_proc.
                         properties:
@@ -8330,10 +8418,10 @@ spec:
                               `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
                               body exceeds that limit. Defaults to `FullDuplexStreamed`.
                             enum:
-                            - None
                             - Buffered
                             - BufferedPartial
                             - FullDuplexStreamed
+                            - None
                             type: string
                           requestHeaderMode:
                             default: Send
@@ -8350,8 +8438,8 @@ spec:
                               Whether request trailers are sent to the external processor.
                               Defaults to `Send`.
                             enum:
-                            - Skip
                             - Send
+                            - Skip
                             type: string
                           responseBodyMode:
                             default: FullDuplexStreamed
@@ -8361,10 +8449,10 @@ spec:
                               `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
                               body exceeds that limit. Defaults to `FullDuplexStreamed`.
                             enum:
-                            - None
                             - Buffered
                             - BufferedPartial
                             - FullDuplexStreamed
+                            - None
                             type: string
                           responseHeaderMode:
                             default: Send
@@ -8381,14 +8469,38 @@ spec:
                               Whether response trailers are sent to the external processor.
                               Defaults to `Send`.
                             enum:
-                            - Skip
                             - Send
+                            - Skip
                             type: string
+                        type: object
+                      requestAttributes:
+                        additionalProperties:
+                          description: A Common Expression Language (CEL) expression.
+                          maxLength: 16384
+                          minLength: 1
+                          type: string
+                        description: |-
+                          Request attributes to send to the external processor in the request
+                          `attributes` field of the ProcessingRequest. Values are CEL expressions
+                          evaluated per request.
+                        maxProperties: 64
+                        type: object
+                      responseAttributes:
+                        additionalProperties:
+                          description: A Common Expression Language (CEL) expression.
+                          maxLength: 16384
+                          minLength: 1
+                          type: string
+                        description: |-
+                          Response attributes to send to the external processor in the response
+                          `attributes` field of the ProcessingRequest. Values are CEL expressions
+                          evaluated per response.
+                        maxProperties: 64
                         type: object
                     type: object
                     x-kubernetes-validations:
                     - message: conditional cannot be set with any other field
-                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.processingOptions)].filter(x,x==true).size()
+                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes)].filter(x,x==true).size()
                         == 0 : true'
                     - message: 'backendRef: Required value'
                       rule: 'has(self.conditional) ? true : has(self.backendRef)'
@@ -8421,28 +8533,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -8501,28 +8598,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -8562,28 +8644,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -8642,28 +8709,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -8735,19 +8787,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -8790,6 +8831,9 @@ spec:
                               flows.
                             enum:
                             - Auth0
+                            - Authentik
+                            - Descope
+                            - Entra
                             - Keycloak
                             - Okta
                             type: string
@@ -8857,29 +8901,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8890,27 +8922,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -8924,6 +8946,7 @@ spec:
                                           == ''Service'') ? has(self.port) : true'
                                     cacheDuration:
                                       default: 5m
+                                      maxLength: 32
                                       type: string
                                       x-kubernetes-validations:
                                       - message: invalid duration value
@@ -9016,29 +9039,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9049,27 +9060,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -9243,29 +9244,15 @@ spec:
                             properties:
                               group:
                                 default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 default: Service
-                                description: |-
-                                  Kind is the Kubernetes resource kind of the referent. For example
-                                  "Service".
-
-                                  Defaults to "Service" when not specified.
-
-                                  ExternalName services can refer to CNAME DNS records that may live
-                                  outside of the cluster and as such are difficult to reason about in
-                                  terms of conformance. They also may not be safe to forward to (see
-                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                  support ExternalName Services.
-
-                                  Support: Core (Services with a type other than ExternalName)
-
-                                  Support: Implementation-specific (Services with type ExternalName)
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9276,27 +9263,16 @@ spec:
                                 minLength: 1
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of the backend. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               port:
-                                description: |-
-                                  Port specifies the destination port number to use for this resource.
-                                  Port is required when the referent is a Kubernetes Service. In this
-                                  case, the port number is the service port number, not the target port.
-                                  For other resources, destination port might be derived from the referent
-                                  resource or this field.
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -9470,43 +9446,10 @@ spec:
                         minimum: 1
                         type: integer
                       backoff:
-                        description: |-
-                          Backoff specifies the minimum duration a Gateway should wait between
-                          retry attempts and is represented in Gateway API Duration formatting.
-
-                          For example, setting the `rules[].retry.backoff` field to the value
-                          `100ms` will cause a backend request to first be retried approximately
-                          100 milliseconds after timing out or receiving a response code configured
-                          to be retriable.
-
-                          An implementation MAY use an exponential or alternative backoff strategy
-                          for subsequent retry attempts, MAY cap the maximum backoff duration to
-                          some amount greater than the specified minimum, and MAY add arbitrary
-                          jitter to stagger requests, as long as unsuccessful backend requests are
-                          not retried before the configured minimum duration.
-
-                          If a Request timeout (`rules[].timeouts.request`) is configured on the
-                          route, the entire duration of the initial request and any retry attempts
-                          MUST not exceed the Request timeout duration. If any retry attempts are
-                          still in progress when the Request timeout duration has been reached,
-                          these SHOULD be canceled if possible and the Gateway MUST immediately
-                          return a timeout error.
-
-                          If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
-                          configured on the route, any retry attempts which reach the configured
-                          BackendRequest timeout duration without a response SHOULD be canceled if
-                          possible and the Gateway should wait for at least the specified backoff
-                          duration before attempting to retry the backend request again.
-
-                          If a BackendRequest timeout is _not_ configured on the route, retry
-                          attempts MAY time out after an implementation default duration, or MAY
-                          remain pending until a configured Request timeout or implementation
-                          default duration for total request time is reached.
-
-                          When this field is unspecified, the time to wait between retry attempts
-                          is implementation-specific.
-
-                          Support: Extended
+                        description: 'Minimum duration to wait between retry attempts,
+                          in Gateway API Duration format. Implementations may add
+                          jitter or use exponential backoff, and must not exceed a
+                          configured request timeout. Support: Extended'
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                       codes:
@@ -9569,6 +9512,7 @@ spec:
                         description: |-
                           Timeout for an individual request from the gateway to a backend. This covers the time from when
                           the request first starts being sent from the gateway to when the full response has been received from the backend.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -10098,7 +10042,7 @@ spec:
                 - message: phase PreRouting only supports extAuth, authorization,
                     transformation, extProc, jwtAuthentication, basicAuthentication,
                     apiKeyAuthentication and cors
-                  rule: 'has(self.phase) && self.phase == ''PreRouting'' ? [has(self.buffer),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size()
+                  rule: 'has(self.phase) && self.phase == ''PreRouting'' ? [has(self.buffer),has(self.csrf),has(self.delay),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size()
                     == 0 : true'
             type: object
             x-kubernetes-validations:
@@ -10126,10 +10070,34 @@ spec:
                 has(self.backend) && has(self.backend.mcp) && has(self.backend.mcp.authentication))'
             - message: the 'frontend' field can only target a Gateway
               rule: 'has(self.frontend) && has(self.targetRefs) ? self.targetRefs.all(t,
-                t.kind == ''Gateway'' && !has(t.sectionName)) : true'
+                t.kind == ''Gateway'') : true'
             - message: the 'frontend' field can only target a Gateway
               rule: 'has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t,
-                t.kind == ''Gateway'' && !has(t.sectionName)) : true'
+                t.kind == ''Gateway'') : true'
+            - message: frontend tcp, networkAuthorization, tls, http, proxyProtocol,
+                and connect policies may only target a Gateway or port, not a listener
+                (sectionName)
+              rule: 'has(self.frontend) && (has(self.frontend.tcp) || has(self.frontend.networkAuthorization)
+                || has(self.frontend.tls) || has(self.frontend.http) || has(self.frontend.proxyProtocol)
+                || has(self.frontend.connect)) && has(self.targetRefs) ? self.targetRefs.all(t,
+                !has(t.sectionName)) : true'
+            - message: frontend tcp, networkAuthorization, tls, http, proxyProtocol,
+                and connect policies may only target a Gateway or port, not a listener
+                (sectionName)
+              rule: 'has(self.frontend) && (has(self.frontend.tcp) || has(self.frontend.networkAuthorization)
+                || has(self.frontend.tls) || has(self.frontend.http) || has(self.frontend.proxyProtocol)
+                || has(self.frontend.connect)) && has(self.targetSelectors) ? self.targetSelectors.all(t,
+                !has(t.sectionName)) : true'
+            - message: port may only be set on frontend-only policies (not traffic
+                or backend)
+              rule: 'has(self.targetRefs) && self.targetRefs.exists(t, has(t.port))
+                ? (has(self.frontend) && !has(self.traffic) && !has(self.backend))
+                : true'
+            - message: port may only be set on frontend-only policies (not traffic
+                or backend)
+              rule: 'has(self.targetSelectors) && self.targetSelectors.exists(t, has(t.port))
+                ? (has(self.frontend) && !has(self.traffic) && !has(self.backend))
+                : true'
             - message: the 'traffic' field can only target a Gateway, ListenerSet,
                 GRPCRoute, HTTPRoute, or InferencePool
               rule: 'has(self.traffic) && has(self.targetRefs) ? self.targetRefs.all(t,
@@ -10158,68 +10126,12 @@ spec:
             description: Current policy status.
             properties:
               ancestors:
-                description: |-
-                  Ancestors is a list of ancestor resources (usually Gateways) that are
-                  associated with the policy, and the status of the policy with respect to
-                  each ancestor. When this policy attaches to a parent, the controller that
-                  manages the parent and the ancestors MUST add an entry to this list when
-                  the controller first sees the policy and SHOULD update the entry as
-                  appropriate when the relevant ancestor is modified.
-
-                  Note that choosing the relevant ancestor is left to the Policy designers;
-                  an important part of Policy design is designing the right object level at
-                  which to namespace this status.
-
-                  Note also that implementations MUST ONLY populate ancestor status for
-                  the Ancestor resources they are responsible for. Implementations MUST
-                  use the ControllerName field to uniquely identify the entries in this list
-                  that they are responsible for.
-
-                  Note that to achieve this, the list of PolicyAncestorStatus structs
-                  MUST be treated as a map with a composite key, made up of the AncestorRef
-                  and ControllerName fields combined.
-
-                  A maximum of 16 ancestors will be represented in this list. An empty list
-                  means the Policy is not relevant for any ancestors.
-
-                  If this slice is full, implementations MUST NOT add further entries.
-                  Instead they MUST consider the policy unimplementable and signal that
-                  on any related resources such as the ancestor that would be referenced
-                  here. For example, if this list was full on BackendTLSPolicy, no
-                  additional Gateways would be able to reference the Service targeted by
-                  the BackendTLSPolicy.
+                description: Ancestor resources (usually Gateways) associated with
+                  the policy, with the policy's status for each. At most 16 entries;
+                  an empty list means the policy is not relevant to any ancestor
                 items:
-                  description: |-
-                    PolicyAncestorStatus describes the status of a route with respect to an
-                    associated Ancestor.
-
-                    Ancestors refer to objects that are either the Target of a policy or above it
-                    in terms of object hierarchy. For example, if a policy targets a Service, the
-                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
-                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
-                    useful object to place Policy status on, so we recommend that implementations
-                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
-                    have a _very_ good reason otherwise.
-
-                    In the context of policy attachment, the Ancestor is used to distinguish which
-                    resource results in a distinct application of this policy. For example, if a policy
-                    targets a Service, it may have a distinct result per attached Gateway.
-
-                    Policies targeting the same resource may have different effects depending on the
-                    ancestors of those resources. For example, different Gateways targeting the same
-                    Service may have different capabilities, especially if they have different underlying
-                    implementations.
-
-                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
-                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
-                    In this case, the relevant object for status is the Gateway, and that is the
-                    ancestor object referred to in this status.
-
-                    Note that a parent is also an ancestor, so for objects where the parent is the
-                    relevant object for status, this struct SHOULD still be used.
-
-                    This struct is intended to be used in a slice that's effectively a map,
-                    with a composite key made up of the AncestorRef and the ControllerName.
+                  description: Status of a policy with respect to an associated ancestor
+                    resource, usually a Gateway
                   properties:
                     ancestorRef:
                       description: |-
@@ -10262,95 +10174,26 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: |-
-                            Namespace is the namespace of the referent. When unspecified, this refers
-                            to the local namespace of the Route.
-
-                            Note that there are specific rules for ParentRefs which cross namespace
-                            boundaries. Cross-namespace references are only valid if they are explicitly
-                            allowed by something in the namespace they are referring to. For example:
-                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                            generic way to enable any other kind of cross-namespace reference.
-
-                            <gateway:experimental:description>
-                            ParentRefs from a Route to a Service in the same namespace are "producer"
-                            routes, which apply default routing rules to inbound connections from
-                            any namespace to the Service.
-
-                            ParentRefs from a Route to a Service in a different namespace are
-                            "consumer" routes, and these routing rules are only applied to outbound
-                            connections originating from the same namespace as the Route, for which
-                            the intended destination of the connections are a Service targeted as a
-                            ParentRef of the Route.
-                            </gateway:experimental:description>
-
-                            Support: Core
+                          description: 'Namespace of the referent. Defaults to the
+                            Route''s local namespace. Cross-namespace references must
+                            be explicitly allowed, for example via ReferenceGrant.
+                            Support: Core'
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |-
-                            Port is the network port this Route targets. It can be interpreted
-                            differently based on the type of parent resource.
-
-                            When the parent resource is a Gateway, this targets all listeners
-                            listening on the specified port that also support this kind of Route(and
-                            select this Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to a specific port
-                            as opposed to a listener(s) whose port(s) may be changed. When both Port
-                            and SectionName are specified, the name and port of the selected listener
-                            must match both specified values.
-
-                            <gateway:experimental:description>
-                            When the parent resource is a Service, this targets a specific port in the
-                            Service spec. When both Port (experimental) and SectionName are specified,
-                            the name and port of the selected port must match both specified values.
-                            </gateway:experimental:description>
-
-                            Implementations MAY choose to support other parent resources.
-                            Implementations supporting other types of parent resources MUST clearly
-                            document how/if Port is interpreted.
-
-                            For the purpose of status, an attachment is considered successful as
-                            long as the parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                            from the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-
-                            Support: Extended
+                          description: 'Port this Route targets on the parent, interpreted
+                            per parent kind (for example a Gateway listener port or
+                            Service port). Support: Extended'
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         sectionName:
-                          description: |-
-                            SectionName is the name of a section within the target resource. In the
-                            following resources, SectionName is interpreted as the following:
-
-                            * Gateway: Listener name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-                            * Service: Port name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-
-                            Implementations MAY choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName is
-                            interpreted.
-
-                            When unspecified (empty string), this will reference the entire resource.
-                            For the purpose of status, an attachment is considered successful if at
-                            least one section in the parent resource accepts it. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
-                            the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route, the
-                            Route MUST be considered detached from the Gateway.
-
-                            Support: Core
+                          description: 'Name of a section within the target resource,
+                            for example a Gateway Listener name or Service port name.
+                            Empty references the entire resource. Support: Core'
                           maxLength: 253
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -10359,38 +10202,8 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: |-
-                        Conditions describes the status of the Policy with respect to the given Ancestor.
-
-                        <gateway:util:excludeFromCRD>
-
-                        Notes for implementors:
-
-                        Conditions are a listType `map`, which means that they function like a
-                        map with a key of the `type` field _in the k8s apiserver_.
-
-                        This means that implementations must obey some rules when updating this
-                        section.
-
-                        * Implementations MUST perform a read-modify-write cycle on this field
-                          before modifying it. That is, when modifying this field, implementations
-                          must be confident they have fetched the most recent version of this field,
-                          and ensure that changes they make are on that recent version.
-                        * Implementations MUST NOT remove or reorder Conditions that they are not
-                          directly responsible for. For example, if an implementation sees a Condition
-                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
-                          Condition.
-                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
-                          rather than creating more than one Condition of the same Type.
-                        * Implementations MUST always update the `observedGeneration` field of the
-                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
-                        * If the `observedGeneration` of a Condition is _greater than_ the value the
-                          implementation knows about, then it MUST NOT perform the update on that Condition,
-                          but must wait for a future reconciliation and status update. (The assumption is that
-                          the implementation's copy of the object is stale and an update will be re-triggered
-                          if relevant.)
-
-                        </gateway:util:excludeFromCRD>
+                      description: Conditions describing the status of the policy
+                        for this ancestor
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.


### PR DESCRIPTION
Regenerate the `agentgateway-crds` chart from agentgateway [v1.4.1](https://github.com/agentgateway/agentgateway/releases/tag/v1.4.1) with `scripts/update_crds.sh`, and bump `version` / `appVersion` to 1.4.1.

```bash
export APP_VERSION=v1.4.1
./scripts/update_crds.sh -r agentgateway/agentgateway -b "$APP_VERSION" --folder controller/install/helm/agentgateway-crds/templates -o charts/agentgateway-crds/templates/
```

### What changes

- New CRD `agentgateway.dev_agentgatewaymodels.yaml` (`AgentgatewayModel`), four CRDs in the chart instead of three.
- All CRDs stay on `v1alpha1`.
- `AgentgatewayParameters` gains `spec.daemonSet` and `spec.workload`.
- The only schema removals are under `ai.promptGuard.{request,response}[]`: upstream narrowed each guardrail provider to the auth kinds it actually supports — e.g. `googleModelArmor` keeps `gcp` and drops `aws` / `azure` / `key` / `secretRef`, `bedrockGuardrails` drops `azure` / `gcp` / `passthrough`. Nothing we deploy uses `promptGuard`, so no CR migration is expected.
- No `creationTimestamp: null` in the regenerated files, nothing to clean up.

### Why

agentgateway is the LLM entrypoint for navi and is about to be rolled out to the remaining teams, so it should be on the current supported release. v1.4.0 also carries a High-severity fix for MCP session handling ([GHSA-mvgg-jvj2-4frq](https://github.com/agentgateway/agentgateway/security/advisories/GHSA-mvgg-jvj2-4frq), 8.1) — low impact for us today since we do not route MCP through the gateway.

agentgateway v1.4.0 hard-requires Gateway API v1.6, already shipped by `gateway-api-crds` 1.6.0 (#881), so keep installing `gateway-api-crds` before this chart.

The `wiremind-services-configuration` bump to these versions is held until this chart is released.

Ref: https://app.notion.com/p/3b5dcbda9c3581e49bfae7bb904c9b95