### PR TITLE
fix(elasticsearch-cluster): refresh Chart.lock onto the commonLabels children (4.5.1)

### DIFF
--- a/charts/elasticsearch-cluster/Chart.lock
+++ b/charts/elasticsearch-cluster/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.17.2
+  version: 8.18.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.17.2
+  version: 8.18.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.17.2
+  version: 8.18.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.17.2
+  version: 8.18.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.17.2
+  version: 8.18.0
 - name: kibana
   repository: https://wiremind.github.io/wiremind-helm-charts
   version: 8.5.23
@@ -22,6 +22,6 @@ dependencies:
   version: 7.4.0
 - name: cerebro
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 2.3.0
-digest: sha256:24c6235fcb10c59cecbdceb031f0a11f456e83056c38b58ba0e8e438f9cf0abd
-generated: "2026-07-30T10:37:24.494750193+02:00"
+  version: 2.4.0
+digest: sha256:6a28dd437921ff6524b71da0ea29c775ca81025e7a5063bf39dd36876a56f22f
+generated: "2026-08-10T16:01:14.943537068+02:00"

--- a/charts/elasticsearch-cluster/Chart.yaml
+++ b/charts/elasticsearch-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Elasticsearch cluster - a hat chart for several elasticsearch charts
 home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch-cluster
 name: elasticsearch-cluster
-version: 4.5.0
+version: 4.5.1
 appVersion: 8.19.12
 dependencies:
   - name: elasticsearch


### PR DESCRIPTION
Follow-up to #897. `elasticsearch-cluster-4.5.0` was published with the **old** children, so most of
that PR's benefit never reached consumers.

## What shipped

| dependency | in 4.5.0 | expected |
| --- | --- | --- |
| `elasticsearch` (×5 aliases) | **8.17.2** | 8.18.0 |
| `cerebro` | **2.3.0** | 2.4.0 |
| `kibana` | 8.5.23 | 8.5.23 ✓ |
| `prometheus-elasticsearch-exporter` | 7.4.0 | 7.4.0 ✓ |

The published tarball's `Chart.lock` is dated `2026-07-30T10:37:24` — the lock from the 4.4.17
release, untouched.

## Why

The dependencies declare `version: "*"`, but that resolves only when the lock is *written*.
`helm dependency build` — which chart-releaser runs — honours the existing committed lock instead of
re-resolving. So 4.5.0 gained `commonLabels` on the three resources this chart renders itself (setup
ConfigMap and Job, keystore Secret) while the 8 elasticsearch node resources and the cerebro Secret
stayed unlabellable: 9 of the 16 resources #897 set out to fix.

This could not have been fixed inside #897 — `elasticsearch-8.18.0` and `cerebro-2.4.0` did not exist
until that PR merged and released.

## This PR

`helm dependency update` re-resolves and rewrites the lock, plus a patch bump to 4.5.1. Two
dependency versions change; no template changes.

## Verified

The contract consumers actually use is `commonLabels` set **per alias** — nothing is forwarded
through `global`, deliberately, so no value can reach a child's immutable `volumeClaimTemplates` by
accident. With the refreshed lock:

```
OK   cerebro-2.4.0                          x4    (was MISS)
OK   es-master                              x6    (was MISS)
OK   es-data-hot                            x6    (was MISS)
MISS prometheus-elasticsearch-exporter      x2    third-party, expected
```

`helm lint --strict` clean.

## Worth a separate decision

Committing `Chart.lock` alongside `version: "*"` dependencies means children are frozen across
releases until someone explicitly runs `helm dependency update`. That is what caused this, and the
same mechanism would silently hold back a security fix in a child chart. Either the lock should not
be committed for `*` dependencies, or releasing should re-resolve — but that is a repo-wide change,
not this PR.
