### PR TITLE
fix(elasticsearch): merge labels and commonLabels into one block

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts
 name: elasticsearch
-version: 8.18.0
+version: 8.19.0
 appVersion: 8.19.12
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch

--- a/charts/elasticsearch/templates/secret.yaml
+++ b/charts/elasticsearch/templates/secret.yaml
@@ -9,11 +9,8 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
-    {{- range $key, $value := .Values.labels }}
+    {{- range $key, $value := merge (dict) (.Values.commonLabels | default dict) (.Values.labels | default dict) }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- with .Values.commonLabels }}
-    {{- toYaml . | nindent 4 }}
     {{- end }}
 type: Opaque
 data:

--- a/charts/elasticsearch/templates/statefulset.yaml
+++ b/charts/elasticsearch/templates/statefulset.yaml
@@ -8,11 +8,8 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     app: "{{ template "elasticsearch.uname" . }}"
-    {{- range $key, $value := .Values.labels }}
+    {{- range $key, $value := merge (dict) (.Values.commonLabels | default dict) (.Values.labels | default dict) }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
-    {{- with .Values.commonLabels }}
-    {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     esMajorVersion: "{{ include "elasticsearch.esMajorVersion" . }}"

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -91,6 +91,8 @@ podAnnotations: {}
 # Labels added to every resource this chart renders. Unlike `labels`, these do NOT reach the
 # StatefulSet's volumeClaimTemplates, whose labels are immutable — so setting them cannot
 # turn an upgrade into a StatefulSet recreate.
+# You can set the same key in `commonLabels` and in `labels`. The StatefulSet and the Secret
+# render the two maps merged, so the key appears one time. `commonLabels` wins.
 commonLabels: {}
 
 labels: {}


### PR DESCRIPTION
## Problem

The StatefulSet and the Secret rendered `labels` and `commonLabels` as two separate blocks. If a key is in both maps, the block writes that key two times. `helm template` accepts a duplicate mapping key and PyYAML keeps the last one, but **kustomize refuses the manifest**, so ArgoCD fails to render the whole Application.

The consumer cannot avoid the collision. `labels` also feeds the StatefulSet's `volumeClaimTemplates`, whose labels are immutable, so a consumer cannot move a key out of `labels`: that change recreates every existing Elasticsearch cluster.

overwhelm therefore had to clear `commonLabels` on its node groups (overwhelm `acc4f97`), which cost the node ConfigMap, PodDisruptionBudget and Services their `app.wiremind.io/overwhelm` label. That commit names this change as the follow-up it was waiting for:

> until the elasticsearch chart merges `labels` and `commonLabels` rather than rendering both

## Change

Both blocks now render `merge (dict) .Values.commonLabels .Values.labels`. `commonLabels` wins, which is the value a duplicate key resolved to before.

`commonLabels` still reaches `metadata.labels` only. The pod template and the `volumeClaimTemplates` keep reading `labels` alone, so setting `commonLabels` still cannot turn an upgrade into a StatefulSet recreate.

`elasticsearch` 8.18.0 -> 8.19.0.

## Verification

Against 8.18.0:

- `commonLabels` unset: every rendered label block is byte-identical (only the generated certs, password and helm-test suffixes differ).
- Same key in both maps: all 9 rendered resources carry it one time. `kustomize build` accepts the output; on 8.18.0 it failed with `mapping key "app.wiremind.io/overwhelm" already defined at line 12`.
- A commonLabels-only key stays out of the pod template and the `volumeClaimTemplates`.
- Rendered `elasticsearch-cluster` with the real per-alias values overwhelm produces: the 8 resources the audit found unlabelled now carry the label, and the volumeClaimTemplate label set matches the live PVCs of `testack-staging-client`.
- `helm lint --strict` passes.

## Follow-up

`charts/elasticsearch-cluster/Chart.lock` needs a refresh once 8.19.0 is published. `helm dependency build` honours the existing lock, so 8.19.0 does not reach the parent chart on its own — same trap as #900 after #897.

Not covered: nothing in CI would catch a regression here. `helm lint` and `ct` tolerate a duplicate mapping key, and this repo has no `kustomize build` step. overwhelm's generate-time duplicate-key check is currently the only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)