### PR TITLE
feat(metabase): fork the pmint93 chart to carry wiremind labels (2.27.5-wiremind0)

### DIFF
--- a/charts/metabase/.helmignore
+++ b/charts/metabase/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+appVersion: v0.61.1.x
+description: The easy, open source way for everyone in your company to ask questions and learn from data.
+home: http://www.metabase.com/
+icon: http://www.metabase.com/images/logo.svg
+maintainers:
+- email: phamminhthanh69@gmail.com
+  name: pmint93
+name: metabase
+sources:
+- https://github.com/metabase/metabase
+version: 2.27.5

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,12 +1,15 @@
 apiVersion: v1
 appVersion: v0.61.1.x
-description: The easy, open source way for everyone in your company to ask questions and learn from data.
+description: The easy, open source way for everyone in your company to ask questions and learn from data. Wiremind fork, adds commonLabels and standard app.kubernetes.io labels.
 home: http://www.metabase.com/
-icon: http://www.metabase.com/images/logo.svg
+icon: https://www.wiremind.io/assets/logo.png
 maintainers:
 - email: phamminhthanh69@gmail.com
   name: pmint93
+- email: platform@wiremind.io
+  name: platform
 name: metabase
 sources:
 - https://github.com/metabase/metabase
-version: 2.27.5
+- https://github.com/pmint93/helm-charts/tree/metabase-2.27.5/charts/metabase
+version: 2.27.5-wiremind0

--- a/charts/metabase/FORK.md
+++ b/charts/metabase/FORK.md
@@ -1,0 +1,51 @@
+# Wiremind fork of pmint93/metabase
+
+This chart is a vendored fork of the upstream
+[pmint93/metabase](https://github.com/pmint93/helm-charts/tree/metabase-2.27.5/charts/metabase)
+Helm chart at tag `metabase-2.27.5`. The functional change is the label set on
+object metadata.
+
+Upstream stamps only `{app, chart, release, heritage}` on each object, and it
+supports no `commonLabels`. Wiremind tooling cannot group on that set, so every
+metabase object falls into the "(no component)" bucket of the ArgoCD Components
+view.
+
+The fork adds a `metabase.wiremindLabels` helper. Each object's
+`metadata.labels` now also carries:
+
+- the standard `app.kubernetes.io/*` labels, from the chart's own (previously
+  unused) `metabase.labels` helper,
+- the `commonLabels` values key, which the caller sets. `overwhelm` passes
+  `app.wiremind.io/overwhelm: metabase` there.
+
+Two objects gained a `metadata.labels` block, because upstream gives them none:
+the `HorizontalPodAutoscaler` and the `pg-dump` pre-upgrade hook `Job`.
+
+## What the fork does not change
+
+The change is metadata only. Every selector in this chart matches on
+`{app, release}`, so the immutable `Deployment`, `Service`, `ServiceMonitor` and
+`SecurityGroupPolicy` selectors stay as upstream wrote them. A live release
+accepts the upgrade.
+
+Pod template labels also stay as upstream wrote them. Use `podLabels` to label
+the pods, as before.
+
+Do not put an `app.kubernetes.io/*` key in `commonLabels`. The chart stamps that
+set already, and a repeated key renders a duplicate YAML key. Helm accepts it,
+but `kustomize build` fails on it.
+
+## On each upstream bump
+
+Sync the new release into this directory, then re-apply the patch:
+
+1. `Chart.yaml` — version `<upstream>-wiremindN`, the wiremind icon, the
+   `platform@wiremind.io` maintainer and the upstream chart source.
+2. `FORK.md` — this file.
+3. `values.yaml` — the `commonLabels` key.
+4. `templates/_helpers.tpl` — the `metabase.wiremindLabels` helper.
+5. Every template that renders an object: one
+   `{{- include "metabase.wiremindLabels" . | nindent 4 }}` line after
+   `heritage:`. `templates/pvc.yaml` uses the helper in place of
+   `metabase.labels`. `templates/hpa.yaml` and `templates/pg-dump-hook.yaml`
+   need the full block.

--- a/charts/metabase/OWNERS
+++ b/charts/metabase/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- pmint93
+reviewers:
+- pmint93

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -1,0 +1,173 @@
+# Metabase
+
+[Metabase](http://metabase.com) is the easy, open source way for everyone in your company to ask questions and learn from data.
+
+## Introduction
+
+This chart bootstraps a [Metabase](https://github.com/metabase/metabase) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+
+
+## Get Repo Info
+
+```bash
+helm repo add pmint93 https://pmint93.github.io/helm-charts
+helm repo update
+```
+
+See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation.
+
+## Installing the Chart
+
+```bash
+# Helm 3
+$ helm install [RELEASE_NAME] pmint93/metabase
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] pmint93/metabase
+```
+
+The command deploys Metabase on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+```bash
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Metabase chart and their default values.
+
+| Parameter                                       | Description                                                                | Default           |
+|-------------------------------------------------|----------------------------------------------------------------------------|-------------------|
+| replicaCount                                    | desired number of controller pods                                          | 1                 |
+| pdb.create                                      | Enable/disable a Pod Disruption Budget creation                            | false             |
+| pdb.minAvailable                                | Minimum number/percentage of pods that should remain scheduled             | 1                 |
+| pdb.maxUnavailable                              | Maximum number/percentage of pods that may be made unavailable             |                   |
+| deploymentAnnotations                           | extra deployment annotations                                               | {}                |
+| deploymentLabels                                | extra deployment labels                                                    | {}                |
+| podAnnotations                                  | controller pods annotations                                                | {}                |
+| podLabels                                       | extra pods labels                                                          | {}                |
+| image.repository                                | controller container image repository                                      | metabase/metabase |
+| image.tag                                       | controller container image tag                                             | null              |
+| image.command                                   | controller container image command                                         | []                |
+| image.pullPolicy                                | controller container image pull policy                                     | IfNotPresent      |
+| image.pullSecrets                               | controller container image pull secrets                                    | []                |
+| fullnameOverride                                | String to fully override metabase.fullname template                        | null              |
+| listen.host                                     | Listening on a specific network host                                       | 0.0.0.0           |
+| listen.port                                     | Listening on a specific network port                                       | 3000              |
+| monitoring.enabled                              | Enable prometheus endpoint                                                 | false             |
+| monitoring.port                                 | Listening port for prometheus endpoint                                     | 9191              |
+| monitoring.serviceMonitor.enabled               | Enable ServiceMonitor resource for prometheus scraping                     | false             |
+| ssl.enabled                                     | Enable SSL to run over HTTPS                                               | false             |
+| ssl.port                                        | SSL port                                                                   | null              |
+| ssl.keyStore                                    | The key store in JKS format                                                | null              |
+| ssl.keyStorePassword                            | The password for key Store                                                 | null              |
+| database.type                                   | Backend database type                                                      | h2                |
+| database.encryptionKey                          | Secret key for encrypt sensitive information into database                 | null              |
+| database.connectionURI                          | Database connection URI (alternative to the below settings)                | null              |
+| database.host                                   | Database host                                                              | null              |
+| database.port                                   | Database port                                                              | null              |
+| database.file                                   | Database file (for H2; also add a volume to store it!)                     | null              |
+| database.dbname                                 | Database name                                                              | null              |
+| database.username                               | Database username                                                          | null              |
+| database.password                               | Database password                                                          | null              |
+| database.existingSecret                         | existing secret for database credentials                                   | null              |
+| database.existingSecretUsernameKey              | Username key for existing secret                                           | null              |
+| database.existingSecretPasswordKey              | Password key for existing secret                                           | null              |
+| database.existingSecretConnectionURIKey         | ConnectionURI key for existing secret                                      | null              |
+| database.existingSecretEncryptionKeyKey         | EncryptionKey key for existing secret                                      | null              |
+| database.googleCloudSQL.instanceConnectionNames | Google Cloud SQL instance connection names. See `values.yaml` for details. | []                |
+| database.googleCloudSQL.sidecarImage            | Specific image for the Google Cloud SQL Auth proxy sidecar                 | gcr.io/cloudsql-docker/gce-proxy            |
+| database.googleCloudSQL.sidecarImageTag         | Specific tag for the Google Cloud SQL Auth proxy sidecar image             | latest            |
+| database.googleCloudSQL.resources               | Google Cloud SQL Auth proxy resource requests and limits                   | {}                |
+| database.googleCloudSQL.securityContext         | Google Cloud SQL Security Context                                          | runAsNonRoot: true|
+| database.postgresBackupHook.enabled             | Enables pg_dump backup pre-upgrade hook of Metabase application database   | false             |
+| database.postgresBackupHook.image               | image that contains 'pg_dump'                                              | postgres:latest   |
+| database.postgresBackupHook.existingSecret      | existing secret for database credentials                                   | null              |
+| database.postgresBackupHook.existingSecretUsernameKey      | Username key for existing secret                                | null              |
+| database.postgresBackupHook.existingSecretPasswordKey      | Password key for existing secret                                | null              |
+| database.postgresBackupHook.existingSecretHostKey          | Username key for existing secret                                | null              |
+| database.postgresBackupHook.existingSecretPortKey          | Password key for existing secret                                | null              |
+| database.postgresBackupHook.existingSecretDatabaseNameKey  | Password key for existing secret                                | null              |
+| database.postgresBackupHook.existingSecretConnectionURIKey | ConnectionURI key for existing secret                           | null              |
+| database.postgresBackupHook.pvcName             | name of the PersistenceVolumeClaim to store the backup                     | null              |
+| database.postgresBackupHook.schema              | pg_dump '--schema' option                                                  | null              |
+| password.complexity                             | Complexity requirement for Metabase account's password                     | normal            |
+| password.length                                 | Minimum length required for Metabase account's password                    | 6                 |
+| timeZone                                        | Service time zone                                                          | UTC               |
+| emojiLogging                                    | Get a funny emoji in service log                                           | true              |
+| colorLogging                                    | Color log lines. When set to false it will disable log line colors         | true              |
+| javaOpts                                        | JVM options                                                                | null              |
+| pluginsDirectory                                | A directory with Metabase plugins                                          | null              |
+| extraInitContainers                             | Additional init containers e.g. to download plugins                        | []                |
+| extraVolumes                                    | Additional server volumes                                                  | []                |
+| extraVolumeMounts                               | Additional server volumeMounts                                             | []                |
+| startupProbe.timeoutSeconds                     | When the probe times out                                                   | 3                 |
+| startupProbe.failureThreshold                   | Minimum consecutive failures for the probe                                 | 60                |
+| startupProbe.periodSeconds                      | How often to perform the probe                                             | 5                 |
+| livenessProbe.initialDelaySeconds               | Delay before liveness probe is initiated                                   | 5                 |
+| livenessProbe.timeoutSeconds                    | When the probe times out                                                   | 30                |
+| livenessProbe.failureThreshold                  | Minimum consecutive failures for the probe                                 | 6                 |
+| readinessProbe.initialDelaySeconds              | Delay before readiness probe is initiated                                  | 5                 |
+| readinessProbe.timeoutSeconds                   | When the probe times out                                                   | 3                 |
+| readinessProbe.periodSeconds                    | How often to perform the probe                                             | 5                 |
+| service.type                                    | ClusterIP, NodePort, or LoadBalancer                                       | ClusterIP         |
+| service.loadBalancerSourceRanges                | Array of Source Ranges                                                     | null              |
+| service.externalPort                            | Service external port                                                      | 80                |
+| service.internalPort                            | Service internal port, should be the same as `listen.port`                 | 3000              |
+| service.nodePort                                | Service node port                                                          | null              |
+| service.annotations                             | Service annotations                                                        | {}                |
+| service.labels                                  | Service labels                                                             | {}                |
+| serviceAccount.create                           | Specifies whether a service account should be created                      | false             |
+| serviceAccount.annotations                      | Annotations to add to the service account                                  | {}                |
+| serviceAccount.name                             | The name of the service account to use                                     | null              |
+| awsEKS.sgp.enabled                              | Enable EKS's Security Groups Policy                                        | false             |
+| awsEKS.sgp.sgIds                                | List of AWS Security Group IDs to attach to the pod                        | null              |
+| ingress.enabled                                 | Enable ingress controller resource                                         | false             |
+| ingress.className                               | Ingress class name (Kubernetes 1.18+)                                      | null              |
+| ingress.hosts                                   | Ingress resource hostnames                                                 | ["*"]             |
+| ingress.path                                    | Ingress path                                                               | /                 |
+| ingress.pathType                                | Ingress pathType                                                           | Prefix            |
+| ingress.labels                                  | Ingress labels configuration                                               | null              |
+| ingress.annotations                             | Ingress annotations configuration                                          | {}                |
+| ingress.tls                                     | Ingress TLS configuration                                                  | null              |
+| route.enabled                                   | Enable OpenShift route resource                                            | false             |
+| route.labels                                    | Route labels configuration                                                 | null              |
+| route.annotations                               | Route annotations configuration                                            | {}                |
+| route.host                                      | Route hostname                                                             | null              |
+| route.path                                      | Route path                                                                 | ""                |
+| route.wildcardPolicy                            | Route wildcard policy                                                      | None              |
+| route.tls                                       | Route tls configuration                                                    | {}                |
+| log4j2XML                                       | Custom `log4j2.xml` file                                                   | null              |
+| log4jProperties                                 | DEPRECATED Custom `log4j.properties` file                                  | null              |
+| resources                                       | Server resource requests and limits                                        | {}                |
+| nodeSelector                                    | Node labels for pod assignment                                             | {}                |
+| tolerations                                     | Toleration labels for pod assignment                                       | []                |
+| affinity                                        | Affinity settings for pod assignment                                       | {}                |
+| priorityClass                                   | PriorityClass settings for pod assignment                                  | null              |
+| jetty.maxThreads                                | Jetty max number of threads                                                | null              |
+| jetty.minThreads                                | Jetty min number of threads                                                | null              |
+| jetty.maxQueued                                 | Jetty max queue size                                                       | null              |
+| jetty.maxIdleTime                               | Jetty max idle time                                                        | null              |
+| siteUrl                                         | Base URL, useful for serving behind a reverse proxy                        | null              |
+| session.maxSessionAge                           | Session expiration defined in minutes                                      | 20160             |
+| session.sessionCookies                          | When browser is closed, user login session will expire                     | null              |
+| extraEnv                                        | Mapping of extra environment variables                                     | {}                |
+| envFrom                                         | Mapping of extra environment variables from secret and/or configMap        | []                |
+| sidecars                                        | Mapping of container sidecars for the main deployment                      | []                |
+| securityContext                                 | Security Context for the Metabase container                                | {}                |
+| podSecurityContext                              | Security Context for the Metabase pod                                      | {}                |
+
+The above parameters map to the env variables defined in [metabase](http://github.com/metabase/metabase). For more information please refer to the [metabase documentations](https://www.metabase.com/docs/v0.41/operations-guide/environment-variables.html).

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -1,5 +1,8 @@
 # Metabase
 
+> This chart is a Wiremind fork of [pmint93/metabase](https://github.com/pmint93/helm-charts/tree/metabase-2.27.5/charts/metabase).
+> See [FORK.md](FORK.md) for the changes and for how to re-apply them on an upstream bump.
+
 [Metabase](http://metabase.com) is the easy, open source way for everyone in your company to ask questions and learn from data.
 
 ## Introduction
@@ -55,6 +58,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | pdb.create                                      | Enable/disable a Pod Disruption Budget creation                            | false             |
 | pdb.minAvailable                                | Minimum number/percentage of pods that should remain scheduled             | 1                 |
 | pdb.maxUnavailable                              | Maximum number/percentage of pods that may be made unavailable             |                   |
+| commonLabels                                    | extra labels on every object (wiremind fork, see FORK.md)                  | {}                |
 | deploymentAnnotations                           | extra deployment annotations                                               | {}                |
 | deploymentLabels                                | extra deployment labels                                                    | {}                |
 | podAnnotations                                  | controller pods annotations                                                | {}                |

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -1,0 +1,32 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if .Values.route.enabled }}
+  {{- if .Values.route.host }}
+    {{- if not (empty .Values.route.tls) }}
+  https://{{- .Values.route.host }}
+    {{- else }}
+  http://{{- .Values.route.host }}
+    {{- end }}
+  {{- else }}
+  export ROUTE_HOST=$(oc get route -n {{ .Release.Namespace }} {{ template "metabase.fullname" . }} -o jsonpath="{.spec.host}")
+    {{- if not (empty .Values.route.tls) }}
+  echo https://$ROUTE_HOST
+    {{- else }}
+  echo http://$ROUTE_HOST
+    {{- end }}
+  {{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "metabase.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "metabase.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "metabase.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "metabase.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metabase.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the apiVersion of deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the apiVersion of hpa.
+*/}}
+{{- define "hpa.apiVersion" -}}
+{{- if semverCompare "<1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "autoscaling/v1" -}}
+{{- else if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "metabase.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "metabase.labels" -}}
+helm.sh/chart: {{ include "metabase.chart" . }}
+{{ include "metabase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metabase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metabase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metabase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the namespace name
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "metabase.namespace" -}}
+{{- if .Values.fullnamespaceOverride -}}
+{{- .Values.fullnamespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -85,6 +85,23 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Wiremind fork: the labels this fork adds to every object's metadata.
+
+Upstream stamps only the legacy {app, chart, release, heritage} set on object
+metadata, which no Wiremind tooling can group on. This adds the standard
+app.kubernetes.io/* labels and the caller-supplied commonLabels.
+
+This is metadata only. Every selector in this chart matches on {app, release},
+so the immutable Deployment, Service and ServiceMonitor selectors are untouched.
+*/}}
+{{- define "metabase.wiremindLabels" -}}
+{{ include "metabase.labels" . }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create the namespace name
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/metabase/templates/config.yaml
+++ b/charts/metabase/templates/config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "metabase.fullname" . }}-config
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if .Values.log4jProperties }}
+  log4j.properties:
+{{ toYaml .Values.log4jProperties | indent 4}}
+  {{- end}}
+  {{- if .Values.log4j2XML }}
+  log4j2.xml:
+{{ toYaml .Values.log4j2XML | indent 4}}
+  {{- end}}

--- a/charts/metabase/templates/config.yaml
+++ b/charts/metabase/templates/config.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 data:
   {{- if .Values.log4jProperties }}
   log4j.properties:

--- a/charts/metabase/templates/database-secret.yaml
+++ b/charts/metabase/templates/database-secret.yaml
@@ -1,0 +1,28 @@
+{{- if or .Values.database.encryptionKey .Values.database.connectionURI .Values.database.username .Values.database.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metabase.fullname" . }}-database
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.database.encryptionKey }}
+  encryptionKey: {{ .Values.database.encryptionKey | b64enc | quote }}
+  {{- end }}
+  {{- if (ne (.Values.database.type | lower) "h2") }}
+    {{- if .Values.database.connectionURI }}
+  connectionURI: {{ .Values.database.connectionURI | b64enc | quote }}
+    {{- end }}
+    {{- if .Values.database.username }}
+  username: {{ .Values.database.username | b64enc | quote }}
+    {{- end }}
+    {{- if .Values.database.password }}
+  password: {{ .Values.database.password | b64enc | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/templates/database-secret.yaml
+++ b/charts/metabase/templates/database-secret.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.database.encryptionKey }}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
     {{- if .Values.deploymentLabels }}
     {{- toYaml .Values.deploymentLabels | trim | nindent 4 }}
     {{- end }}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -1,0 +1,379 @@
+apiVersion: {{ template "deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | trim | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | trim | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+  {{ if not .Values.hpa.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{ end }}
+  {{- with .Values.strategy }}
+  strategy:
+{{ toYaml . | trim | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | trim | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "metabase.name" . }}
+        release: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+        {{ toYaml .Values.extraInitContainers | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.image.pullSecrets) 0 }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name:  {{ template "metabase.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- with .Values.image.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: MB_JETTY_HOST
+            value: {{ .Values.listen.host | quote }}
+          - name: MB_JETTY_PORT
+            value: {{ .Values.listen.port | quote }}
+          {{- if .Values.monitoring.enabled }}
+          - name: MB_PROMETHEUS_SERVER_PORT
+            value: {{ .Values.monitoring.port  | quote }}
+          {{- end }}
+          {{- if .Values.ssl.enabled }}
+          - name: MB_JETTY_SSL
+            value: true
+          - name: MB_JETTY_SSL_Port
+            value: {{ .Values.ssl.port | quote }}
+          - name: MB_JETTY_SSL_Keystore
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-ssl
+                key: keystore
+          - name: MB_JETTY_SSL_Keystore_Password
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-ssl
+                key: password
+          {{- end }}
+          {{- if .Values.jetty }}
+            {{- range $key, $value := .Values.jetty }}
+          - name: MB_JETTY_{{ $key | upper }}
+            value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          - name: MB_DB_TYPE
+            value: {{ .Values.database.type | lower }}
+          {{- if .Values.database.file }}
+          - name: MB_DB_FILE
+            value: {{ .Values.database.file }}
+          {{- end }}
+          {{- if and .Values.database.existingSecret .Values.database.existingSecretEncryptionKeyKey }}
+          - name: MB_ENCRYPTION_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretEncryptionKeyKey }}
+          {{- else if .Values.database.encryptionKey }}
+          - name: MB_ENCRYPTION_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ printf "%s-database" (include "metabase.fullname" .)}}
+                key: encryptionKey
+          {{- end }}
+          {{- if ne (.Values.database.type | lower) "h2" }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretConnectionURIKey }}
+          - name: MB_DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretConnectionURIKey }}
+            {{- else if .Values.database.connectionURI }}
+          - name: MB_DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: connectionURI
+            {{- else }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretHostKey }}
+          - name: MB_DB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretHostKey }}
+            {{- else }}
+          - name: MB_DB_HOST
+            value: {{ .Values.database.host | quote }}
+            {{- end }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretPortKey }}
+          - name: MB_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretPortKey }}
+            {{- else }}
+          - name: MB_DB_PORT
+            value: {{ .Values.database.port | quote }}
+            {{- end}}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretDatabaseNameKey }}
+          - name: MB_DB_DBNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretDatabaseNameKey }}
+            {{- else }}
+          - name: MB_DB_DBNAME
+            value: {{ .Values.database.dbname | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretUsernameKey }}
+          - name: MB_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretUsernameKey }}
+            {{- else if .Values.database.username }}
+          - name: MB_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ printf "%s-database" (include "metabase.fullname" .) }}
+                key: username
+            {{- end }}
+            {{- if and .Values.database.existingSecret .Values.database.existingSecretPasswordKey }}
+          - name: MB_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.database.existingSecret }}
+                key: {{ .Values.database.existingSecretPasswordKey }}
+            {{- else if .Values.database.password }}
+          - name: MB_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ (printf "%s-database" (include "metabase.fullname" .)) }}
+                key: password
+            {{- end }}
+          {{- end }}
+          - name: MB_PASSWORD_COMPLEXITY
+            value: {{ .Values.password.complexity }}
+          - name: MB_PASSWORD_LENGTH
+            value: {{ .Values.password.length | quote }}
+          - name: JAVA_TIMEZONE
+            value: {{ .Values.timeZone }}
+          {{- if .Values.javaOpts }}
+          - name: JAVA_OPTS
+            value: {{ .Values.javaOpts | quote }}
+          {{- else }}
+            {{- if .Values.log4jProperties }}
+          - name: JAVA_OPTS
+            value: "-Dlog4j.configuration=file:/tmp/conf/log4j.properties"
+            {{- end }}
+            {{- if .Values.log4j2XML }}
+          - name: JAVA_OPTS
+            value: "-Dlog4j.configurationFile=file:/tmp/conf/log4j2.xml"
+            {{- end }}
+          {{- end }}
+          {{- if .Values.pluginsDirectory }}
+          - name: MB_PLUGINS_DIR
+            value: {{ .Values.pluginsDirectory | quote }}
+          {{- end }}
+          - name: MB_EMOJI_IN_LOGS
+            value: {{ .Values.emojiLogging | quote }}
+          - name: MB_COLORIZE_LOGS
+            value: {{ .Values.colorLogging | quote }}
+          {{- if .Values.siteUrl }}
+          - name: MB_SITE_URL
+            value: {{ .Values.siteUrl | quote }}
+          {{- end }}
+          {{- if .Values.session.maxSessionAge }}
+          - name: MAX_SESSION_AGE
+            value: {{ .Values.session.maxSessionAge | quote }}
+          {{- end }}
+          {{- if .Values.session.sessionCookies }}
+          - name: MB_SESSION_COOKIES
+            value: {{ .Values.session.sessionCookies | quote }}
+          {{- end }}
+          {{- if .Values.session.cookieSameSite }}
+          - name: MB_COOKIE_SAMESITE
+            value: {{ .Values.session.cookieSameSite | quote }}
+          {{- end }}
+          {{- if gt (len .Values.extraEnv) 0 }}
+          {{- .Values.extraEnv | toYaml | nindent 10 }}
+          {{- end }}
+          {{- if gt (len .Values.envFrom) 0 }}
+          envFrom:
+            {{- range .Values.envFrom }}
+            - {{ .type }}Ref:
+                name: {{ .name }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+            {{- if .Values.monitoring.enabled }}
+            - containerPort: {{ .Values.monitoring.port }}
+              name: metrics
+            {{- end }}
+          {{- if .Values.securityContext}}
+          securityContext:
+          {{- .Values.securityContext | toYaml | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          {{- if or .Values.log4jProperties .Values.log4j2XML (ne (len .Values.extraVolumeMounts) 0) .Values.database.persistence.enabled }}
+          volumeMounts:
+            {{- if .Values.database.persistence.enabled }}
+            - name: {{ template "metabase.fullname" . }}-database
+              mountPath: /metabase.db/
+            {{- end }}
+            {{- if or .Values.log4jProperties .Values.log4j2XML }}
+            - name: config
+              mountPath: /tmp/conf/
+            {{- end }}
+            {{- if ne (len .Values.extraVolumeMounts) 0 }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        {{- if gt (len .Values.database.googleCloudSQL.instanceConnectionNames) 0 }}
+        - name: cloudsql-proxy
+          image: "{{ or .Values.database.googleCloudSQL.sidecarImage "gcr.io/cloudsql-docker/gce-proxy" }}:{{ or .Values.database.googleCloudSQL.sidecarImageTag "latest" }}"
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ join "," .Values.database.googleCloudSQL.instanceConnectionNames }}"
+            - "-term_timeout=10s"
+            - "-structured_logs"
+            - "-use_http_health_check"
+            - "-enable_iam_login"
+            {{- if .Values.database.googleCloudSQL.ipAddressTypes }}
+            - "-ip_address_types={{ .Values.database.googleCloudSQL.ipAddressTypes }}"
+            {{- end }}
+          securityContext:
+          {{- .Values.database.googleCloudSQL.securityContext | toYaml | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 8090
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8090
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 2
+          startupProbe:
+            httpGet:
+              path: /startup
+              port: 8090
+            periodSeconds: 1
+            timeoutSeconds: 5
+            failureThreshold: 20
+          resources:
+{{ toYaml .Values.database.googleCloudSQL.resources | indent 12 }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{ toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
+    {{- if .Values.podSecurityContext}}
+      securityContext:
+    {{- .Values.podSecurityContext | toYaml | nindent 8 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.hostAliases }}
+      hostAliases:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      {{- if .Values.priorityClass}}
+      priorityClassName: {{ .Values.priorityClass }}
+      {{- end }}
+      serviceAccountName: {{ template "metabase.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      volumes:
+        {{- if .Values.database.persistence.enabled }}
+        - name: {{ template "metabase.fullname" . }}-database
+          persistentVolumeClaim:
+            claimName: {{ template "metabase.fullname" . }}-database
+        {{- end }}
+        {{- if or .Values.log4jProperties .Values.log4j2XML }}
+        - name: config
+          configMap:
+            name: {{ template "metabase.fullname" . }}-config
+            items:
+            {{- if .Values.log4jProperties }}
+            - key: log4j.properties
+              path: log4j.properties
+            {{- end }}
+            {{- if .Values.log4j2XML}}
+            - key: log4j2.xml
+              path: log4j2.xml
+            {{- end }}
+        {{- end }}
+        {{- if ne (len .Values.extraVolumes) 0 }}
+          {{ toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}

--- a/charts/metabase/templates/hpa.yaml
+++ b/charts/metabase/templates/hpa.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.hpa.enabled (not .Values.hpa.external) }}
+apiVersion: {{ template "hpa.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "metabase.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "metabase.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  {{- with .Values.hpa.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.hpa.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/templates/hpa.yaml
+++ b/charts/metabase/templates/hpa.yaml
@@ -3,6 +3,12 @@ apiVersion: {{ template "hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "metabase.fullname" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/metabase/templates/httproute.yaml
+++ b/charts/metabase/templates/httproute.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace: {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.httpRoute.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if .Values.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.httpRoute.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+      {{- if .port }}
+      port: {{ .port }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+  {{- range .Values.httpRoute.hostnames }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httpRoute.rules }}
+  {{- range .Values.httpRoute.rules }}
+    - matches:
+      {{- range .matches }}
+        - path:
+            type: {{ .path.type | default "PathPrefix" }}
+            value: {{ .path.value | default "/" }}
+          {{- if .headers }}
+          headers:
+          {{- range .headers }}
+            - name: {{ .name }}
+              value: {{ .value }}
+              {{- if .type }}
+              type: {{ .type }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
+      {{- if .name }}
+      name: {{ .name }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+      {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      {{- if .timeouts }}
+      timeouts:
+      {{- toYaml .timeouts | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ $.Values.httpRoute.servicePort | default $.Values.service.port | default 80 }}
+          {{- if .weight }}
+          weight: {{ .weight }}
+          {{- end }}
+  {{- end }}
+  {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httpRoute.path | default "/" }}
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ .Values.httpRoute.servicePort | default .Values.service.port | default 80 }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/templates/httproute.yaml
+++ b/charts/metabase/templates/httproute.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
   {{- range $key, $value := .Values.httpRoute.labels }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- else -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end }}
+{{- end -}}

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
   {{- range $key, $value := .Values.ingress.labels }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
@@ -53,6 +54,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
   {{- range $key, $value := .Values.ingress.labels }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/metabase/templates/pdb.yaml
+++ b/charts/metabase/templates/pdb.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+      {{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | trim | indent 6 }}
+      {{- end }}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | trim | indent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/metabase/templates/pdb.yaml
+++ b/charts/metabase/templates/pdb.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}

--- a/charts/metabase/templates/pg-dump-hook.yaml
+++ b/charts/metabase/templates/pg-dump-hook.yaml
@@ -1,0 +1,67 @@
+{{- if and (eq .Values.database.type "postgres") .Values.database.postgresBackupHook.enabled }}
+{{- $fullName := include "metabase.fullname" . }}
+{{- $datestring := (now | date "20060102-150405") }}
+{{- $jobname := ( printf "%s-rev-%d-%s" $fullName .Release.Revision $datestring ) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobname }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: pg-dump
+    spec:
+      containers:
+        - name: pg-dump
+          image: {{ .Values.database.postgresBackupHook.image | required "database.postgresBackupHook.image must be set" }}
+          env:
+            {{- if .Values.database.postgresBackupHook.existingSecretConnectionURIKey }}
+            - name: BACKUP_CONNECTION_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgresBackupHook.existingSecret | required "database.postgresBackupHook.existingSecret must be set" }}
+                  key: {{ .Values.database.postgresBackupHook.existingSecretConnectionURIKey }}
+            {{- else }}
+            - name: PGPASSWORD 
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgresBackupHook.existingSecret }}
+                  key: {{ .Values.database.postgresBackupHook.existingSecretPasswordKey }}
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgresBackupHook.existingSecret }}
+                  key: {{ .Values.database.postgresBackupHook.existingSecretHostKey }}
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgresBackupHook.existingSecret }}
+                  key: {{ .Values.database.postgresBackupHook.existingSecretUsernameKey }}
+            - name: PGDATABASE 
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgresBackupHook.existingSecret }}
+                  key: {{ .Values.database.postgresBackupHook.existingSecretDatabaseNameKey }}
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgresBackupHook.existingSecret }}
+                  key: {{ .Values.database.postgresBackupHook.existingSecretPortKey }}
+            {{- end }}
+          command:
+            - sh
+            - "-c" 
+            - pg_dump --file {{ ( printf "/backup/metabase_db_rev_%d_%s.dump" .Release.Revision $datestring ) | squote }} --format=c --verbose --verbose {{ if .Values.database.postgresBackupHook.schema }}--schema={{ .Values.database.postgresBackupHook.schema | squote }}{{- end }} {{ if .Values.database.postgresBackupHook.existingSecretConnectionURIKey }}$BACKUP_CONNECTION_URI{{- else }}$PGDATABASE{{- end }}
+          volumeMounts:
+            - name: backup-storage
+              mountPath: /backup
+      restartPolicy: Never
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.database.postgresBackupHook.pvcName | required ".Values.database.postgresBackupHook.pvcName is required" }}
+{{- end }}

--- a/charts/metabase/templates/pg-dump-hook.yaml
+++ b/charts/metabase/templates/pg-dump-hook.yaml
@@ -6,6 +6,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $jobname }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/metabase/templates/pvc.yaml
+++ b/charts/metabase/templates/pvc.yaml
@@ -1,0 +1,36 @@
+{{- if and  .Values.database.persistence.enabled (not .Values.database.persistence.existingClaim) (eq .Values.database.persistence.type "pvc")}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "metabase.fullname" . }}-database
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+    {{- with .Values.database.persistence.extraPvcLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.database.persistence.annotations  }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.database.persistence.finalizers  }}
+  finalizers:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.database.persistence.size | quote }}
+  {{- if and (.Values.database.persistence.lookupVolumeName) (lookup "v1" "PersistentVolumeClaim" (include "metabase.namespace" .) (include "metabase.fullname" .)) }}
+  volumeName: {{ (lookup "v1" "PersistentVolumeClaim" (include "metabase.namespace" .) (include "metabase.fullname" .)).spec.volumeName }}
+  {{- end }}
+  {{- with .Values.database.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.database.persistence.selectorLabels }}
+  selector:
+    matchLabels:
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/templates/pvc.yaml
+++ b/charts/metabase/templates/pvc.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "metabase.fullname" . }}-database
   labels:
-    {{- include "metabase.labels" . | nindent 4 }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
     {{- with .Values.database.persistence.extraPvcLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/metabase/templates/route.yaml
+++ b/charts/metabase/templates/route.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.route.enabled -}}
+{{- $serviceName := include "metabase.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.route.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.route.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  host: {{ .Values.route.host | quote }}
+  path: {{ .Values.route.path }}
+  wildcardPolicy: {{ .Values.route.wildcardPolicy }}
+{{- if not (empty .Values.route.tls) }}
+  tls:
+{{- with .Values.route.tls }}
+    termination: {{ .termination }}
+    insecureEdgeTerminationPolicy: {{ .insecureEdgeTerminationPolicy }}
+    {{- with .key }}
+    key: |
+{{ . | indent 6 }}
+    {{- end }}
+    {{- with .certificate }}
+    certificate: |
+{{ . | indent 6 }}
+    {{- end }}
+    {{- with .caCertificate }}
+    caCertificate: |
+{{ . | nindent 6 }}
+    {{- end }}
+    {{- with .destinationCACertificate }}
+    destinationCACertificate: |
+{{ . | nindent 6 }}
+    {{- end }}
+{{- end }}
+{{- end }}
+  to:
+    kind: Service
+    name: {{ $serviceName }}
+  port:
+    targetPort: {{ .Values.service.name }}
+{{- end }}

--- a/charts/metabase/templates/route.yaml
+++ b/charts/metabase/templates/route.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
   {{- range $key, $value := .Values.route.labels }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/metabase/templates/securitygrouppolicy.yaml
+++ b/charts/metabase/templates/securitygrouppolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.awsEKS.sgp.enabled -}}
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+      release: {{ .Release.Name }}
+  securityGroups:
+    groupIds:
+      {{- range .Values.awsEKS.sgp.sgIds }}
+      - {{ . | quote }}
+      {{- end }}
+{{- end }}

--- a/charts/metabase/templates/securitygrouppolicy.yaml
+++ b/charts/metabase/templates/securitygrouppolicy.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/metabase/templates/service.yaml
+++ b/charts/metabase/templates/service.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+{{- end }}
+{{- if .Values.service.ipFamilies }}
+  ipFamilies:
+{{ toYaml .Values.service.ipFamilies | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+{{toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end}}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+{{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end}}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+{{- if .Values.monitoring.enabled }}
+    - port: {{ .Values.monitoring.port }}
+      targetPort: {{ .Values.monitoring.port }}
+      protocol: TCP
+      name: metrics
+{{- end }}
+  selector:
+    app: {{ template "metabase.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/metabase/templates/service.yaml
+++ b/charts/metabase/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}

--- a/charts/metabase/templates/serviceaccount.yaml
+++ b/charts/metabase/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "metabase.serviceAccountName" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/metabase/templates/serviceaccount.yaml
+++ b/charts/metabase/templates/serviceaccount.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/metabase/templates/servicemonitor.yaml
+++ b/charts/metabase/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "metabase.fullname" . }}
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Values.monitoring.serviceMonitor.releaseLabel | default .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metabase.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - path: /metrics
+      port: metrics
+{{- end }}

--- a/charts/metabase/templates/servicemonitor.yaml
+++ b/charts/metabase/templates/servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Values.monitoring.serviceMonitor.releaseLabel | default .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/metabase/templates/ssl-secret.yaml
+++ b/charts/metabase/templates/ssl-secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ssl.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "metabase.fullname" . }}-ssl
+  namespace:  {{ template "metabase.namespace" . }}
+  labels:
+    app: {{ template "metabase.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  keystore: {{ .Values.ssl.keystore | b64enc | quote }}
+  password: {{ .Values.ssl.keyStorePassword | b64enc | quote }}
+{{- end }}

--- a/charts/metabase/templates/ssl-secret.yaml
+++ b/charts/metabase/templates/ssl-secret.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- include "metabase.wiremindLabels" . | nindent 4 }}
 type: Opaque
 data:
   keystore: {{ .Values.ssl.keystore | b64enc | quote }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -23,6 +23,11 @@ pdb:
   minAvailable: 1
   maxUnavailable: ""
 
+# Wiremind fork: labels added to the metadata of every object this chart creates.
+# Selectors are not affected, so you can change these on a live release.
+# Do not put app.kubernetes.io/* keys here. The chart already stamps that set,
+# and a repeated key renders a duplicate YAML key that breaks kustomize.
+commonLabels: {}
 deploymentAnnotations: {}
 deploymentLabels: {}
 podAnnotations: {}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -1,0 +1,457 @@
+replicaCount: 1
+
+hpa:
+  enabled: false
+  # If external: false, the HPA will be managed by the chart
+  # If external: true, the HPA will not be created by the chart
+  # Useful for external HPA controllers such as KEDA.
+  external: false
+  minReplicas: 1
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# Adding host aliases to the metabase deployment
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "foo.local"
+#   - "bar.local"
+
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+deploymentAnnotations: {}
+deploymentLabels: {}
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+image:
+  repository: metabase/metabase
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  command: []
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+## Strings to fully override metabase.fullname and metabase.namespace templates
+##
+# fullnameOverride:
+# fullnamespaceOverride:
+
+# Config Jetty web server
+listen:
+  host: "0.0.0.0"
+  port: 3000
+
+monitoring:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    # Override the release label, e.g. "kube-prometheus-stack"
+    releaseLabel: ""
+  port: 9191
+
+ssl:
+  # If you have an ssl certificate and would prefer to have Metabase run over HTTPS
+  enabled: false
+  # port: 8443
+  # keyStore: |-
+  #   << JKS KEY STORE >>
+  # keyStorePassword: storepass
+jetty:
+#  maxThreads: 254
+#  minThreads: 8
+#  maxQueued: -1
+#  maxIdleTime: 60000
+
+# Backend database
+database:
+  # Database type (h2 / mysql / postgres), default: h2
+  type: h2
+  # if h2 is used, the persistentVolume and pvc are used to store the database. Only for non-production environments.
+  persistence:
+    type: pvc
+    enabled: false
+    # storageClassName: default
+    ## (Optional) Use this to bind the claim to an existing PersistentVolume (PV) by name.
+    volumeName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    # annotations: {}
+    finalizers:
+      - kubernetes.io/pvc-protection
+    # selectorLabels: {}
+    ## Sub-directory of the PV to mount. Can be templated.
+    # subPath: ""
+    ## Name of an existing PVC. Can be templated.
+    # existingClaim:
+    ## Extra labels to apply to a PVC.
+    extraPvcLabels: {}
+    disableWarning: false
+
+    ## If 'lookupVolumeName' is set to true, Helm will attempt to retrieve
+    ## the current value of 'spec.volumeName' and incorporate it into the template.
+    lookupVolumeName: true
+  ## Specify file to store H2 database.  You will also have to back this with a volume (cf. extraVolume and extraVolumeMounts)!
+  # file:
+  # encryptionKey: << YOUR ENCRYPTION KEY OR LEAVE BLANK AND USE EXISTING SECRET >>
+  ## Only need when you use mysql / postgres
+  # host:
+  # port:
+  # dbname:
+  # username:
+  # password:
+  ## Alternatively, use a connection URI for full configurability. Example for SSL enabled Postgres.
+  # connectionURI: postgres://<host>:<port>/<database>?user=<username>&password=<password>&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory
+  ## If a secret with the database credentials already exists, use the following values:
+  # existingSecret:
+  # existingSecretUsernameKey:
+  # existingSecretPasswordKey:
+  # existingSecretConnectionURIKey:
+  # existingSecretEncryptionKeyKey:
+  # existingSecretPortKey:
+  # existingSecretHostKey:
+  # existingSecretDatabaseNameKey:
+  ## One or more Google Cloud SQL database instances can be made available to Metabase via the *Cloud SQL Auth proxy*.
+  ## These can be used for Metabase's internal database (by specifying `host: localhost` and the port above), or as
+  ## additional databases (configured at Admin → Databases). Workload Identity should be used for authentication, so
+  ## that when `serviceAccount.create=true`, `serviceAccount.annotations` should contain:
+  ##   iam.gke.io/gcp-service-account: your-gsa@email
+  ## Ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
+  googleCloudSQL:
+    ## Found in Cloud Console "Cloud SQL Instance details" or using `gcloud sql instances describe INSTANCE_ID`
+    ## example format: $project:$region:$instance=tcp:$port
+    ## Each connection must have a unique TCP port.
+    instanceConnectionNames: []
+    ## IP address types for Cloud SQL (e.g. PRIVATE,PUBLIC)
+    ipAddressTypes: ""
+    #
+    ## Option to use a specific version and image of the *Cloud SQL Auth proxy* sidecar image.
+    ## ref: https://console.cloud.google.com/gcr/images/cloudsql-docker/GLOBAL/gce-proxy
+    # sidecarImage: gcr.io/cloudsql-docker/gce-proxy
+    # sidecarImageTag: latest
+    ## ref: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine#running_the_as_a_sidecar
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+  postgresBackupHook:
+    ## Only when you use postgres
+    ## enables a pre-upgrade hook that backups the metabase database with pg_dump prior to upgrading the Helm release
+    enabled: false
+    ## image that contains 'pg_dump'
+    ## version/tag should align with your actual version of postgres (e.g. 'postgres:17.7') for best compability of the dump
+    image: "postgres:latest"
+    ## secret with the database credentials must exist
+    # existingSecret:
+    ## either use connection string
+    # existingSecretConnectionURIKey:
+    ## or specify user,password,host,port and database seperately
+    # existingSecretUsernameKey:
+    # existingSecretPasswordKey:
+    # existingSecretPortKey:
+    # existingSecretHostKey:
+    # existingSecretDatabaseNameKey:
+    ## name of the PersistenceVolumeClaim to store the backup
+    # pvcName:
+    ## optional: specify pg_dump '--schema' option (e.g. if you have multiple schemas and only want to backup specific ones)
+    # schema:
+
+password:
+  # Changing Metabase password complexity:
+  # weak: no character constraints
+  # normal: at least 1 digit (default)
+  # strong: minimum 8 characters w/ 2 lowercase, 2 uppercase, 1 digit, and 1 special character
+  complexity: normal
+  length: 6
+
+timeZone: UTC
+emojiLogging: true
+colorLogging: true
+# javaOpts:
+# pluginsDirectory: /plugins
+# siteUrl:
+
+session:
+  {}
+  # maxSessionAge:
+  # sessionCookies:
+  # cookieSameSite:
+
+# specify init containers, e.g. for module download
+extraInitContainers: []
+#  - name: download-modules
+#    image: "curlimages/curl:7.70.0"
+#    imagePullPolicy: "IfNotPresent"
+#    volumeMounts:
+#      - name: plugins
+#        mountPath: /plugins
+#    workingDir: /plugins
+#    command:
+#      - "/bin/sh"
+#      - "-ec"
+#      - |
+#        curl -Lso /plugins/athena.metabase-driver.jar \
+#                  https://github.com/dacort/metabase-athena-driver/releases/download/v1.1.0/athena.metabase-driver.jar
+
+extraVolumeMounts: []
+#  - name: plugins
+#    mountPath: /plugins
+#    readOnly: false
+
+extraVolumes: []
+#  - name: plugins
+#    emptyDir: {}
+
+startupProbe:
+  path: /api/health
+  timeoutSeconds: 3
+  failureThreshold: 60
+  periodSeconds: 5
+
+livenessProbe:
+  path: /api/health
+  initialDelaySeconds: 5
+  timeoutSeconds: 30
+  failureThreshold: 6
+
+readinessProbe:
+  path: /api/health
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 5
+
+service:
+  name: metabase
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 3000
+  # Used to fix NodePort when service.type: NodePort.
+  nodePort:
+  annotations:
+    {}
+    # Used to add custom annotations to the Service.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+  labels:
+    {}
+    # Used to add custom labels to the Service.
+  loadBalancerSourceRanges:
+    {}
+  # ipFamilyPolicy: PreferDualStack
+  # ipFamilies:
+  #   - IPv6
+  #   - IPv4
+  # Used to configure a static IP address
+  loadBalancerIP:
+
+ingress:
+  enabled: false
+  # The ingress class name, if you use multiple ingress controllers:
+  # className: ...
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - "*"
+    # - metabase.domain.com
+  # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.
+  path: /
+  pathType: Prefix
+  labels:
+    # Used to add custom labels to the Ingress
+    # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses
+    # traffic: internal
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: metabase-tls
+    #   hosts:
+    #     - metabase.domain.com
+
+# Note: This is the Openshift route
+route:
+  enabled: false
+  labels:
+    # Used to add custom labels to the Route
+    # Useful if for example you have multiple Ingress controllers (Routers) and want your Routers to bind to specific Routes
+    # traffic: internal
+  annotations:
+    {}
+    # haproxy.router.openshift.io/timeout: "60s"
+  # host: ""
+  path: ""
+  wildcardPolicy: "None"
+  tls:
+    {}
+    # termination: "Edge"
+    # insecureEdgeTerminationPolicy: "Redirect"
+    # key: ""
+    # certificate: ""
+    # caCertificate: ""
+    # destinationCACertificate: ""
+
+# A custom log4j2.xml file can be provided using a multiline YAML string.
+# See https://github.com/metabase/metabase/blob/master/resources/log4j2.xml
+#
+# log4j2XML:
+
+# DEPRECATED; A custom log4j.properties file can be provided using a multiline YAML string.
+# See https://github.com/metabase/metabase/blob/master/resources/log4j.properties
+#
+# log4jProperties:
+
+# The deployment strategy to use
+# https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
+# strategy:
+#   type: "Recreate"
+
+# -- Kubernetes Gateway API HTTPRoute
+# Use it with a Gateway API implementation (e.g. Envoy Gateway, Istio, Cilium, etc.)
+# Ref: https://gateway-api.sigs.k8s.io/
+httpRoute:
+  enabled: false
+
+  ## Labels to add to the HTTPRoute resource
+  labels: {}
+
+  ## Annotations to add to the HTTPRoute resource
+  annotations: {}
+
+  ## Parent Gateway reference(s) that this HTTPRoute attaches to.
+  ## The Gateway must already exist and have a matching listener.
+  ## TLS termination is configured on the Gateway, not here.
+  parentRefs:
+    - name: ""
+      # namespace: gateway-namespace
+      # sectionName: https
+
+  ## Hostnames to match. Must align with the Gateway listener's hostname/certificate.
+  ## Example:
+  ##   hostnames:
+  ##     - metabase.example.com
+  hostnames: []
+
+  ## Simple path-based routing (used when 'rules' is not set)
+  path: "/"
+
+  ## Override the backend service port (defaults to .Values.service.port)
+  # servicePort: 80
+
+  ## Advanced: define custom routing rules.
+  ## When set, 'path' above is ignored. Each rule gets the service backend automatically.
+  ## Example:
+  ##   rules:
+  ##     - matches:
+  ##         - path:
+  ##             type: PathPrefix
+  ##             value: /
+  ##       name: root
+  ##       filters:
+  ##         - type: RequestHeaderModifier
+  ##           requestHeaderModifier:
+  ##             set:
+  ##               - name: X-Forwarded-Proto
+  ##                 value: https
+  # rules: []
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # autoMount is deprecated in favor of automountServiceAccountToken
+  # If you want to disable auto mount of Service Account Token then you can set the value to false;
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+  automountServiceAccountToken: false
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+# You can also opt out of automounting API credentials for a particular Pod;
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+automountServiceAccountToken: true
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Spread Constraints for pod assignment
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+
+## PriorityClass for pod assignment
+## ref:
+## https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
+## priorityClass: ""
+
+## AWS Security Group Policy (EKS)
+## ref: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html
+##
+awsEKS:
+  sgp:
+    enabled: false
+    # AWS Security Group IDs to attach to the pod
+    # sgIds:
+    #   - sg-abc123
+    #   - sg-xyz456
+
+extraEnv: []
+#  - name: MB_CHECK_FOR_UPDATES
+#    value: false
+#  - name: MB_ADMIN_EMAIL
+#    valueFrom:
+#      configMapKeyRef:
+#        name: metabase
+#        key: email
+
+envFrom: []
+  # - type: secret
+  #   name: metabase-secret
+  # - type: configMap
+  #   name: metabase-cm
+
+securityContext: {}
+
+sidecars: []
+  # - name: busybox
+  #   image: busybox
+  #   ports:
+  #     - containerPort: 80
+  #       name: http
+  #   resources:
+  #     requests:
+  #       memory: 100Mi
+  #       cpu: 10m
+  #     limits:
+  #       memory: 100Mi
+  #       cpu: 10m
+  #   command: ["/bin/sh"]
+  #   args: ["-c", "while true; do echo hello; sleep 10;done"]


### PR DESCRIPTION
## Why

The upstream [pmint93 metabase chart](https://github.com/pmint93/helm-charts/tree/metabase-2.27.5/charts/metabase) stamps only the legacy `{app, chart, release, heritage}` set on object metadata, and it supports no `commonLabels`. Wiremind tooling cannot group on that set, so every metabase object falls into the "(no component)" bucket of the ArgoCD Components view. A label audit found 7 such objects in one namespace, and 45 metabase Deployments carry the bare set across `ovh-main-gra11-prod`.

## What

This vendors pmint93 `metabase-2.27.5` as `2.27.5-wiremind0` and adds a `metabase.wiremindLabels` helper. Each object's `metadata.labels` now also carries:

- the standard `app.kubernetes.io/*` labels, from the chart's own (previously unused) `metabase.labels` helper,
- the new `commonLabels` values key, which the caller sets. `overwhelm` will pass `app.wiremind.io/overwhelm: metabase` there.

Every template gets one `include` line after `heritage:`. The `HorizontalPodAutoscaler` and the `pg-dump` pre-upgrade hook `Job` gained a full labels block, because upstream gives them none.

[FORK.md](charts/metabase/FORK.md) records the divergence and how to re-apply it on an upstream bump.

## Safety

The change is metadata only. Every selector in this chart matches on `{app, release}`, so the immutable `Deployment`, `Service`, `ServiceMonitor` and `SecurityGroupPolicy` selectors stay as upstream wrote them. Pod template labels also stay unchanged; `podLabels` still labels the pods. A live release accepts the upgrade.

Do not put an `app.kubernetes.io/*` key in `commonLabels`. The chart stamps that set already, and a repeated key renders a duplicate YAML key. Helm accepts it, but `kustomize build` fails on it.

## Verification

- `helm lint` passes on default values and on wiremind values.
- A render diff against upstream 2.27.5 shows only the added labels and the chart-version string.
- A strict YAML parse finds no duplicate keys, and `kustomize build` accepts the output.
- A render of the `wiremind` chart against this fork puts `app.wiremind.io/overwhelm: metabase` on all 7 audited objects.

## Follow-up

`wiremind/devops/helm-charts-private` repoints its metabase dependency to this fork after release. `overwhelm` then passes `commonLabels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
