### PR TITLE
fix(elasticsearch-cluster): refresh Chart.lock onto elasticsearch 8.19.0 (4.5.2)

### DIFF
--- a/charts/elasticsearch-cluster/Chart.lock
+++ b/charts/elasticsearch-cluster/Chart.lock
@@ -1,19 +1,19 @@
 dependencies:
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.18.0
+  version: 8.19.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.18.0
+  version: 8.19.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.18.0
+  version: 8.19.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.18.0
+  version: 8.19.0
 - name: elasticsearch
   repository: https://wiremind.github.io/wiremind-helm-charts
-  version: 8.18.0
+  version: 8.19.0
 - name: kibana
   repository: https://wiremind.github.io/wiremind-helm-charts
   version: 8.5.23
@@ -23,5 +23,5 @@ dependencies:
 - name: cerebro
   repository: https://wiremind.github.io/wiremind-helm-charts
   version: 2.4.0
-digest: sha256:6a28dd437921ff6524b71da0ea29c775ca81025e7a5063bf39dd36876a56f22f
-generated: "2026-08-10T16:01:14.943537068+02:00"
+digest: sha256:598c44737357f0d8fee2816cdff160ea6dd5f155e9fa1e0e657654314595a7a4
+generated: "2026-08-14T10:06:10.401066054+02:00"

--- a/charts/elasticsearch-cluster/Chart.yaml
+++ b/charts/elasticsearch-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Elasticsearch cluster - a hat chart for several elasticsearch charts
 home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/elasticsearch-cluster
 name: elasticsearch-cluster
-version: 4.5.1
+version: 4.5.2
 appVersion: 8.19.12
 dependencies:
   - name: elasticsearch


### PR DESCRIPTION
Follow-up to #903, same shape as #900 after #897.

## Why

4.5.1 locks `elasticsearch` 8.18.0. The dependencies declare `version: "*"`, but that resolves only when the lock is written: `helm dependency build` — what chart-releaser runs — honours the existing lock. So the label merge #903 added to the child does not reach this chart on its own.

## Change

`helm dependency update charts/elasticsearch-cluster` moves the five elasticsearch aliases 8.18.0 -> 8.19.0. `kibana` (8.5.23), `cerebro` (2.4.0) and `prometheus-elasticsearch-exporter` (7.4.0) are unchanged.

`elasticsearch-cluster` 4.5.1 -> 4.5.2 (patch: no interface change, a child fix only).

## Verification

Rendered 4.5.2 with the per-alias values overwhelm produces, which set the same `app.wiremind.io/overwhelm` key in **both** `commonLabels` and `labels` — the combination that failed before #903:

- The 8 node resources the audit found unlabelled now carry it: `Service` x4, `PodDisruptionBudget` x2, `ConfigMap` x2.
- `kustomize build` accepts the render.
- overwhelm's `_reject_duplicate_keys` passes.
- Confirmed the pulled `elasticsearch-8.19.0.tgz` contains the merged label block.

`prometheus-elasticsearch-exporter` stays unlabelled, as expected and as noted in #897: it is third-party and exposes no such hook.

## Next in the chain

1. This MR — publishes elasticsearch-cluster 4.5.2.
2. `helm-charts-private`: pin 4.5.2, patch-bump the `wiremind` chart.
3. overwhelm!546: restore `commonLabels` on the node groups and raise `MIN_HELM_CHART_VERSION` to that chart version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)