### PR TITLE
chore(buildkitd): use v0.32.2 by default

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: buildkitd
 description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
-appVersion: 0.28.0  # renovate: datasource=docker depName=moby/buildkit
+appVersion: 0.32.2  # renovate: datasource=docker depName=moby/buildkit
 kubeVersion: ">=1.19.0-0"
-version: 0.28.0  # renovate: datasource=docker depName=moby/buildkit
+version: 0.32.2  # renovate: datasource=docker depName=moby/buildkit
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts


### PR DESCRIPTION
Bumps the buildkitd chart from buildkit 0.28.0 to 0.32.2, the latest upstream release (2026-08-04). Chart bumps here are manual (Renovate does not run on this repo), so the chart had been stale since March. `moby/buildkit:v0.32.2-rootless` verified on Docker Hub.

Follow-up once released: bump the chart version in wiremind-services-configuration (gitlab-shared-runners/buildkitd) — Renovate picks it up there.

See: https://github.com/moby/buildkit/releases/tag/v0.32.2

Ref: https://app.notion.com/p/3c8dcbda9c3581ec8e96c5e5d2363ab2