### PR TITLE
feat(renovate): add repo config so renovate-bot-github stops skipping this repo

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: Renovate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - renovate.json
+      - .github/workflows/renovate.yml
+  push:
+    branches:
+      - main
+    paths:
+      - renovate.json
+      - .github/workflows/renovate.yml
+jobs:
+  validate:
+    name: Validate Renovate Config
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/renovatebot/renovate:43
+      options: --user 0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate configuration
+        run: |
+          renovate-config-validator --strict renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": true,
+  "baseBranchPatterns": [
+    "main"
+  ],
+  "commitMessageSuffix": "({{updateType}})",
+  "extends": [
+    "config:best-practices",
+    "default:semanticCommits",
+    ":disableRateLimiting"
+  ],
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Chart\\.yaml$/"
+      ],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "(?:appVersion|version): (?<currentValue>.*?)\\s+# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\n"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "timezone": "Europe/Paris"
+}


### PR DESCRIPTION
renovate-bot-github (bots namespace) autodiscovers `wiremind/**` but runs with `onboarding=false` and `requireConfig=required`, so any repo without a `renovate.json` is silently skipped — which is why the `# renovate:` annotations in `charts/buildkitd/Chart.yaml` never produced a PR and chart bumps were manual (see #908).

- `renovate.json` mirrors infra-services (`config:best-practices`, semantic commits, no rate limiting) with a single custom regex manager matching Chart.yaml `# renovate:` annotations. The regex is verified against the buildkitd annotations, and the config passes `renovate-config-validator --strict`.
- `helmv3` is deliberately left disabled: it would open PRs for pinned vendored chart dependencies.
- `.github/workflows/renovate.yml` validates the config on change, same as infra-services.

Other charts can opt in by adding the same `# renovate:` annotation to their Chart.yaml.

Ref: https://app.notion.com/p/3c8dcbda9c3581b39a93ed103a1a4d6b