### PR TITLE
feat(buildkitd): make startup probe period and timeout configurable

### DIFF
--- a/charts/buildkitd/Chart.yaml
+++ b/charts/buildkitd/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for https://github.com/moby/buildkit (rootless)
 type: application
 appVersion: 0.32.2  # renovate: datasource=docker depName=moby/buildkit
 kubeVersion: ">=1.19.0-0"
-version: 0.32.2  # renovate: datasource=docker depName=moby/buildkit
+version: 0.33.0  # renovate: datasource=docker depName=moby/buildkit
 maintainers:
   - name: Wiremind
     url: https://github.com/wiremind/wiremind-helm-charts

--- a/charts/buildkitd/templates/statefulset.yaml
+++ b/charts/buildkitd/templates/statefulset.yaml
@@ -126,7 +126,8 @@ spec:
                 - debug
                 - workers
             failureThreshold: {{ .Values.startupProbe.retries }}
-            periodSeconds: 1
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           securityContext:
             capabilities:
               add:

--- a/charts/buildkitd/values.yaml
+++ b/charts/buildkitd/values.yaml
@@ -155,6 +155,8 @@ readinessProbe:
 
 startupProbe:
   retries: 60
+  periodSeconds: 1
+  timeoutSeconds: 1
 
 extraSecurityContext: {}
 


### PR DESCRIPTION
The startup probe execs `buildctl debug workers` with hardcoded `periodSeconds: 1` and the Kubernetes default `timeoutSeconds: 1`. `buildctl` is OTEL-instrumented (`cmd/buildctl/common/trace.go` builds a span exporter from the standard `OTEL_EXPORTER_OTLP_*` env and flushes on exit via `tp.Shutdown`) — and probe execs inherit the container env. With OTEL export enabled on buildkitd, every probe exec blocks on the trace flush, exceeds 1s, and after 60 failures kubelet kills a perfectly healthy container in a loop.

This exposes `startupProbe.periodSeconds` and `startupProbe.timeoutSeconds` (defaults unchanged: 1/1), mirroring the liveness/readiness probes. Chart 0.33.0, appVersion stays 0.32.2.

Seen in production today on gra11: startup-probe kill loop took the shared-runner buildkitd down after enabling OTEL export.

Ref: https://app.notion.com/p/3c9dcbda9c3581d3afaac5dfe681ee76