### PR TITLE
chore(cnpg): update the cloudnative-pg and barman-cloud CRDs

### DIFF
--- a/charts/cloudnative-pg-crds/Chart.yaml
+++ b/charts/cloudnative-pg-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: cloudnative-pg-crds
-version: 1.28.0
-appVersion: "v1.28.0"
+version: 1.30.0
+appVersion: "v1.30.0"
 description: Manage cloudnative-pg CRDs
 keywords:
   - cloudnative-pg

--- a/charts/cloudnative-pg-crds/README.md
+++ b/charts/cloudnative-pg-crds/README.md
@@ -11,7 +11,7 @@ CRDs are located [here](https://github.com/cloudnative-pg/charts/blob/main/chart
 **Do not forget to change APP_VERSION**
 
 ``` bash
-export CHART_VERSION=v0.27.0
+export CHART_VERSION=v0.29.0
 cd charts/cloudnative-pg-crds
 curl https://raw.githubusercontent.com/cloudnative-pg/charts/refs/tags/cloudnative-pg-$CHART_VERSION/charts/cloudnative-pg/templates/crds/crds.yaml -L -o crds.yaml
 sed -i '/{{- if .Values.crds.create }}/d; /{{- end }}/d' crds.yaml

--- a/charts/cloudnative-pg-crds/templates/backups.yaml
+++ b/charts/cloudnative-pg-crds/templates/backups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -211,6 +211,11 @@ spec:
                         - key
                         - name
                       type: object
+                    useDefaultAzureCredentials:
+                      description: |-
+                        Use the default Azure authentication flow, which includes DefaultAzureCredential.
+                        This allows authentication using environment variables and managed identities.
+                      type: boolean
                   type: object
                 backupId:
                   description: The ID of the Barman backup
@@ -304,6 +309,13 @@ spec:
                     podName:
                       description: The pod name
                       type: string
+                    sessionID:
+                      description: |-
+                        The instance manager session ID. This is a unique identifier generated at instance manager
+                        startup and changes on every restart (including container reboots). Used to detect if
+                        the instance manager was restarted during long-running operations like backups, which
+                        would terminate any running backup process.
+                      type: string
                   type: object
                 majorVersion:
                   description: |-
@@ -324,6 +336,14 @@ spec:
                     type: string
                   description: A map containing the plugin metadata
                   type: object
+                reconciliationStartedAt:
+                  description: When the backup process was started by the operator
+                  format: date-time
+                  type: string
+                reconciliationTerminatedAt:
+                  description: When the reconciliation was terminated by the operator (either successfully or not)
+                  format: date-time
+                  type: string
                 s3Credentials:
                   description: The credentials to use to upload data to S3
                   properties:
@@ -414,11 +434,11 @@ spec:
                       type: array
                   type: object
                 startedAt:
-                  description: When the backup was started
+                  description: When the backup execution was started by the backup tool
                   format: date-time
                   type: string
                 stoppedAt:
-                  description: When the backup was terminated
+                  description: When the backup execution was terminated by the backup tool
                   format: date-time
                   type: string
                 tablespaceMapFile:

--- a/charts/cloudnative-pg-crds/templates/clusterimagecatalogs.yaml
+++ b/charts/cloudnative-pg-crds/templates/clusterimagecatalogs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -45,11 +45,147 @@ spec:
                 Specification of the desired behavior of the ClusterImageCatalog.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
+                componentImages:
+                  description: |-
+                    ComponentImages is a list of named images for components other than PostgreSQL
+                    (e.g. pgbouncer). Keys must be unique within a catalog.
+                  items:
+                    description: CatalogComponentImage is a named image entry for a non-PostgreSQL component.
+                    properties:
+                      image:
+                        description: Image is the container image reference.
+                        type: string
+                      key:
+                        description: Key is the unique identifier for this image within the catalog.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                      - image
+                      - key
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - key
+                  x-kubernetes-list-type: map
+                  x-kubernetes-validations:
+                    - message: Component image keys must be unique
+                      rule: self.all(e, self.filter(f, f.key==e.key).size() == 1)
                 images:
                   description: List of CatalogImages available in the catalog
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: |-
+                                The name of the extension, required. The limit of 59 characters
+                                leaves room for the prefix the operator adds when deriving the
+                                extension's Kubernetes Volume name (capped at 63 characters).
+                              maxLength: 59
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string

--- a/charts/cloudnative-pg-crds/templates/clusters.yaml
+++ b/charts/cloudnative-pg-crds/templates/clusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -984,9 +984,10 @@ spec:
                           operator:
                             description: |-
                               Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                               Exists is equivalent to wildcard for value, so that a pod can
                               tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
                             description: |-
@@ -1077,6 +1078,11 @@ spec:
                                 - key
                                 - name
                               type: object
+                            useDefaultAzureCredentials:
+                              description: |-
+                                Use the default Azure authentication flow, which includes DefaultAzureCredential.
+                                This allows authentication using environment variables and managed identities.
+                              type: boolean
                           type: object
                         data:
                           description: |-
@@ -1108,10 +1114,11 @@ spec:
                               description: |-
                                 Compress a backup file (a tar file per tablespace) while streaming it
                                 to the object store. Available options are empty string (no
-                                compression, default), `gzip`, `bzip2`, and `snappy`.
+                                compression, default), `gzip`, `bzip2`, `lz4`, and `snappy`.
                               enum:
                                 - bzip2
                                 - gzip
+                                - lz4
                                 - snappy
                               type: string
                             encryption:
@@ -1908,7 +1915,9 @@ spec:
                               description: The target timeline ("latest" or a positive integer)
                               type: string
                             targetTime:
-                              description: The target time as a timestamp in the RFC3339 standard
+                              description: |-
+                                The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.
+                                Timestamps without an explicit timezone are interpreted as UTC.
                               type: string
                             targetXID:
                               description: The target transaction ID
@@ -2410,7 +2419,7 @@ spec:
                             resources:
                               description: |-
                                 resources represents the minimum resources the volume should have.
-                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                Users are allowed to specify resource requirements
                                 that are lower than previous value but must still be higher than capacity recorded in the
                                 status field of the claim.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -2607,6 +2616,11 @@ spec:
                                   - key
                                   - name
                                 type: object
+                              useDefaultAzureCredentials:
+                                description: |-
+                                  Use the default Azure authentication flow, which includes DefaultAzureCredential.
+                                  This allows authentication using environment variables and managed identities.
+                                type: boolean
                             type: object
                           data:
                             description: |-
@@ -2638,10 +2652,11 @@ spec:
                                 description: |-
                                   Compress a backup file (a tar file per tablespace) while streaming it
                                   to the object store. Available options are empty string (no
-                                  compression, default), `gzip`, `bzip2`, and `snappy`.
+                                  compression, default), `gzip`, `bzip2`, `lz4`, and `snappy`.
                                 enum:
                                   - bzip2
                                   - gzip
+                                  - lz4
                                   - snappy
                                 type: string
                               encryption:
@@ -3172,6 +3187,8 @@ spec:
                             description: |-
                               List of one or more existing roles to which this role will be
                               immediately added as a new member. Default empty.
+                              Changes to the list are applied to an existing role through
+                              `GRANT` and `REVOKE` statements, not only at role creation.
                             items:
                               type: string
                             type: array
@@ -3179,7 +3196,7 @@ spec:
                             default: true
                             description: |-
                               Whether a role "inherits" the privileges of roles it is a member of.
-                              Defaults is `true`.
+                              Default is `true`.
                             type: boolean
                           login:
                             description: |-
@@ -3193,8 +3210,10 @@ spec:
                             type: string
                           passwordSecret:
                             description: |-
-                              Secret containing the password of the role (if present)
-                              If null, the password will be ignored unless DisablePassword is set
+                              Secret containing the password of the role (if present).
+                              If null, the password will be ignored unless DisablePassword is set.
+                              When set, the secret must follow the `kubernetes.io/basic-auth` format
+                              and contain both a `username` and a `password` field.
                             properties:
                               name:
                                 description: Name of the referent.
@@ -4194,6 +4213,80 @@ spec:
                           type: string
                       type: object
                   type: object
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs defines named pod label selectors that can be referenced
+                    in pg_hba rules using the ${podselector:NAME} syntax in the address field.
+                    The operator resolves matching pod IPs and the instance manager expands
+                    pg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.
+                  items:
+                    description: |-
+                      PodSelectorRef defines a named pod label selector for use in pg_hba rules.
+                      Pods matching the selector in the Cluster's namespace will have their IPs
+                      resolved and made available for pg_hba address expansion via the
+                      `${podselector:NAME}` syntax.
+                    properties:
+                      name:
+                        description: |-
+                          Name is the identifier used to reference this selector in pg_hba rules
+                          via the ${podselector:NAME} syntax in the address field.
+                        minLength: 1
+                        pattern: ^[a-z]([a-z0-9_-]*[a-z0-9])?$
+                        type: string
+                      selector:
+                        description: |-
+                          Selector is a label selector that identifies the pods whose IPs
+                          should be resolved. Only pods in the Cluster's namespace are considered.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - name
+                      - selector
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 postgresGID:
                   default: 26
                   description: The GID of the `postgres` user inside the image, defaults to `26`
@@ -4221,6 +4314,13 @@ spec:
                           ExtensionConfiguration is the configuration used to add
                           PostgreSQL extensions to the Cluster.
                         properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
                           dynamic_library_path:
                             description: |-
                               The list of directories inside the image which should be added to dynamic_library_path.
@@ -4228,6 +4328,45 @@ spec:
                             items:
                               type: string
                             type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           extension_control_path:
                             description: |-
                               The list of directories inside the image which should be added to extension_control_path.
@@ -4236,7 +4375,7 @@ spec:
                               type: string
                             type: array
                           image:
-                            description: The image containing the extension, required
+                            description: The image containing the extension.
                             properties:
                               pullPolicy:
                                 description: |-
@@ -4256,24 +4395,27 @@ spec:
                                   container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                             type: object
-                            x-kubernetes-validations:
-                              - message: An image reference is required
-                                rule: has(self.reference)
                           ld_library_path:
                             description: The list of directories inside the image which should be added to ld_library_path.
                             items:
                               type: string
                             type: array
                           name:
-                            description: The name of the extension, required
+                            description: |-
+                              The name of the extension, required. The limit of 59 characters
+                              leaves room for the prefix the operator adds when deriving the
+                              extension's Kubernetes Volume name (capped at 63 characters).
+                            maxLength: 59
                             minLength: 1
-                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                             type: string
                         required:
-                          - image
                           - name
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     ldap:
                       description: Options to specify LDAP configuration
                       properties:
@@ -4349,7 +4491,9 @@ spec:
                     pg_hba:
                       description: |-
                         PostgreSQL Host Based Authentication rules (lines to be appended
-                        to the pg_hba.conf file)
+                        to the pg_hba.conf file).
+                        Use the ${podselector:NAME} syntax to reference a pod selector;
+                        the rule will be expanded for each Pod IP matching that selector.
                       items:
                         type: string
                       type: array
@@ -4457,6 +4601,53 @@ spec:
                       x-kubernetes-validations:
                         - message: dataDurability set to 'preferred' requires empty 'standbyNamesPre' and empty 'standbyNamesPost'
                           rule: self.dataDurability!='preferred' || ((!has(self.standbyNamesPre) || self.standbyNamesPre.size()==0) && (!has(self.standbyNamesPost) || self.standbyNamesPost.size()==0))
+                  type: object
+                primaryLease:
+                  description: |-
+                    Configuration of the Kubernetes `Lease` used to coordinate safe primary
+                    election within the cluster. When omitted, the operator applies built-in
+                    defaults; tune these values only if you understand the consequences for
+                    failover timing.
+                  properties:
+                    leaseDurationSeconds:
+                      default: 15
+                      description: |-
+                        How long, in seconds, the primary lease is considered valid before it
+                        expires and another instance may acquire it. It must be greater than
+                        `renewDeadlineSeconds`.
+                        Defaults to 15.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    releasedLeaseDurationSeconds:
+                      default: 1
+                      description: |-
+                        The TTL, in seconds, written when the primary explicitly releases the
+                        lease on a clean shutdown, allowing a replica to promote without waiting
+                        for the full lease duration to expire.
+                        Defaults to 1.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    renewDeadlineSeconds:
+                      default: 10
+                      description: |-
+                        How long, in seconds, the current primary keeps retrying to renew the
+                        lease before giving up and stopping. It must be smaller than
+                        `leaseDurationSeconds`.
+                        Defaults to 10.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    retryPeriodSeconds:
+                      default: 2
+                      description: |-
+                        How frequently, in seconds, a non-holder instance retries acquiring or
+                        renewing the lease.
+                        Defaults to 2.
+                      format: int32
+                      minimum: 1
+                      type: integer
                   type: object
                 primaryUpdateMethod:
                   default: restart
@@ -5020,6 +5211,24 @@ spec:
                               signerName:
                                 description: Kubelet's generated CSRs will be addressed to this signer.
                                 type: string
+                              userAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  userAnnotations allow pod authors to pass additional information to
+                                  the signer implementation.  Kubernetes does not restrict or validate this
+                                  metadata in any way.
+
+                                  These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                  the PodCertificateRequest objects that Kubelet creates.
+
+                                  Entries are subject to the same validation as object metadata annotations,
+                                  with the addition that all keys must be domain-prefixed. No restrictions
+                                  are placed on values, except an overall size limitation on the entire field.
+
+                                  Signers should document the keys and values they support. Signers should
+                                  deny requests that contain keys they do not recognize.
+                                type: object
                             required:
                               - keyType
                               - signerName
@@ -5380,7 +5589,6 @@ spec:
                         procMount denotes the type of proc mount to use for the containers.
                         The default value is Default which uses the container runtime defaults for
                         readonly paths and masked paths.
-                        This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
@@ -5495,6 +5703,20 @@ spec:
                           type: string
                       type: object
                   type: object
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the cluster.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple clusters (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the cluster name.
+                    Mutually exclusive with ServiceAccountTemplate.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceAccountTemplate:
                   description: Configure the generation of the service account
                   properties:
@@ -5645,7 +5867,7 @@ spec:
                         resources:
                           description: |-
                             resources represents the minimum resources the volume should have.
-                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                            Users are allowed to specify resource requirements
                             that are lower than previous value but must still be higher than capacity recorded in the
                             status field of the claim.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -5892,7 +6114,7 @@ spec:
                               resources:
                                 description: |-
                                   resources represents the minimum resources the volume should have.
-                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                  Users are allowed to specify resource requirements
                                   that are lower than previous value but must still be higher than capacity recorded in the
                                   status field of the claim.
                                   More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6291,7 +6513,7 @@ spec:
                         resources:
                           description: |-
                             resources represents the minimum resources the volume should have.
-                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                            Users are allowed to specify resource requirements
                             that are lower than previous value but must still be higher than capacity recorded in the
                             status field of the claim.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -6686,7 +6908,10 @@ spec:
                     Deprecated: the field is not set for backup plugins.
                   type: object
                 latestGeneratedNode:
-                  description: ID of the latest generated node (used to avoid node name clashing)
+                  description: |-
+                    ID of the latest generated node (used to avoid node name clashing)
+
+                    Deprecated: this field is not set anymore
                   type: integer
                 managedRolesStatus:
                   description: ManagedRolesStatus reports the state of the managed roles in the cluster
@@ -6704,8 +6929,10 @@ spec:
                           type: string
                         type: array
                       description: |-
-                        CannotReconcile lists roles that cannot be reconciled in PostgreSQL,
-                        with an explanation of the cause
+                        CannotReconcile lists roles that cannot be reconciled, with an
+                        explanation of the cause. Failures may originate in PostgreSQL
+                        (e.g. dropping a role that owns objects) or in Kubernetes (e.g.
+                        the referenced password Secret cannot be fetched).
                       type: object
                     passwordStatus:
                       additionalProperties:
@@ -6725,9 +6952,121 @@ spec:
                 onlineUpdateEnabled:
                   description: OnlineUpdateEnabled shows if the online upgrade is enabled inside the cluster
                   type: boolean
+                operatorCertificateFingerprint:
+                  description: |-
+                    OperatorCertificateFingerprint is the SHA256 fingerprint of the operator's
+                    in-memory client certificate public key. The instance manager pins this
+                    fingerprint to authenticate requests from the operator.
+                  type: string
                 pgDataImageInfo:
                   description: PGDataImageInfo contains the details of the latest image that has run on the current data directory.
                   properties:
+                    extensions:
+                      description: Extensions contains the container image extensions available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: |-
+                              The name of the extension, required. The limit of 59 characters
+                              leaves room for the prefix the operator adds when deriving the
+                              extension's Kubernetes Volume name (capped at 63 characters).
+                            maxLength: 59
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
                     image:
                       description: Image is the image name
                       type: string
@@ -6800,6 +7139,30 @@ spec:
                       - version
                     type: object
                   type: array
+                podSelectorRefs:
+                  description: |-
+                    PodSelectorRefs contains the resolved pod IPs for each named selector
+                    defined in spec.podSelectorRefs.
+                  items:
+                    description: PodSelectorRefStatus contains the resolved pod IPs for a named selector.
+                    properties:
+                      ips:
+                        description: |-
+                          IPs is the list of pod IPs matching the selector.
+                          Each IP is a single address (no CIDR notation).
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name corresponds to the name in the spec's PodSelectorRef.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 poolerIntegrations:
                   description: The integration needed by poolers referencing the cluster
                   properties:
@@ -6876,6 +7239,13 @@ spec:
                       description: The resource version of the "postgres" user secret
                       type: string
                   type: object
+                selector:
+                  description: |-
+                    Selector is the serialized form of the label selector that identifies
+                    the pods managed by this cluster. Populated by the operator and exposed
+                    through the scale sub-resource so an autoscaler (such as HPA or VPA)
+                    can discover the managed instance pods.
+                  type: string
                 switchReplicaClusterStatus:
                   description: SwitchReplicaClusterStatus is the status of the switch to replica cluster
                   properties:
@@ -6908,6 +7278,128 @@ spec:
                       - state
                     type: object
                   type: array
+                targetPgDataImageInfo:
+                  description: |-
+                    TargetPGDataImageInfo contains the details of the target image for an
+                    in-progress major upgrade. It is set before the upgrade Job is created,
+                    and cleared on successful completion or when the upgrade is rolled back.
+                  properties:
+                    extensions:
+                      description: Extensions contains the container image extensions available for the current Image
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: |-
+                              The name of the extension, required. The limit of 59 characters
+                              leaves room for the prefix the operator adds when deriving the
+                              extension's Kubernetes Volume name (capped at 63 characters).
+                            maxLength: 59
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is the image name
+                      type: string
+                    majorVersion:
+                      description: MajorVersion is the major version of the image
+                      type: integer
+                  required:
+                    - image
+                    - majorVersion
+                  type: object
                 targetPrimary:
                   description: |-
                     Target primary instance, this is different from the previous one
@@ -6962,6 +7454,7 @@ spec:
       storage: true
       subresources:
         scale:
+          labelSelectorPath: .status.selector
           specReplicasPath: .spec.instances
           statusReplicasPath: .status.instances
         status: {}

--- a/charts/cloudnative-pg-crds/templates/databaseroles.yaml
+++ b/charts/cloudnative-pg-crds/templates/databaseroles.yaml
@@ -1,0 +1,321 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+    helm.sh/resource-policy: keep
+  name: databaseroles.postgresql.cnpg.io
+spec:
+  group: postgresql.cnpg.io
+  names:
+    kind: DatabaseRole
+    listKind: DatabaseRoleList
+    plural: databaseroles
+    singular: databaserole
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.cluster.name
+          name: Cluster
+          type: string
+        - jsonPath: .spec.name
+          name: PG Name
+          type: string
+        - jsonPath: .status.applied
+          name: Applied
+          type: boolean
+        - description: Latest reconciliation message
+          jsonPath: .status.message
+          name: Message
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: DatabaseRole is the Schema for the databaseroles API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired DatabaseRole.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                bypassrls:
+                  description: |-
+                    Whether a role bypasses every row-level security (RLS) policy.
+                    Default is `false`.
+                  type: boolean
+                clientCertificate:
+                  description: |-
+                    ClientCertificate configures the operator to generate and renew a TLS client
+                    certificate for this role, signed by the cluster's client CA. The certificate
+                    is stored in a Secret named `<databaserole-name>-client-cert`.
+                    Requires login to be true.
+                  properties:
+                    enabled:
+                      default: true
+                      description: |-
+                        Enabled turns on client certificate issuance for this role. When true,
+                        the role must have login enabled. Defaults to true when the block is present.
+                      type: boolean
+                  type: object
+                cluster:
+                  description: The corresponding cluster
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                    - message: cluster reference is immutable after creation
+                      rule: self == oldSelf
+                comment:
+                  description: Description of the role
+                  type: string
+                connectionLimit:
+                  default: -1
+                  description: |-
+                    If the role can log in, this specifies how many concurrent
+                    connections the role can make. `-1` (the default) means no limit.
+                  format: int64
+                  type: integer
+                createdb:
+                  description: |-
+                    When set to `true`, the role being defined will be allowed to create
+                    new databases. Specifying `false` (default) will deny a role the
+                    ability to create databases.
+                  type: boolean
+                createrole:
+                  description: |-
+                    Whether the role will be permitted to create, alter, drop, comment
+                    on, change the security label for, and grant or revoke membership in
+                    other roles. Default is `false`.
+                  type: boolean
+                databaseRoleReclaimPolicy:
+                  default: retain
+                  description: The policy for end-of-life maintenance of this role
+                  enum:
+                    - delete
+                    - retain
+                  type: string
+                disablePassword:
+                  description: DisablePassword indicates that a role's password should be set to NULL in Postgres
+                  type: boolean
+                ensure:
+                  default: present
+                  description: Ensure the role is `present` or `absent` - defaults to "present"
+                  enum:
+                    - present
+                    - absent
+                  type: string
+                inRoles:
+                  description: |-
+                    List of one or more existing roles to which this role will be
+                    immediately added as a new member. Default empty.
+                    Changes to the list are applied to an existing role through
+                    `GRANT` and `REVOKE` statements, not only at role creation.
+                  items:
+                    type: string
+                  type: array
+                inherit:
+                  default: true
+                  description: |-
+                    Whether a role "inherits" the privileges of roles it is a member of.
+                    Default is `true`.
+                  type: boolean
+                login:
+                  description: |-
+                    Whether the role is allowed to log in. A role having the `login`
+                    attribute can be thought of as a user. Roles without this attribute
+                    are useful for managing database privileges, but are not users in
+                    the usual sense of the word. Default is `false`.
+                  type: boolean
+                name:
+                  description: Name of the role
+                  type: string
+                passwordSecret:
+                  description: |-
+                    Secret containing the password of the role (if present).
+                    If null, the password will be ignored unless DisablePassword is set.
+                    When set, the secret must follow the `kubernetes.io/basic-auth` format
+                    and contain both a `username` and a `password` field.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                replication:
+                  description: |-
+                    Whether a role is a replication role. A role must have this
+                    attribute (or be a superuser) in order to be able to connect to the
+                    server in replication mode (physical or logical replication) and in
+                    order to be able to create or drop replication slots. A role having
+                    the `replication` attribute is a very highly privileged role, and
+                    should only be used on roles actually used for replication. Default
+                    is `false`.
+                  type: boolean
+                superuser:
+                  description: |-
+                    Whether the role is a `superuser` who can override all access
+                    restrictions within the database - superuser status is dangerous and
+                    should be used only when really needed. You must yourself be a
+                    superuser to create a new superuser. Defaults is `false`.
+                  type: boolean
+                validUntil:
+                  description: |-
+                    Date and time after which the role's password is no longer valid.
+                    When omitted, the password will never expire (default).
+                  format: date-time
+                  type: string
+              required:
+                - cluster
+                - name
+              type: object
+              x-kubernetes-validations:
+                - message: name is immutable
+                  rule: self.name == oldSelf.name
+                - message: 'ensure: absent is not supported for DatabaseRole; delete the resource with databaseRoleReclaimPolicy: delete instead'
+                  rule: '!has(self.ensure) || self.ensure != ''absent'''
+                - message: the role name postgres is reserved
+                  rule: self.name != 'postgres'
+                - message: the role name streaming_replica is reserved
+                  rule: self.name != 'streaming_replica'
+                - message: role names starting with pg_ are reserved by PostgreSQL
+                  rule: '!self.name.startsWith(''pg_'')'
+                - message: role names starting with cnpg_ are reserved by the operator
+                  rule: '!self.name.startsWith(''cnpg_'')'
+                - message: role name must not be empty
+                  rule: self.name.size() != 0
+                - message: passwordSecret and disablePassword are mutually exclusive
+                  rule: '!has(self.passwordSecret) || !has(self.disablePassword) || !self.disablePassword'
+                - message: clientCertificate requires the role to have login enabled
+                  rule: '!has(self.clientCertificate) || !self.clientCertificate.enabled || self.login'
+            status:
+              description: |-
+                Most recently observed status of the DatabaseRole. This data may not be up
+                to date. Populated by the system. Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                applied:
+                  description: Applied is true if the role was reconciled correctly
+                  type: boolean
+                clientCertificate:
+                  description: |-
+                    ClientCertificate holds the observed state of the generated TLS client
+                    certificate, when client certificate issuance is enabled.
+                  properties:
+                    expiration:
+                      description: Expiration is the expiration time of the generated client certificate, in RFC3339 format.
+                      type: string
+                    message:
+                      description: |-
+                        Message contains a human-readable explanation of the current certificate status,
+                        such as why issuance was skipped or why an existing Secret was left untouched.
+                      type: string
+                  type: object
+                conditions:
+                  description: Conditions for the DatabaseRole object
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                message:
+                  description: Message is the reconciliation error message
+                  type: string
+                observedGeneration:
+                  description: |-
+                    A sequence number representing the latest
+                    desired state that was synchronized
+                  format: int64
+                  type: integer
+                secretResourceVersion:
+                  description: |-
+                    SecretResourceVersion is the resource version of the password secret
+                    last applied to the role; a change to it triggers reconciliation.
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/cloudnative-pg-crds/templates/databases.yaml
+++ b/charts/cloudnative-pg-crds/templates/databases.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -87,6 +87,9 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                    - message: cluster reference is immutable after creation
+                      rule: self == oldSelf
                 collationVersion:
                   description: |-
                     Maps to the `COLLATION_VERSION` parameter of `CREATE DATABASE`. This

--- a/charts/cloudnative-pg-crds/templates/failoverquorums.yaml
+++ b/charts/cloudnative-pg-crds/templates/failoverquorums.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:

--- a/charts/cloudnative-pg-crds/templates/imagecatalogs.yaml
+++ b/charts/cloudnative-pg-crds/templates/imagecatalogs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -45,11 +45,147 @@ spec:
                 Specification of the desired behavior of the ImageCatalog.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
+                componentImages:
+                  description: |-
+                    ComponentImages is a list of named images for components other than PostgreSQL
+                    (e.g. pgbouncer). Keys must be unique within a catalog.
+                  items:
+                    description: CatalogComponentImage is a named image entry for a non-PostgreSQL component.
+                    properties:
+                      image:
+                        description: Image is the container image reference.
+                        type: string
+                      key:
+                        description: Key is the unique identifier for this image within the catalog.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                      - image
+                      - key
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - key
+                  x-kubernetes-list-type: map
+                  x-kubernetes-validations:
+                    - message: Component image keys must be unique
+                      rule: self.all(e, self.filter(f, f.key==e.key).size() == 1)
                 images:
                   description: List of CatalogImages available in the catalog
                   items:
                     description: CatalogImage defines the image and major version
                     properties:
+                      extensions:
+                        description: The configuration of the extensions to be added
+                        items:
+                          description: |-
+                            ExtensionConfiguration is the configuration used to add
+                            PostgreSQL extensions to the Cluster.
+                          properties:
+                            bin_path:
+                              description: |-
+                                A list of directories within the image to be appended to the
+                                PostgreSQL process's `PATH` environment variable.
+                              items:
+                                type: string
+                              type: array
+                            dynamic_library_path:
+                              description: |-
+                                The list of directories inside the image which should be added to dynamic_library_path.
+                                If not defined, defaults to "/lib".
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: |-
+                                Env is a list of custom environment variables to be set in the
+                                PostgreSQL process for this extension. It is the responsibility of the
+                                cluster administrator to ensure the variables are correct for the
+                                specific extension. Note that changes to these variables require
+                                a manual cluster restart to take effect.
+                              items:
+                                description: |-
+                                  ExtensionEnvVar defines an environment variable for a specific extension
+                                  image volume.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable to be injected into the
+                                      PostgreSQL process.
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Value of the environment variable. CloudNativePG performs a direct
+                                      replacement of this value, with support for placeholder expansion.
+                                      The ${`image_root`} placeholder resolves to the absolute mount path
+                                      of the extension's volume (e.g., `/extensions/my-extension`). This
+                                      is particularly useful for allowing applications or libraries to
+                                      locate specific directories within the mounted image.
+                                      Unrecognized placeholders are rejected. To include a literal ${...}
+                                      in the value, escape it as $${...}.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            extension_control_path:
+                              description: |-
+                                The list of directories inside the image which should be added to extension_control_path.
+                                If not defined, defaults to "/share".
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              description: The image containing the extension.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            ld_library_path:
+                              description: The list of directories inside the image which should be added to ld_library_path.
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: |-
+                                The name of the extension, required. The limit of 59 characters
+                                leaves room for the prefix the operator adds when deriving the
+                                extension's Kubernetes Volume name (capped at 63 characters).
+                              maxLength: 59
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - name
+                        x-kubernetes-list-type: map
                       image:
                         description: The image reference
                         type: string

--- a/charts/cloudnative-pg-crds/templates/poolers.yaml
+++ b/charts/cloudnative-pg-crds/templates/poolers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -23,6 +23,9 @@ spec:
           type: string
         - jsonPath: .spec.type
           name: Type
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
           type: string
       name: v1
       schema:
@@ -62,6 +65,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: cluster reference is immutable after creation
+                      rule: self == oldSelf
                 deploymentStrategy:
                   description: The deployment strategy to use for pgbouncer to replace existing pods with new ones
                   properties:
@@ -114,18 +120,22 @@ spec:
                   format: int32
                   type: integer
                 monitoring:
-                  description: |-
-                    The configuration of the monitoring infrastructure of this pooler.
-
-                    Deprecated: This feature will be removed in an upcoming release. If
-                    you need this functionality, you can create a PodMonitor manually.
+                  description: The configuration of the monitoring infrastructure of this pooler.
                   properties:
                     enablePodMonitor:
                       default: false
-                      description: Enable or disable the `PodMonitor`
+                      description: |-
+                        Enable or disable the `PodMonitor`
+
+                        Deprecated: This feature will be removed in an upcoming release. If
+                        you need this functionality, you can create a PodMonitor manually.
                       type: boolean
                     podMonitorMetricRelabelings:
-                      description: The list of metric relabelings for the `PodMonitor`. Applied to samples before ingestion.
+                      description: |-
+                        The list of metric relabelings for the `PodMonitor`. Applied to samples before ingestion.
+
+                        Deprecated: This feature will be removed in an upcoming release. If
+                        you need this functionality, you can create a PodMonitor manually.
                       items:
                         description: |-
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
@@ -210,7 +220,11 @@ spec:
                         type: object
                       type: array
                     podMonitorRelabelings:
-                      description: The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
+                      description: |-
+                        The list of relabelings for the `PodMonitor`. Applied to samples before scraping.
+
+                        Deprecated: This feature will be removed in an upcoming release. If
+                        you need this functionality, you can create a PodMonitor manually.
                       items:
                         description: |-
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
@@ -294,6 +308,18 @@ spec:
                             type: string
                         type: object
                       type: array
+                    tls:
+                      description: |-
+                        Configure TLS communication for the metrics endpoint.
+                        Changing tls.enabled option will force a rollout of all instances.
+                      properties:
+                        enabled:
+                          default: false
+                          description: |-
+                            Enable TLS for the monitoring endpoint.
+                            Changing this option will force a rollout of all instances.
+                          type: boolean
+                      type: object
                   type: object
                 pgbouncer:
                   description: The PgBouncer configuration
@@ -342,6 +368,45 @@ spec:
                       required:
                         - name
                       type: object
+                    image:
+                      description: |-
+                        Image is the pgbouncer container image to use. When set, it takes
+                        precedence over ImageCatalogRef and the operator default, but is
+                        overridden by an explicit image set in the pod template.
+                      type: string
+                    imageCatalogRef:
+                      description: |-
+                        ImageCatalogRef points to an entry in an ImageCatalog or ClusterImageCatalog.
+                        Mutually exclusive with Image.
+                      properties:
+                        apiGroup:
+                          description: |-
+                            APIGroup is the group for the resource being referenced.
+                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                            For any other third-party types, APIGroup is required.
+                          type: string
+                        key:
+                          description: Key identifies the entry within the catalog's componentImages list.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                        - key
+                        - kind
+                        - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                        - message: Only ImageCatalog and ClusterImageCatalog are supported
+                          rule: self.kind == 'ImageCatalog' || self.kind == 'ClusterImageCatalog'
+                        - message: apiGroup must be postgresql.cnpg.io
+                          rule: self.apiGroup == 'postgresql.cnpg.io'
                     parameters:
                       additionalProperties:
                         type: string
@@ -395,6 +460,22 @@ spec:
                         - name
                       type: object
                   type: object
+                  x-kubernetes-validations:
+                    - message: image and imageCatalogRef are mutually exclusive
+                      rule: '!(has(self.image) && has(self.imageCatalogRef))'
+                serviceAccountName:
+                  description: |-
+                    Name of an existing ServiceAccount in the same namespace to use for the pooler.
+                    When specified, the operator will not create a new ServiceAccount
+                    but will use the provided one. This is useful for sharing a single
+                    ServiceAccount across multiple poolers (e.g., for cloud IAM configurations).
+                    If not specified, a ServiceAccount will be created with the pooler name.
+                  maxLength: 253
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                  x-kubernetes-validations:
+                    - message: serviceAccountName is immutable
+                      rule: self == oldSelf
                 serviceTemplate:
                   description: Template for the Service to be created
                   properties:
@@ -2519,7 +2600,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -2743,7 +2826,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -4238,7 +4320,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -4704,7 +4785,6 @@ spec:
                             When set to false, a new userns is created for the pod. Setting false is useful for
                             mitigating container breakout vulnerabilities even allowing users to run their
                             containers as root without actually having root privileges on the host.
-                            This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                           type: boolean
                         hostname:
                           description: |-
@@ -5592,7 +5672,9 @@ spec:
                                     type: integer
                                 type: object
                               resizePolicy:
-                                description: Resources resize policy for the container.
+                                description: |-
+                                  Resources resize policy for the container.
+                                  This field cannot be set on ephemeral containers.
                                 items:
                                   description: ContainerResizePolicy represents resource resize policy for the container.
                                   properties:
@@ -5816,7 +5898,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -6353,8 +6434,8 @@ spec:
                             will be made available to those containers which consume them
                             by name.
 
-                            This is an alpha field and requires enabling the
-                            DynamicResourceAllocation feature gate.
+                            This is a stable field but requires that the
+                            DynamicResourceAllocation feature gate is enabled.
 
                             This field is immutable.
                           items:
@@ -6365,6 +6446,14 @@ spec:
 
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
+
+                              When the DRAWorkloadResourceClaims feature gate is enabled and this Pod
+                              belongs to a PodGroup, a PodResourceClaim is matched to a
+                              PodGroupResourceClaim if all of their fields are equal (Name,
+                              ResourceClaimName, and ResourceClaimTemplateName). A matched claim references
+                              a single ResourceClaim shared across all Pods in the PodGroup, reserved for
+                              the PodGroup in ResourceClaimStatus.ReservedFor rather than for individual
+                              Pods.
                             properties:
                               name:
                                 description: |-
@@ -6389,6 +6478,16 @@ spec:
                                   will also be deleted. The pod name and resource name, along with a
                                   generated component, will be used to form a unique name for the
                                   ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  When the DRAWorkloadResourceClaims feature gate is enabled and the pod
+                                  belongs to a PodGroup that defines a PodGroupResourceClaim with the same
+                                  Name and ResourceClaimTemplateName, this PodResourceClaim resolves to the
+                                  ResourceClaim generated for the PodGroup. All pods in the group that
+                                  define an equivalent PodResourceClaim matching the
+                                  PodGroupResourceClaim's Name and ResourceClaimTemplateName share the same
+                                  generated ResourceClaim. ResourceClaims generated for a PodGroup are
+                                  owned by the PodGroup and their lifecycles are tied to the PodGroup
+                                  instead of any individual pod.
 
                                   This field is immutable and no changes will be made to the
                                   corresponding ResourceClaim by the control plane after creating the
@@ -6514,6 +6613,28 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        schedulingGroup:
+                          description: |-
+                            SchedulingGroup provides a reference to the immediate scheduling runtime
+                            grouping object that this Pod belongs to.
+                            This field is used by the scheduler to identify the group and apply the
+                            correct group scheduling policies. The association with a group also
+                            impacts other lifecycle aspects of a Pod that are relevant in a wider context
+                            of scheduling like preemption, resource attachment, etc. If not specified,
+                            the Pod is treated as a single unit in all of these aspects.
+                            The group object referenced by this field may not exist at the time the
+                            Pod is created.
+                            This field is immutable, but a group object with the same name may be
+                            recreated with different policies. Doing this during pod scheduling
+                            may result in the placement not conforming to the expected policies.
+                          properties:
+                            podGroupName:
+                              description: |-
+                                PodGroupName specifies the name of the standalone PodGroup object
+                                that represents the runtime instance of this group.
+                                Must be a DNS subdomain.
+                              type: string
+                          type: object
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
@@ -6806,9 +6927,10 @@ spec:
                               operator:
                                 description: |-
                                   Operator represents a key's relationship to the value.
-                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                   Exists is equivalent to wildcard for value, so that a pod can
                                   tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                 type: string
                               tolerationSeconds:
                                 description: |-
@@ -7563,7 +7685,7 @@ spec:
                                           resources:
                                             description: |-
                                               resources represents the minimum resources the volume should have.
-                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              Users are allowed to specify resource requirements
                                               that are lower than previous value but must still be higher than capacity recorded in the
                                               status field of the claim.
                                               More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7882,7 +8004,7 @@ spec:
                                   A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  The volume will be mounted read-only (ro).
                                   Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
@@ -8050,8 +8172,7 @@ spec:
                                 description: |-
                                   portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                   Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                  is on.
+                                  are redirected to the pxd.portworx.com CSI driver.
                                 properties:
                                   fsType:
                                     description: |-
@@ -8398,6 +8519,24 @@ spec:
                                             signerName:
                                               description: Kubelet's generated CSRs will be addressed to this signer.
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                userAnnotations allow pod authors to pass additional information to
+                                                the signer implementation.  Kubernetes does not restrict or validate this
+                                                metadata in any way.
+
+                                                These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                the PodCertificateRequest objects that Kubelet creates.
+
+                                                Entries are subject to the same validation as object metadata annotations,
+                                                with the addition that all keys must be domain-prefixed. No restrictions
+                                                are placed on values, except an overall size limitation on the entire field.
+
+                                                Signers should document the keys and values they support. Signers should
+                                                deny requests that contain keys they do not recognize.
+                                              type: object
                                           required:
                                             - keyType
                                             - signerName
@@ -8829,10 +8968,33 @@ spec:
                 date. Populated by the system. Read-only.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
+                error:
+                  description: Error is the latest admission validation error
+                  type: string
+                image:
+                  description: |-
+                    Image is the resolved pgbouncer container image that the operator is
+                    using for this Pooler, including any override coming from spec.template.
+                    While Phase is Active or Paused this field reflects what the Deployment
+                    actually runs; while Phase is Inactive or Failed it may carry the last
+                    successfully resolved value (or be empty if the Pooler has never reconciled
+                    successfully).
+                  type: string
                 instances:
                   description: The number of pods trying to be scheduled
                   format: int32
                   type: integer
+                phase:
+                  description: Phase summarizes the overall lifecycle state of the Pooler.
+                  enum:
+                    - active
+                    - paused
+                    - inactive
+                    - failed
+                  type: string
+                phaseReason:
+                  description: PhaseReason is a human-readable explanation of the current Phase.
+                  type: string
                 secrets:
                   description: The resource version of the config object
                   properties:

--- a/charts/cloudnative-pg-crds/templates/publications.yaml
+++ b/charts/cloudnative-pg-crds/templates/publications.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -70,6 +70,9 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                    - message: cluster reference is immutable after creation
+                      rule: self == oldSelf
                 dbname:
                   description: |-
                     The name of the database where the publication will be installed in

--- a/charts/cloudnative-pg-crds/templates/scheduledbackups.yaml
+++ b/charts/cloudnative-pg-crds/templates/scheduledbackups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -72,6 +72,9 @@ spec:
                   required:
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: cluster reference is immutable after creation
+                      rule: self == oldSelf
                 immediate:
                   description: If the first backup has to be immediately start after creation or not
                   type: boolean
@@ -165,6 +168,9 @@ spec:
                 to date. Populated by the system. Read-only.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
+                error:
+                  description: Error is the latest admission validation error
+                  type: string
                 lastCheckTime:
                   description: The latest time the schedule
                   format: date-time

--- a/charts/cloudnative-pg-crds/templates/subscriptions.yaml
+++ b/charts/cloudnative-pg-crds/templates/subscriptions.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:
@@ -70,6 +70,9 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                    - message: cluster reference is immutable after creation
+                      rule: self == oldSelf
                 dbname:
                   description: |-
                     The name of the database where the publication will be installed in

--- a/charts/plugin-barman-cloud-crds/Chart.yaml
+++ b/charts/plugin-barman-cloud-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: plugin-barman-cloud-crds
-version: 0.11.0
-appVersion: "v0.11.0"
+version: 0.14.0
+appVersion: "v0.14.0"
 description: Manage plugin-barman-cloud CRDs
 keywords:
   - cloudnative-pg

--- a/charts/plugin-barman-cloud-crds/README.md
+++ b/charts/plugin-barman-cloud-crds/README.md
@@ -11,7 +11,7 @@ CRDs are located [here](https://github.com/cloudnative-pg/charts/blob/main/chart
 **Do not forget to change APP_VERSION**
 
 ``` bash
-export CHART_VERSION=v0.5.0
+export CHART_VERSION=v0.7.1
 cd charts/plugin-barman-cloud-crds
 curl https://raw.githubusercontent.com/cloudnative-pg/charts/refs/tags/plugin-barman-cloud-$CHART_VERSION/charts/plugin-barman-cloud/templates/crds/crds.yaml -L -o crds.yaml
 sed -i '/{{- if .Values.crds.create }}/d; /{{- end }}/d' crds.yaml

--- a/charts/plugin-barman-cloud-crds/templates/objectstores.yaml
+++ b/charts/plugin-barman-cloud-crds/templates/objectstores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: objectstores.barmancloud.cnpg.io
 spec:
@@ -142,10 +142,11 @@ spec:
                           description: |-
                             Compress a backup file (a tar file per tablespace) while streaming it
                             to the object store. Available options are empty string (no
-                            compression, default), `gzip`, `bzip2`, and `snappy`.
+                            compression, default), `gzip`, `bzip2`, `lz4`, and `snappy`.
                           enum:
                             - bzip2
                             - gzip
+                            - lz4
                             - snappy
                           type: string
                         encryption:
@@ -173,6 +174,25 @@ spec:
                           format: int32
                           minimum: 1
                           type: integer
+                        restoreAdditionalCommandArgs:
+                          description: |-
+                            Additional arguments that can be appended to the 'barman-cloud-restore'
+                            command-line invocation. These arguments provide flexibility to customize
+                            the data restore process further, according to specific requirements or
+                            configurations.
+
+                            Example:
+                            In a scenario where specialized restore options are required, such as setting
+                            a specific read timeout or defining custom behavior, users can use this field
+                            to specify additional command arguments.
+
+                            Note:
+                            It's essential to ensure that the provided arguments are valid and supported
+                            by the 'barman-cloud-restore' command, to avoid potential errors or unintended
+                            behavior during execution.
+                          items:
+                            type: string
+                          type: array
                       type: object
                     destinationPath:
                       description: |-


### PR DESCRIPTION
## What

| Chart | From | To | Upstream source |
|---|---|---|---|
| `cloudnative-pg-crds` | 1.28.0 | 1.30.0 | tag `cloudnative-pg-v0.29.0` |
| `plugin-barman-cloud-crds` | 0.11.0 | 0.14.0 | tag `plugin-barman-cloud-v0.7.1` |

Regenerated with the procedure each chart README documents. The README examples now name the tags used here.

CloudNativePG 1.30.0 adds one CRD: `databaseroles.postgresql.cnpg.io`. The `cloudnative-pg` operator chart 0.29.0 refers to `databaseroles`, `databaseroles/status` and `databaseroles/finalizers` in its RBAC, so this chart must ship the CRD before the operator starts.

The Barman `ObjectStore` CRD gains `lz4` base-backup compression and `restoreAdditionalCommandArgs`.

## Why

`wiremind-services-configuration` upgrades the CNPG operator to 1.30.0 and the Barman plugin to 0.14.0. CNPG 1.31.0 removes native (in-tree) Barman Cloud support, so the plugin has to stay current. 1.29 and 1.30 also carry `CVE-2026-55769`, `CVE-2026-55765` and `GHSA-7qwx-x8ff-3px9`.

Verified: `helm lint` and `helm template` pass on both charts and render 11 and 1 CRDs. `kustomize build` over the rendered output passes, which catches the duplicate keys that `helm lint` lets through. Every CRD keeps `helm.sh/resource-policy: keep`, and each one serves a single `v1` that is also the storage version, so no storage-version migration is needed. No `creationTimestamp: null` is present.

## Merge order

Merge and release this before the `wiremind-services-configuration` MR, which pins these two chart versions.

---
Task: [TASKS2-4153](https://www.notion.so/3cadcbda9c358139bdcdc156bc3fbb26)