### PR TITLE
chore(cert-manager-crds): upgrade to 1.21.1

### DIFF
--- a/charts/cert-manager-crds/Chart.yaml
+++ b/charts/cert-manager-crds/Chart.yaml
@@ -2,8 +2,8 @@ annotations:
   category: DeveloperTools
 apiVersion: v2
 name: cert-manager-crds
-version: 1.20.0
-appVersion: "v1.20.0"
+version: 1.21.1
+appVersion: "v1.21.1"
 description: Manage cert-manager CRDs
 keywords:
   - cert

--- a/charts/cert-manager-crds/templates/certificaterequests.yaml
+++ b/charts/cert-manager-crds/templates/certificaterequests.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.1"
 spec:
   group: cert-manager.io
   names:

--- a/charts/cert-manager-crds/templates/certificates.yaml
+++ b/charts/cert-manager-crds/templates/certificates.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.1"
 spec:
   group: cert-manager.io
   names:
@@ -288,10 +288,16 @@ spec:
                             `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
                             (e.g., because of company policy). Please note that the security of the algorithm is not that important
                             in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                            `Modern2026`: Encodes PKCS#12 files using algorithms that are considered modern as of 2026.
+                            Private keys and certificates are encrypted using PBES2 with PBKDF2-HMAC-SHA-256 and AES-256-CBC.
+                            The MAC algorithm is PBMAC1 with PBKDF2-HMAC-SHA-256 and HMAC-SHA256.
+                            Files produced with this profile can be read by OpenSSL 3.4.0 and higher, Java 26 and higher,
+                            or with Java using compatible versions of Bouncy Castle. Meets FIPS 140-3 requirements.
                           enum:
                             - LegacyRC2
                             - LegacyDES
                             - Modern2023
+                            - Modern2026
                           type: string
                       required:
                         - create
@@ -504,6 +510,53 @@ spec:
                     Cannot be set if the `renewBefore` field is set.
                   format: int32
                   type: integer
+                renewal:
+                  description: |-
+                    `renewal` allows configuration of how your certificate is renewed. If the policy mentioned is
+                    `RenewBefore` then the controller respects `renewBefore` and `renewBeforePercentage`.
+                  properties:
+                    policy:
+                      description: '`policy` must be one of `Disabled`, `RenewBefore`.'
+                      enum:
+                        - RenewBefore
+                        - Disabled
+                      type: string
+                    windows:
+                      description: '`windows` mentions the behavior of when the renewal must happen.'
+                      items:
+                        description: CertificateRenewalWindows is the definition for renewal windows
+                        properties:
+                          cron:
+                            description: |-
+                              `cron` is a cron compliant string to allow when the renewal should be allowed. Format is as shown below:
+                              * * * * *
+                              | | | | |
+                              | | | | day of the week (0–6) (Sunday to Saturday;
+                              | | | month (1–12)             7 is also Sunday on some systems)
+                              | | day of the month (1–31)
+                              | hour (0–23)
+                              minute (0–59)
+                            minLength: 1
+                            type: string
+                          timezone:
+                            description: |-
+                              `timezone` is IANA compliant timezone. For example America/Denver.
+                              If this field is not set, timezone is treated as UTC.
+                            minLength: 1
+                            type: string
+                          windowDuration:
+                            description: |-
+                              `windowDuration` is how long the cron definition is active for.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                            pattern: ^([0-9]+(\.[0-9]+)?(s|m|h))+$
+                            type: string
+                        required:
+                          - cron
+                          - windowDuration
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
                 revisionHistoryLimit:
                   description: |-
                     The maximum number of CertificateRequest revisions that are maintained in
@@ -694,6 +747,47 @@ spec:
                 Read-only.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
+                acme:
+                  description: ACME stores information that is fetched from the ACME CA server.
+                  properties:
+                    ari:
+                      description: |-
+                        ARI stores the ACME Renewal Information that is fetched from the ACME server
+                        in accordance with RFC 9773. This is only populated if the ARI feature gate is enabled.
+                      properties:
+                        explanationURL:
+                          description: |-
+                            ExplanationURL is a human-readable URL that may explain why the suggested window
+                            has its current value.
+                          type: string
+                        lastChecked:
+                          description: LastChecked is the time at which the ACME server was last checked for renewal information.
+                          format: date-time
+                          type: string
+                        lastError:
+                          description: LastError is the last error encountered when checking the ACME server for renewal information, if any.
+                          type: string
+                        nextCheck:
+                          description: NextCheck is the time at which the ACME server will next be checked for renewal information.
+                          format: date-time
+                          type: string
+                        suggestedWindow:
+                          description: SuggestedWindow is the suggested renewal window as returned by the ACME server in accordance with RFC 9773.
+                          properties:
+                            end:
+                              description: End is the end of the suggested renewal window.
+                              format: date-time
+                              type: string
+                            start:
+                              description: Start is the start of the suggested renewal window.
+                              format: date-time
+                              type: string
+                          required:
+                            - end
+                            - start
+                          type: object
+                      type: object
+                  type: object
                 conditions:
                   description: |-
                     List of status conditions to indicate the status of certificates.

--- a/charts/cert-manager-crds/templates/challenges.yaml
+++ b/charts/cert-manager-crds/templates/challenges.yaml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.1"
 spec:
   group: acme.cert-manager.io
   names:
@@ -3231,6 +3231,24 @@ spec:
                             this challenge solver will apply to.
                           type: object
                       type: object
+                    waitInsteadOfSelfCheck:
+                      description: |-
+                        WaitInsteadOfSelfCheck, if set, skips cert-manager's self-check and
+                        instead waits this long after presentation before asking the ACME server
+                        to validate the challenge.
+
+                        This is an advanced escape hatch for environments where cert-manager's
+                        self-check cannot succeed from its own network or DNS viewpoint even
+                        though the ACME server can still validate successfully, for example due
+                        to split-horizon DNS or NAT hairpinning.
+
+                        A value of 0 skips the self-check and asks the ACME server to validate
+                        immediately after presentation, relying on the ACME server's own
+                        validation retries (RFC 8555 section 8.2) to succeed once the challenge
+                        has propagated. A negative duration is rejected.
+                        Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration,
+                        for example `30s` or `2m`.
+                      type: string
                   type: object
                 token:
                   description: |-
@@ -3269,13 +3287,21 @@ spec:
               properties:
                 presented:
                   description: |-
-                    presented will be set to true if the challenge values for this challenge
-                    are currently 'presented'.
-                    This *does not* imply the self check is passing. Only that the values
-                    have been 'submitted' for the appropriate challenge mechanism (i.e. the
-                    DNS01 TXT record has been presented, or the HTTP01 configuration has been
-                    configured).
+                    Presented is true once cert-manager has configured the solver resources
+                    needed to expose this challenge's validation material.
+                    For example, the DNS01 TXT record has been created, or the HTTP01 solver
+                    has been configured to serve the challenge token.
+                    This does not imply the self check is passing, that the ACME server has
+                    validated the challenge, or that cert-manager has already accepted the
+                    challenge with the ACME server.
                   type: boolean
+                presentedAt:
+                  description: |-
+                    PresentedAt records when cert-manager first configured the solver
+                    resources for this challenge. This is used by the optional delay-based
+                    readiness logic.
+                  format: date-time
+                  type: string
                 processing:
                   description: |-
                     Used to denote whether this challenge should be processed or not.

--- a/charts/cert-manager-crds/templates/clusterissuers.yaml
+++ b/charts/cert-manager-crds/templates/clusterissuers.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.1"
 spec:
   group: cert-manager.io
   names:
@@ -3330,6 +3330,24 @@ spec:
                                   this challenge solver will apply to.
                                 type: object
                             type: object
+                          waitInsteadOfSelfCheck:
+                            description: |-
+                              WaitInsteadOfSelfCheck, if set, skips cert-manager's self-check and
+                              instead waits this long after presentation before asking the ACME server
+                              to validate the challenge.
+
+                              This is an advanced escape hatch for environments where cert-manager's
+                              self-check cannot succeed from its own network or DNS viewpoint even
+                              though the ACME server can still validate successfully, for example due
+                              to split-horizon DNS or NAT hairpinning.
+
+                              A value of 0 skips the self-check and asks the ACME server to validate
+                              immediately after presentation, relying on the ACME server's own
+                              validation retries (RFC 8555 section 8.2) to succeed once the challenge
+                              has propagated. A negative duration is rejected.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration,
+                              for example `30s` or `2m`.
+                            type: string
                         type: object
                       type: array
                       x-kubernetes-list-type: atomic
@@ -3443,6 +3461,62 @@ spec:
                             - path
                             - roleId
                             - secretRef
+                          type: object
+                        aws:
+                          description: |-
+                            AWS authenticates with Vault using AWS IAM authentication.
+                            This allows authentication using IAM roles for service accounts (IRSA),
+                            EKS Pod Identity (PIA), or ambient credentials (EC2 instance profiles, ECS task role).
+                          properties:
+                            iamRoleArn:
+                              description: |-
+                                The ARN of the AWS IAM role to assume using the Kubernetes service account
+                                token. Required when using IRSA (serviceAccountRef is set).
+                                This role must have a trust policy that allows the OIDC provider to assume it.
+                              type: string
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/aws" will be used.
+                              type: string
+                            region:
+                              description: |-
+                                The AWS region to use for authentication. If not specified, the region
+                                will be determined from AWS_REGION or AWS_DEFAULT_REGION environment
+                                variables, falling back to "us-east-1" if not set.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume when authenticating.
+                              minLength: 1
+                              type: string
+                            serviceAccountRef:
+                              description: |-
+                                A reference to a service account that will be used to request a web identity
+                                token for IRSA (IAM Roles for Service Accounts) authentication.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            vaultHeaderValue:
+                              description: |-
+                                The Vault header value to include in the STS signing request.
+                                This is used to prevent replay attacks.
+                              type: string
+                          required:
+                            - role
                           type: object
                         clientCertificate:
                           description: |-
@@ -3678,6 +3752,46 @@ spec:
                       required:
                         - apiTokenSecretRef
                       type: object
+                    ngts:
+                      description: |-
+                        NGTS specifies Palo Alto Networks Next Generation Trust Services (NGTS) configuration
+                        using OAuth 2.0 Client Credentials. Only one of tpp, cloud, or ngts may be specified.
+                      properties:
+                        credentialsRef:
+                          description: |-
+                            CredentialsRef is a reference to a Kubernetes Secret containing the OAuth 2.0
+                            Client ID and Client Secret. The secret must contain the keys 'client-id' and
+                            'client-secret'.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tokenEndpoint:
+                          description: |-
+                            TokenEndpoint is the OAuth 2.0 token endpoint URL used to obtain access tokens,
+                            for example "https://auth.apps.paloaltonetworks.com/oauth2/access_token".
+                            Defaults to "https://auth.apps.paloaltonetworks.com/oauth2/access_token" if not set.
+                          type: string
+                        tsgID:
+                          description: |-
+                            TSGID is the Tenant Service Group ID used to scope the OAuth 2.0 access token,
+                            for example "1234567890". The tsg_id: prefix is added automatically.
+                            This field is required.
+                          type: string
+                        url:
+                          description: |-
+                            URL is the base URL for the NGTS API endpoint.
+                            Defaults to "https://api.strata.paloaltonetworks.com/ngts" if not set.
+                          type: string
+                      required:
+                        - credentialsRef
+                        - tsgID
+                      type: object
                     tpp:
                       description: |-
                         TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
@@ -3746,6 +3860,9 @@ spec:
                   required:
                     - zone
                   type: object
+                  x-kubernetes-validations:
+                    - message: exactly one of tpp, cloud, or ngts must be configured
+                      rule: '(has(self.tpp) ? 1 : 0) + (has(self.cloud) ? 1 : 0) + (has(self.ngts) ? 1 : 0) == 1'
               type: object
             status:
               description: Status of the ClusterIssuer. This is set and managed automatically.

--- a/charts/cert-manager-crds/templates/issuers.yaml
+++ b/charts/cert-manager-crds/templates/issuers.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.1"
 spec:
   group: cert-manager.io
   names:
@@ -3329,6 +3329,24 @@ spec:
                                   this challenge solver will apply to.
                                 type: object
                             type: object
+                          waitInsteadOfSelfCheck:
+                            description: |-
+                              WaitInsteadOfSelfCheck, if set, skips cert-manager's self-check and
+                              instead waits this long after presentation before asking the ACME server
+                              to validate the challenge.
+
+                              This is an advanced escape hatch for environments where cert-manager's
+                              self-check cannot succeed from its own network or DNS viewpoint even
+                              though the ACME server can still validate successfully, for example due
+                              to split-horizon DNS or NAT hairpinning.
+
+                              A value of 0 skips the self-check and asks the ACME server to validate
+                              immediately after presentation, relying on the ACME server's own
+                              validation retries (RFC 8555 section 8.2) to succeed once the challenge
+                              has propagated. A negative duration is rejected.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration,
+                              for example `30s` or `2m`.
+                            type: string
                         type: object
                       type: array
                       x-kubernetes-list-type: atomic
@@ -3442,6 +3460,62 @@ spec:
                             - path
                             - roleId
                             - secretRef
+                          type: object
+                        aws:
+                          description: |-
+                            AWS authenticates with Vault using AWS IAM authentication.
+                            This allows authentication using IAM roles for service accounts (IRSA),
+                            EKS Pod Identity (PIA), or ambient credentials (EC2 instance profiles, ECS task role).
+                          properties:
+                            iamRoleArn:
+                              description: |-
+                                The ARN of the AWS IAM role to assume using the Kubernetes service account
+                                token. Required when using IRSA (serviceAccountRef is set).
+                                This role must have a trust policy that allows the OIDC provider to assume it.
+                              type: string
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/aws" will be used.
+                              type: string
+                            region:
+                              description: |-
+                                The AWS region to use for authentication. If not specified, the region
+                                will be determined from AWS_REGION or AWS_DEFAULT_REGION environment
+                                variables, falling back to "us-east-1" if not set.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume when authenticating.
+                              minLength: 1
+                              type: string
+                            serviceAccountRef:
+                              description: |-
+                                A reference to a service account that will be used to request a web identity
+                                token for IRSA (IAM Roles for Service Accounts) authentication.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            vaultHeaderValue:
+                              description: |-
+                                The Vault header value to include in the STS signing request.
+                                This is used to prevent replay attacks.
+                              type: string
+                          required:
+                            - role
                           type: object
                         clientCertificate:
                           description: |-
@@ -3677,6 +3751,46 @@ spec:
                       required:
                         - apiTokenSecretRef
                       type: object
+                    ngts:
+                      description: |-
+                        NGTS specifies Palo Alto Networks Next Generation Trust Services (NGTS) configuration
+                        using OAuth 2.0 Client Credentials. Only one of tpp, cloud, or ngts may be specified.
+                      properties:
+                        credentialsRef:
+                          description: |-
+                            CredentialsRef is a reference to a Kubernetes Secret containing the OAuth 2.0
+                            Client ID and Client Secret. The secret must contain the keys 'client-id' and
+                            'client-secret'.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tokenEndpoint:
+                          description: |-
+                            TokenEndpoint is the OAuth 2.0 token endpoint URL used to obtain access tokens,
+                            for example "https://auth.apps.paloaltonetworks.com/oauth2/access_token".
+                            Defaults to "https://auth.apps.paloaltonetworks.com/oauth2/access_token" if not set.
+                          type: string
+                        tsgID:
+                          description: |-
+                            TSGID is the Tenant Service Group ID used to scope the OAuth 2.0 access token,
+                            for example "1234567890". The tsg_id: prefix is added automatically.
+                            This field is required.
+                          type: string
+                        url:
+                          description: |-
+                            URL is the base URL for the NGTS API endpoint.
+                            Defaults to "https://api.strata.paloaltonetworks.com/ngts" if not set.
+                          type: string
+                      required:
+                        - credentialsRef
+                        - tsgID
+                      type: object
                     tpp:
                       description: |-
                         TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
@@ -3745,6 +3859,9 @@ spec:
                   required:
                     - zone
                   type: object
+                  x-kubernetes-validations:
+                    - message: exactly one of tpp, cloud, or ngts must be configured
+                      rule: '(has(self.tpp) ? 1 : 0) + (has(self.cloud) ? 1 : 0) + (has(self.ngts) ? 1 : 0) == 1'
               type: object
             status:
               description: Status of the Issuer. This is set and managed automatically.

--- a/charts/cert-manager-crds/templates/orders.yaml
+++ b/charts/cert-manager-crds/templates/orders.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.1"
 spec:
   group: acme.cert-manager.io
   names:
@@ -81,7 +81,7 @@ spec:
                 duration:
                   description: |-
                     Duration is the duration for the not after date for the requested certificate.
-                    this is set on order creation as pe the ACME spec.
+                    This is set on order creation as per the ACME spec.
                   type: string
                 ipAddresses:
                   description: |-
@@ -120,6 +120,15 @@ spec:
                   description: |-
                     Profile allows requesting a certificate profile from the ACME server.
                     Supported profiles are listed by the server's ACME directory URL.
+                  type: string
+                replaces:
+                  description: |-
+                    Replaces is the ARI CertID (RFC 9773 §4.1) of the certificate that this
+                    Order is intended to replace. When set, cert-manager will include the
+                    "replaces" field on the newOrder request to the ACME server if and only
+                    if the server advertises ARI support in its directory. The CertID has
+                    the form "base64url(AKI).base64url(serial)" and is derived locally from
+                    the currently issued leaf certificate.
                   type: string
                 request:
                   description: |-


### PR DESCRIPTION
Bumps the CRD chart to match cert-manager 1.21.1, so the controller bump in `infra-services` (cert-manager 1.20.2 -> 1.21.1) can ship with matching CRDs instead of running against 1.20.0 schemas.

1.21 adds Certificate API fields (`renewalPolicies`, `spec.renewal.policy`) that a 1.20.0 schema would prune silently.

Regenerated per the chart README:

```
export APP_VERSION=v1.21.1
cd charts/cert-manager-crds
curl https://github.com/cert-manager/cert-manager/releases/download/$APP_VERSION/cert-manager.crds.yaml -L -o crds.yaml
bash ../../scripts/cut_crds.sh crds.yaml
```

Checks:
- same 6 CRDs, same names, none dropped — a chart that removes a CRD fails the release
- `helm.sh/resource-policy: keep` still present on all 6
- `helm lint` passes, `helm template` renders 6 CRDs
- deletions in the diff are upstream doc-string rewording only
