### PR TITLE
chore(ack-controllers-crds): vendor s3 CRDs from s3-controller v1.11.0

### DIFF
--- a/charts/ack-controllers-crds/Chart.yaml
+++ b/charts/ack-controllers-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: ack-controllers-crds
 description: Manage some CRDs of the ACK controllers
-version: 1.1.1
+version: 1.2.0
 appVersion: v1.0.0
 home: https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/ack-controllers-crds
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/ack-controllers-crds/README.md
+++ b/charts/ack-controllers-crds/README.md
@@ -15,7 +15,7 @@ script once per controller vendored here, so the s3 and iam CRDs do not drift
 apart:
 
 ```
-./scripts/update_crds.sh -r aws-controllers-k8s/s3-controller -b v1.8.2 \
+./scripts/update_crds.sh -r aws-controllers-k8s/s3-controller -b v1.11.0 \
   --folder helm/crds -o charts/ack-controllers-crds/templates
 ./scripts/update_crds.sh -r aws-controllers-k8s/iam-controller -b v1.7.3 \
   --folder helm/crds -o charts/ack-controllers-crds/templates
@@ -38,7 +38,7 @@ charts, so vendoring them from either release gives the same bytes.
 
 | CRD | Upstream | Version |
 | --- | --- | --- |
-| `buckets.s3.services.k8s.aws` | [aws-controllers-k8s/s3-controller](https://github.com/aws-controllers-k8s/s3-controller/tree/v1.8.2/helm/crds) | v1.8.2 |
+| `buckets.s3.services.k8s.aws` | [aws-controllers-k8s/s3-controller](https://github.com/aws-controllers-k8s/s3-controller/tree/v1.11.0/helm/crds) | v1.11.0 |
 | `*.iam.services.k8s.aws` | [aws-controllers-k8s/iam-controller](https://github.com/aws-controllers-k8s/iam-controller/tree/v1.7.3/helm/crds) | v1.7.3 |
 | `fieldexports.services.k8s.aws`, `iamroleselectors.services.k8s.aws` | ACK runtime commons, shipped identically by both controller charts above | v1.7.3 (iam) |
 | `adoptedresources.services.k8s.aws` | ACK runtime commons, no longer shipped upstream | v1.4.2 (iam) |

--- a/charts/ack-controllers-crds/templates/s3.services.k8s.aws_buckets.yaml
+++ b/charts/ack-controllers-crds/templates/s3.services.k8s.aws_buckets.yaml
@@ -42,6 +42,18 @@ spec:
 
               In terms of implementation, a Bucket is a resource.
             properties:
+              abac:
+                description: |-
+                  The ABAC status of the general purpose bucket. When ABAC is enabled for the
+                  general purpose bucket, you can use tags to manage access to the general
+                  purpose buckets as well as for cost tracking purposes. When ABAC is disabled
+                  for the general purpose buckets, you can only use tags for cost tracking
+                  purposes. For more information, see Using tags with S3 general purpose buckets
+                  (https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html).
+                properties:
+                  status:
+                    type: string
+                type: object
               accelerate:
                 description: Container for setting the transfer acceleration state.
                 properties:


### PR DESCRIPTION
Vendors the ACK s3 CRDs from `s3-controller` v1.11.0, up from v1.8.2, ahead of moving the deployed `ack-s3-controller` chart to 1.11.0.

## What changes

The `Bucket` CRD gains one optional field, and nothing else:

```yaml
abac:
  properties:
    status:
      type: string
  type: object
```

`spec.abac.status` controls attribute-based access control on general purpose buckets, letting tags govern access rather than only cost tracking.

## Why it has to land first

The API server drops unknown fields silently. With the CRD still at v1.8.2, an `abac` key on a `Bucket` is accepted and then discarded, with no error anywhere — so the CRD needs to be in place before the controller chart moves.

## Notes for review

- **Minor bump** (1.1.1 → 1.2.0) per the repo rule: a new field, with no CRD added or removed. The chart still ships the same 11 CRDs.
- The shared `services.k8s.aws` commons re-downloaded from v1.11.0 (`fieldexports`, `iamroleselectors`) come out byte-identical to the iam v1.7.3 copies already vendored, which is why they show no diff.
- `adoptedresources` is deliberately left alone — upstream no longer ships it, and the script only downloads and overwrites, so it is not pruned.
- The iam CRDs are untouched: `iam-controller` v1.7.3 and v1.9.0 are byte-identical, so the iam entry in the sources table stays accurate.
- s3-controller v1.12.0 was cut on 2026-09-03 and adds `targetObjectKeyFormat` to the logging config. Deliberately not included here, so the sources table keeps matching the controller version actually deployed.