### PR TITLE
chore(gpu-operator-crds): update CRDs to gpu-operator v26.7.0

### DIFF
--- a/charts/gpu-operator-crds/Chart.yaml
+++ b/charts/gpu-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: gpu-operator-crds
-version: 26.3.3
-appVersion: "v26.3.3"
+version: 26.7.0
+appVersion: "v26.7.0"
 description: Manage gpu-operator CRDs
 keywords:
   - gpu-operator

--- a/charts/gpu-operator-crds/README.md
+++ b/charts/gpu-operator-crds/README.md
@@ -11,5 +11,5 @@ CRDs are retrieved from [here](https://github.com/NVIDIA/gpu-operator/tree/main/
 
 To download them, you can use the following script at root : 
 ```
-./scripts/update_crds.sh -r NVIDIA/gpu-operator -b v26.3.3 --folder deployments/gpu-operator/crds -o charts/gpu-operator-crds/templates/
+./scripts/update_crds.sh -r NVIDIA/gpu-operator -b v26.7.0 --folder deployments/gpu-operator/crds -o charts/gpu-operator-crds/templates/
 ```

--- a/charts/gpu-operator-crds/templates/nvidia.com_clusterpolicies.yaml
+++ b/charts/gpu-operator-crds/templates/nvidia.com_clusterpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterpolicies.nvidia.com
 spec:
   group: nvidia.com
@@ -698,11 +698,9 @@ spec:
                         additionalProperties:
                           type: string
                         description: AdditionalLabels to add to ServiceMonitor instance
-                          for NVIDIA DCGM Exporter
                         type: object
                       enabled:
                         description: Enabled indicates if ServiceMonitor is deployed
-                          for NVIDIA DCGM Exporter
                         type: boolean
                       honorLabels:
                         description: HonorLabels chooses the metric’s labels on collisions
@@ -710,13 +708,13 @@ spec:
                         type: boolean
                       interval:
                         description: |-
-                          Interval which metrics should be scraped from NVIDIA DCGM Exporter. If not specified Prometheus’ global scrape interval is used.
+                          Interval at which metrics should be scraped. If not specified, Prometheus’ global scrape interval is used.
                           Supported units: y, w, d, h, m, s, ms
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                       relabelings:
                         description: Relabelings allows to rewrite labels on metric
-                          sets for NVIDIA DCGM Exporter
+                          sets
                         items:
                           description: |-
                             RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
@@ -763,6 +761,7 @@ spec:
 
                                 Only applicable when the action is `HashMod`.
                               format: int64
+                              minimum: 0
                               type: integer
                             regex:
                               description: regex defines the regular expression against
@@ -802,6 +801,13 @@ spec:
                               type: string
                           type: object
                         type: array
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                          If not specified, Prometheus' global scrape timeout is used.
+                          Supported units: y, w, d, h, m, s, ms
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
                     type: object
                   version:
                     description: NVIDIA DCGM Exporter image tag
@@ -1521,6 +1527,12 @@ spec:
                       DriverInstallDir represents the root at which driver files including libraries,
                       config files, and executables can be found.
                     type: string
+                  kubeletRootDir:
+                    default: /var/lib/kubelet
+                    description: |-
+                      KubeletRootDir represents the location of the kubelet root directory.
+                      If empty, it will default to "/var/lib/kubelet".
+                    type: string
                   rootFS:
                     description: |-
                       RootFS represents the path to the root filesystem of the host.
@@ -1531,7 +1543,9 @@ spec:
                     type: string
                 type: object
               kataManager:
-                description: KataManager component spec
+                description: |-
+                  Deprecated: This field is no longer honored by the GPU Operator. All values under this field are ignored.
+                  KataManager component spec
                 properties:
                   args:
                     description: 'Optional: List of arguments'
@@ -1981,6 +1995,130 @@ spec:
                       Optional: Map of string keys and values that can be used to organize and categorize
                       (scope and select) objects. May match selectors of replication controllers
                       and services.
+                    type: object
+                  metrics:
+                    description: Metrics configuration for NVIDIA GPU Operator
+                    properties:
+                      serviceMonitor:
+                        description: 'Optional: ServiceMonitor configuration for NVIDIA
+                          GPU Operator'
+                        properties:
+                          additionalLabels:
+                            additionalProperties:
+                              type: string
+                            description: AdditionalLabels to add to ServiceMonitor
+                              instance
+                            type: object
+                          enabled:
+                            description: Enabled indicates if ServiceMonitor is deployed
+                            type: boolean
+                          honorLabels:
+                            description: HonorLabels chooses the metric’s labels on
+                              collisions with target labels.
+                            type: boolean
+                          interval:
+                            description: |-
+                              Interval at which metrics should be scraped. If not specified, Prometheus’ global scrape interval is used.
+                              Supported units: y, w, d, h, m, s, ms
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
+                          relabelings:
+                            description: Relabelings allows to rewrite labels on metric
+                              sets
+                            items:
+                              description: |-
+                                RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                                scraped samples and remote write samples.
+
+                                More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                              properties:
+                                action:
+                                  default: replace
+                                  description: |-
+                                    action to perform based on the regex matching.
+
+                                    `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                    `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                    Default: "Replace"
+                                  enum:
+                                  - replace
+                                  - Replace
+                                  - keep
+                                  - Keep
+                                  - drop
+                                  - Drop
+                                  - hashmod
+                                  - HashMod
+                                  - labelmap
+                                  - LabelMap
+                                  - labeldrop
+                                  - LabelDrop
+                                  - labelkeep
+                                  - LabelKeep
+                                  - lowercase
+                                  - Lowercase
+                                  - uppercase
+                                  - Uppercase
+                                  - keepequal
+                                  - KeepEqual
+                                  - dropequal
+                                  - DropEqual
+                                  type: string
+                                modulus:
+                                  description: |-
+                                    modulus to take of the hash of the source label values.
+
+                                    Only applicable when the action is `HashMod`.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                                regex:
+                                  description: regex defines the regular expression
+                                    against which the extracted value is matched.
+                                  type: string
+                                replacement:
+                                  description: |-
+                                    replacement value against which a Replace action is performed if the
+                                    regular expression matches.
+
+                                    Regex capture groups are available.
+                                  type: string
+                                separator:
+                                  description: separator defines the string between
+                                    concatenated SourceLabels.
+                                  type: string
+                                sourceLabels:
+                                  description: |-
+                                    sourceLabels defines the source labels select values from existing labels. Their content is
+                                    concatenated using the configured Separator and matched against the
+                                    configured regular expression.
+                                  items:
+                                    description: |-
+                                      LabelName is a valid Prometheus label name.
+                                      For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                      For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  description: |-
+                                    targetLabel defines the label to which the resulting string is written in a replacement.
+
+                                    It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                    `KeepEqual` and `DropEqual` actions.
+
+                                    Regex capture groups are available.
+                                  type: string
+                              type: object
+                            type: array
+                          scrapeTimeout:
+                            description: |-
+                              ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                              If not specified, Prometheus' global scrape timeout is used.
+                              Supported units: y, w, d, h, m, s, ms
+                            pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                            type: string
+                        type: object
                     type: object
                   runtimeClass:
                     default: nvidia

--- a/charts/gpu-operator-crds/templates/nvidia.com_gpuclusters.yaml
+++ b/charts/gpu-operator-crds/templates/nvidia.com_gpuclusters.yaml
@@ -1,0 +1,1045 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: gpuclusters.nvidia.com
+spec:
+  group: nvidia.com
+  names:
+    kind: GPUCluster
+    listKind: GPUClusterList
+    plural: gpuclusters
+    shortNames:
+    - gc
+    singular: gpucluster
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GPUCluster is the Schema for the gpuclusters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GPUClusterSpec defines the desired state of GPUCluster, the DRA-based
+              software-enablement stack. Unlike ClusterPolicy, it does not manage the NVIDIA driver
+              or the device-plugin; the driver is installed separately (host-installed or via an
+              NVIDIADriver CR) and GPUCluster waits for driver readiness before proceeding.
+            properties:
+              daemonsets:
+                description: |-
+                  Daemonsets defines the common configuration applied to all DaemonSets deployed
+                  by the GPUCluster controller.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Optional: Annotations is an unstructured key value map stored with a resource that may be
+                      set by external tools to store and retrieve arbitrary metadata. They are not
+                      queryable and should be preserved when modifying objects.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Optional: Map of string keys and values that can be used to organize and categorize
+                      (scope and select) objects. May match selectors of replication controllers
+                      and services.
+                    type: object
+                  podSecurityContext:
+                    description: 'Optional: Set pod-level security context for all
+                      DaemonSet pods (applies as defaults to all containers)'
+                    properties:
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxChangePolicy:
+                        description: |-
+                          seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                          It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                          Valid values are "MountOption" and "Recursive".
+
+                          "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                          This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                          "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                          This requires all Pods that share the same volume to use the same SELinux label.
+                          It is not possible to share the same volume among privileged and unprivileged Pods.
+                          Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                          whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                          CSIDriver instance. Other volumes are always re-labelled recursively.
+                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                          and "Recursive" for all other volumes.
+
+                          This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                          All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and fsGroup (if specified).  If
+                          the SupplementalGroupsPolicy feature is enabled, the
+                          supplementalGroupsPolicy field determines whether these are in addition
+                          to or instead of any group memberships defined in the container image.
+                          If unspecified, no additional groups are added, though group memberships
+                          defined in the container image may still be used, depending on the
+                          supplementalGroupsPolicy field.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                          (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                          and the container runtime must implement support for this feature.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  priorityClassName:
+                    type: string
+                  rollingUpdate:
+                    description: 'Optional: Configuration for rolling update of all
+                      DaemonSet pods'
+                    properties:
+                      maxUnavailable:
+                        type: string
+                    type: object
+                  tolerations:
+                    description: 'Optional: Set tolerations'
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  updateStrategy:
+                    default: RollingUpdate
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              dcgm:
+                description: |-
+                  DCGM defines the spec for the standalone NVIDIA DCGM hostengine. Disabled by default;
+                  when disabled, dcgm-exporter uses its embedded nv-hostengine. NOTE: the reused enabled
+                  field carries no server-side default and its IsEnabled() treats nil as enabled, so the
+                  controller must default nil enabled to disabled here.
+                properties:
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA DCGM Hostengine
+                      as a separate pod is enabled.
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable.
+                          type: string
+                        value:
+                          description: Value of the environment variable.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  hostNetwork:
+                    description: HostNetwork indicates whether the DCGM pod uses the
+                      host's network namespace.
+                    type: boolean
+                  hostPort:
+                    description: 'Deprecated: HostPort represents host port that needs
+                      to be bound for DCGM engine (Default: 5555)'
+                    format: int32
+                    type: integer
+                  image:
+                    description: NVIDIA DCGM image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA DCGM image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  version:
+                    description: NVIDIA DCGM image tag
+                    type: string
+                type: object
+              dcgmExporter:
+                description: |-
+                  DCGMExporter defines the spec for NVIDIA DCGM Exporter. Enabled by default, but the
+                  reused enabled field carries no server-side default; the controller defaults nil enabled.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Optional: Annotations is an unstructured key value map stored with a resource that may be
+                      set by external tools to store and retrieve arbitrary metadata. They are not
+                      queryable and should be preserved when modifying objects.
+                    type: object
+                  args:
+                    description: 'Optional: List of arguments'
+                    items:
+                      type: string
+                    type: array
+                  config:
+                    description: 'Optional: Custom metrics configuration for NVIDIA
+                      DCGM Exporter'
+                    properties:
+                      name:
+                        description: ConfigMap name with file dcgm-metrics.csv for
+                          metrics to be collected by NVIDIA DCGM Exporter
+                        type: string
+                    type: object
+                  enablePodLabels:
+                    description: |-
+                      Enable Kubernetes pod labels as Prometheus label dimensions in DCGM exporter metrics.
+                      (Requires cluster-level read access to pods.)
+                    type: boolean
+                  enablePodUID:
+                    description: |-
+                      Enable Kubernetes pod UID as a Prometheus label dimension in DCGM exporter metrics.
+                      (Requires cluster-level read access to pods.)
+                    type: boolean
+                  enabled:
+                    description: Enabled indicates if deployment of NVIDIA DCGM Exporter
+                      through operator is enabled
+                    type: boolean
+                  env:
+                    description: 'Optional: List of environment variables'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable.
+                          type: string
+                        value:
+                          description: Value of the environment variable.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  hostNetwork:
+                    description: HostNetwork allows the DCGM-Exporter daemon set to
+                      expose metrics port on the host's network namespace.
+                    type: boolean
+                  hostPID:
+                    description: HostPID allows the DCGM-Exporter daemon set to access
+                      the host's PID namespace
+                    type: boolean
+                  hpcJobMapping:
+                    description: 'Optional: HPC job mapping configuration for NVIDIA
+                      DCGM Exporter'
+                    properties:
+                      directory:
+                        description: |-
+                          Directory path where HPC job mapping files are created by the workload manager
+                          Defaults to /var/lib/dcgm-exporter/job-mapping if not specified
+                        type: string
+                      enabled:
+                        description: Enable HPC job mapping for DCGM Exporter
+                        type: boolean
+                    type: object
+                  image:
+                    description: NVIDIA DCGM Exporter image name
+                    pattern: '[a-zA-Z0-9\-]+'
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  podLabelAllowlistRegex:
+                    description: |-
+                      Regex list for filtering which Kubernetes pod labels are included in DCGM exporter metrics.
+                      Empty means all pod labels are included.
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA DCGM Exporter image repository
+                    type: string
+                  resources:
+                    description: 'Optional: Define resources requests and limits for
+                      each pod'
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  service:
+                    description: 'Optional: Service configuration for NVIDIA DCGM
+                      Exporter'
+                    properties:
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy describes how nodes distribute
+                          service traffic they receive on the ClusterIP.
+                        type: string
+                      type:
+                        description: Type represents the ServiceType which describes
+                          ingress methods for a service
+                        type: string
+                    type: object
+                  serviceMonitor:
+                    description: 'Optional: ServiceMonitor configuration for NVIDIA
+                      DCGM Exporter'
+                    properties:
+                      additionalLabels:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalLabels to add to ServiceMonitor instance
+                        type: object
+                      enabled:
+                        description: Enabled indicates if ServiceMonitor is deployed
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric’s labels on collisions
+                          with target labels.
+                        type: boolean
+                      interval:
+                        description: |-
+                          Interval at which metrics should be scraped. If not specified, Prometheus’ global scrape interval is used.
+                          Supported units: y, w, d, h, m, s, ms
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      relabelings:
+                        description: Relabelings allows to rewrite labels on metric
+                          sets
+                        items:
+                          description: |-
+                            RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                            scraped samples and remote write samples.
+
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                          properties:
+                            action:
+                              default: replace
+                              description: |-
+                                action to perform based on the regex matching.
+
+                                `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                Default: "Replace"
+                              enum:
+                              - replace
+                              - Replace
+                              - keep
+                              - Keep
+                              - drop
+                              - Drop
+                              - hashmod
+                              - HashMod
+                              - labelmap
+                              - LabelMap
+                              - labeldrop
+                              - LabelDrop
+                              - labelkeep
+                              - LabelKeep
+                              - lowercase
+                              - Lowercase
+                              - uppercase
+                              - Uppercase
+                              - keepequal
+                              - KeepEqual
+                              - dropequal
+                              - DropEqual
+                              type: string
+                            modulus:
+                              description: |-
+                                modulus to take of the hash of the source label values.
+
+                                Only applicable when the action is `HashMod`.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            regex:
+                              description: regex defines the regular expression against
+                                which the extracted value is matched.
+                              type: string
+                            replacement:
+                              description: |-
+                                replacement value against which a Replace action is performed if the
+                                regular expression matches.
+
+                                Regex capture groups are available.
+                              type: string
+                            separator:
+                              description: separator defines the string between concatenated
+                                SourceLabels.
+                              type: string
+                            sourceLabels:
+                              description: |-
+                                sourceLabels defines the source labels select values from existing labels. Their content is
+                                concatenated using the configured Separator and matched against the
+                                configured regular expression.
+                              items:
+                                description: |-
+                                  LabelName is a valid Prometheus label name.
+                                  For Prometheus 3.x, a label name is valid if it contains UTF-8 characters.
+                                  For Prometheus 2.x, a label name is only valid if it contains ASCII characters, letters, numbers, as well as underscores.
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: |-
+                                targetLabel defines the label to which the resulting string is written in a replacement.
+
+                                It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                `KeepEqual` and `DropEqual` actions.
+
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      scrapeTimeout:
+                        description: |-
+                          ScrapeTimeout to use when scraping metrics. Must not be greater than Interval.
+                          If not specified, Prometheus' global scrape timeout is used.
+                          Supported units: y, w, d, h, m, s, ms
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                    type: object
+                  version:
+                    description: NVIDIA DCGM Exporter image tag
+                    type: string
+                type: object
+              draDriver:
+                description: DRADriver defines the spec for the NVIDIA DRA driver
+                  stack (gpus + computeDomains).
+                properties:
+                  computeDomains:
+                    description: ComputeDomains configures the compute-domain capability
+                      of the DRA driver.
+                    properties:
+                      controller:
+                        description: Controller configures the compute-domain controller
+                          Deployment.
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable.
+                                  type: string
+                                value:
+                                  description: Value of the environment variable.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          resources:
+                            description: 'Optional: Define resources requests and
+                              limits for the controller container'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                      enabled:
+                        default: true
+                        description: Enabled indicates if the computeDomains capability
+                          of the DRA driver is enabled.
+                        type: boolean
+                      kubeletPlugin:
+                        description: KubeletPlugin configures the kubelet-plugin workload
+                          for the computeDomains capability.
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable.
+                                  type: string
+                                value:
+                                  description: Value of the environment variable.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          healthcheck:
+                            description: 'Optional: Configure the container''s gRPC
+                              health service and its probes'
+                            properties:
+                              enabled:
+                                default: true
+                                type: boolean
+                              port:
+                                description: Defaults to 51516 for the gpus container
+                                  and 51515 for the computeDomains container.
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Optional: Define resources requests and
+                              limits for the kubelet-plugin container'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: |-
+                      FeatureGates is a map of feature gate names to a boolean enabling or disabling each.
+                      It is rendered as the FEATURE_GATES environment variable on the DRA driver containers.
+                    type: object
+                  gpus:
+                    description: GPUs configures the gpu.nvidia.com capability of
+                      the DRA driver.
+                    properties:
+                      kubeletPlugin:
+                        description: KubeletPlugin configures the kubelet-plugin workload
+                          for the gpus capability.
+                        properties:
+                          env:
+                            description: 'Optional: List of environment variables'
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable.
+                                  type: string
+                                value:
+                                  description: Value of the environment variable.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          healthcheck:
+                            description: 'Optional: Configure the container''s gRPC
+                              health service and its probes'
+                            properties:
+                              enabled:
+                                default: true
+                                type: boolean
+                              port:
+                                description: Defaults to 51516 for the gpus container
+                                  and 51515 for the computeDomains container.
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Optional: Define resources requests and
+                              limits for the kubelet-plugin container'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  image:
+                    description: NVIDIA DRA driver image name
+                    pattern: ^[a-zA-Z0-9\-]+$
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets
+                    items:
+                      type: string
+                    type: array
+                  repository:
+                    description: NVIDIA DRA driver image repository
+                    type: string
+                  version:
+                    description: NVIDIA DRA driver image tag
+                    type: string
+                type: object
+              hostPaths:
+                description: HostPaths defines the host paths used in host-path volumes
+                  for various components.
+                properties:
+                  driverInstallDir:
+                    description: |-
+                      DriverInstallDir represents the root at which driver files including libraries,
+                      config files, and executables can be found.
+                    type: string
+                  kubeletRootDir:
+                    default: /var/lib/kubelet
+                    description: |-
+                      KubeletRootDir represents the location of the kubelet root directory.
+                      If empty, it will default to "/var/lib/kubelet".
+                    type: string
+                type: object
+            required:
+            - draDriver
+            type: object
+          status:
+            description: GPUClusterStatus defines the observed state of GPUCluster
+            properties:
+              conditions:
+                description: Conditions is a list of conditions representing the GPUCluster's
+                  current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              namespace:
+                description: Namespace indicates the namespace in which the operator
+                  and operands are installed
+                type: string
+              state:
+                description: State indicates the status of the GPUCluster instance
+                enum:
+                - ready
+                - notReady
+                - disabled
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: GPUCluster is a singleton, metadata.name must be 'gpu-cluster'
+          rule: self.metadata.name == 'gpu-cluster'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/gpu-operator-crds/templates/nvidia.com_nvidiadrivers.yaml
+++ b/charts/gpu-operator-crds/templates/nvidia.com_nvidiadrivers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: nvidiadrivers.nvidia.com
 spec:
   group: nvidia.com
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .status.state
       name: Status
       type: string
+    - jsonPath: .spec.default
+      name: Default
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: string
@@ -48,7 +51,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: NVIDIADriverSpec defines the desired state of NVIDIADriver
+            description: |-
+              NVIDIADriverSpec defines the desired state of NVIDIADriver.
+              The CEL validation allows non-default drivers to use nodeSelector, but requires
+              default drivers to leave nodeSelector unset or empty.
             properties:
               annotations:
                 additionalProperties:
@@ -70,6 +76,12 @@ spec:
                   name:
                     type: string
                 type: object
+              default:
+                default: false
+                description: |-
+                  Default indicates that this NVIDIADriver acts as the fallback driver daemon set manager for GPU nodes
+                  that do not match any non-default NVIDIADriver nodeSelector.
+                type: boolean
               driverType:
                 default: gpu
                 description: DriverType defines NVIDIA driver type
@@ -941,6 +953,107 @@ spec:
                       type: string
                   type: object
                 type: array
+              upgradePolicy:
+                description: UpgradePolicy allows to control automatic upgrade of
+                  the driver on nodes
+                properties:
+                  autoUpgrade:
+                    default: true
+                    description: |-
+                      AutoUpgrade is a switch for automatic upgrade feature.
+                      If set to false all other options are ignored.
+                    type: boolean
+                  drain:
+                    description: DrainSpec describes configuration for node drain
+                      during automatic upgrade
+                    properties:
+                      deleteEmptyDir:
+                        default: false
+                        description: |-
+                          DeleteEmptyDir indicates if should continue even if there are pods using emptyDir
+                          (local data that will be deleted when the node is drained)
+                        type: boolean
+                      enable:
+                        default: false
+                        description: Enable indicates if node draining is allowed
+                          during upgrade
+                        type: boolean
+                      force:
+                        default: false
+                        description: Force indicates if force draining is allowed
+                        type: boolean
+                      podSelector:
+                        description: |-
+                          PodSelector specifies a label selector to filter pods on the node that need to be drained
+                          For more details on label selectors, see:
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                        type: string
+                      timeoutSeconds:
+                        default: 300
+                        description: TimeoutSecond specifies the length of time in
+                          seconds to wait before giving up drain, zero means infinite
+                        minimum: 0
+                        type: integer
+                    type: object
+                  maxParallelUpgrades:
+                    default: 1
+                    description: |-
+                      MaxParallelUpgrades indicates how many nodes can be upgraded in parallel.
+                      0 means no limit, all nodes will be upgraded in parallel.
+                    minimum: 0
+                    type: integer
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 25%
+                    description: |-
+                      MaxUnavailable is the maximum number of nodes with the driver installed, that can be unavailable during the upgrade.
+                      Value can be an absolute number (ex: 5) or a percentage of total nodes at the start of upgrade (ex: 10%).
+                      Absolute number is calculated from percentage by rounding up.
+                      By default, a fixed value of 25% is used.
+                    x-kubernetes-int-or-string: true
+                  podDeletion:
+                    description: PodDeletionSpec describes configuration for deletion
+                      of pods using special resources during automatic upgrade
+                    properties:
+                      deleteEmptyDir:
+                        default: false
+                        description: |-
+                          DeleteEmptyDir indicates if should continue even if there are pods using emptyDir
+                          (local data that will be deleted when the pod is deleted)
+                        type: boolean
+                      force:
+                        default: false
+                        description: Force indicates if force deletion is allowed
+                        type: boolean
+                      timeoutSeconds:
+                        default: 300
+                        description: |-
+                          TimeoutSecond specifies the length of time in seconds to wait before giving up on pod termination, zero means
+                          infinite
+                        minimum: 0
+                        type: integer
+                    type: object
+                  waitForCompletion:
+                    description: WaitForCompletionSpec describes the configuration
+                      for waiting on job completions
+                    properties:
+                      podSelector:
+                        description: |-
+                          PodSelector specifies a label selector for the pods to wait for completion
+                          For more details on label selectors, see:
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                        type: string
+                      timeoutSeconds:
+                        default: 0
+                        description: |-
+                          TimeoutSecond specifies the length of time in seconds to wait before giving up on pod termination, zero means
+                          infinite
+                        minimum: 0
+                        type: integer
+                    type: object
+                type: object
               useOpenKernelModules:
                 description: |-
                   Deprecated: This field is no longer honored by the gpu-operator. Please use KernelModuleType instead.
@@ -968,9 +1081,14 @@ spec:
                     type: string
                 type: object
             required:
+            - default
             - driverType
             - image
             type: object
+            x-kubernetes-validations:
+            - message: default NVIDIADriver must not use nodeSelector
+              rule: 'has(self.default) && self.default ? !has(self.nodeSelector) ||
+                size(self.nodeSelector) == 0 : true'
           status:
             description: NVIDIADriverStatus defines the observed state of NVIDIADriver
             properties:

--- a/charts/gpu-operator-crds/templates/resource.nvidia.com_computedomaincliques.yaml
+++ b/charts/gpu-operator-crds/templates/resource.nvidia.com_computedomaincliques.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: computedomaincliques.resource.nvidia.com
+spec:
+  group: resource.nvidia.com
+  names:
+    kind: ComputeDomainClique
+    listKind: ComputeDomainCliqueList
+    plural: computedomaincliques
+    singular: computedomainclique
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ComputeDomainClique holds information about a specific clique within a ComputeDomain.
+          It is created in the driver namespace and named as "<computeDomainUID>.<cliqueID>".
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          daemons:
+            items:
+              description: ComputeDomainDaemonInfo provides information about each
+                daemon in a ComputeDomainClique.
+              properties:
+                cliqueID:
+                  type: string
+                index:
+                  description: |-
+                    The Index field is used to ensure a consistent IP-to-DNS name
+                    mapping across all machines within an IMEX domain. Each node's index
+                    directly determines its DNS name within a given NVLink partition
+                    (i.e. clique). In other words, the 2-tuple of (CliqueID, Index) will
+                    always be unique. This field is marked as optional (but not
+                    omitempty) in order to support downgrades and avoid an API bump.
+                  type: integer
+                ipAddress:
+                  type: string
+                nodeName:
+                  type: string
+                status:
+                  default: NotReady
+                  description: |-
+                    The Status field tracks the readiness of the IMEX daemon running on
+                    this node. It gets switched to Ready whenever the IMEX daemon is
+                    ready to broker GPU memory exchanges and switches to NotReady when
+                    it is not. It is marked as optional in order to support downgrades
+                    and avoid an API bump.
+                  enum:
+                  - Ready
+                  - NotReady
+                  type: string
+              required:
+              - cliqueID
+              - ipAddress
+              - nodeName
+              type: object
+            type: array
+            x-kubernetes-list-map-keys:
+            - nodeName
+            x-kubernetes-list-type: map
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/charts/gpu-operator-crds/templates/resource.nvidia.com_computedomains.yaml
+++ b/charts/gpu-operator-crds/templates/resource.nvidia.com_computedomains.yaml
@@ -1,0 +1,162 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: computedomains.resource.nvidia.com
+spec:
+  group: resource.nvidia.com
+  names:
+    kind: ComputeDomain
+    listKind: ComputeDomainList
+    plural: computedomains
+    singular: computedomain
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ComputeDomain prepares a set of nodes to run a multi-node workload
+          in.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ComputeDomainSpec provides the spec for a ComputeDomain.
+            properties:
+              channel:
+                description: ComputeDomainChannelSpec provides the spec for a channel
+                  used to run a workload inside a ComputeDomain.
+                properties:
+                  allocationMode:
+                    default: Single
+                    description: |-
+                      Allows for requesting all IMEX channels (the maximum per IMEX domain) or
+                      precisely one.
+                    enum:
+                    - All
+                    - Single
+                    type: string
+                  resourceClaimTemplate:
+                    description: ComputeDomainResourceClaimTemplate provides the details
+                      of the ResourceClaimTemplate to generate.
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - resourceClaimTemplate
+                type: object
+              numNodes:
+                description: |-
+                  Intended number of IMEX daemons (i.e., individual compute nodes) in the
+                  ComputeDomain. Must be zero or greater.
+
+                  With `featureGates.IMEXDaemonsWithDNSNames=true` (the default), this is
+                  recommended to be set to zero. Workload must implement and consult its
+                  own source of truth for the number of workers online before trying to
+                  share GPU memory (and hence triggering IMEX interaction). When non-zero,
+                  `numNodes` is used only for automatically updating the global
+                  ComputeDomain `Status` (indicating `Ready` when the number of ready IMEX
+                  daemons equals `numNodes`). In this mode, a `numNodes` value greater than
+                  zero in particular does not gate the startup of IMEX daemons: individual
+                  IMEX daemons are started immediately without waiting for its peers, and
+                  any workload pod gets released right after its local IMEX daemon has
+                  started.
+
+                  With `featureGates.IMEXDaemonsWithDNSNames=false`, `numNodes` must be set
+                  to the expected number of worker nodes joining the ComputeDomain. In that
+                  mode, all workload pods are held back (with containers in state
+                  `ContainerCreating`) until the underlying IMEX domain has been joined by
+                  `numNodes` IMEX daemons. Pods from more than `numNodes` nodes trying to
+                  join the ComputeDomain may lead to unexpected behavior.
+
+                  The `numNodes` parameter is deprecated and will be removed in the next
+                  API version.
+                type: integer
+            required:
+            - channel
+            - numNodes
+            type: object
+            x-kubernetes-validations:
+            - message: A computeDomain.spec is immutable
+              rule: self == oldSelf
+          status:
+            description: |-
+              Global ComputeDomain status. Can be used to guide debugging efforts.
+              Workload however should not rely on inspecting this field at any point
+              during its lifecycle.
+            properties:
+              nodes:
+                items:
+                  description: ComputeDomainNode provides information about each node
+                    added to a ComputeDomain.
+                  properties:
+                    cliqueID:
+                      type: string
+                    index:
+                      description: |-
+                        The Index field is used to ensure a consistent IP-to-DNS name
+                        mapping across all machines within an IMEX domain. Each node's index
+                        directly determines its DNS name within a given NVLink partition
+                        (i.e. clique). In other words, the 2-tuple of (CliqueID, Index) will
+                        always be unique. This field is marked as optional (but not
+                        omitempty) in order to support downgrades and avoid an API bump.
+                      type: integer
+                    ipAddress:
+                      type: string
+                    name:
+                      type: string
+                    status:
+                      default: NotReady
+                      description: |-
+                        The Status field tracks the readiness of the IMEX daemon running on
+                        this node. It gets switched to Ready whenever the IMEX daemon is
+                        ready to broker GPU memory exchanges and switches to NotReady when
+                        it is not. It is marked as optional in order to support downgrades
+                        and avoid an API bump.
+                      enum:
+                      - Ready
+                      - NotReady
+                      type: string
+                  required:
+                  - cliqueID
+                  - ipAddress
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              status:
+                default: NotReady
+                enum:
+                - Ready
+                - NotReady
+                type: string
+            required:
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Brings the chart from v26.3.3 to v26.7.0, ahead of moving the deployed `gpu-operator` release to 26.7.0.

## Three new CRDs

| | v26.3.3 | v26.7.0 |
|---|---|---|
| `clusterpolicies.nvidia.com` | ✅ | ✅ |
| `nvidiadrivers.nvidia.com` | ✅ | ✅ |
| `gpuclusters.nvidia.com` | — | **new** |
| `computedomains.resource.nvidia.com` | — | **new** |
| `computedomaincliques.resource.nvidia.com` | — | **new** |

The operator at 26.7.0 runs controllers for all five. Installed against the old chart, three of those watch resource types that do not exist in the cluster, so the CRDs need to land first.

## Nothing is removed

The two existing CRDs are additive: `+264/-8` lines, and all eight removed lines are description rewordings plus the `controller-gen.kubebuilder.io/version` annotation. Comparing the parsed schemas, the `spec` property set of `clusterpolicies` is **identical** before and after — `kataManager` is still there, now carrying `Deprecated: This field is no longer honored by the GPU Operator.` in its description.

## Notes

- Chart version mirrors the operator version, per this chart README ("The Chart has the same version as the `gpu-operator`, try to keep them equal").
- Vendored with the documented command, only the tag changed:
  `./scripts/update_crds.sh -r NVIDIA/gpu-operator -b v26.7.0 --folder deployments/gpu-operator/crds -o charts/gpu-operator-crds/templates/`
- No `creationTimestamp: null` in the upstream output, so the cleanup step was a no-op.
- Largest CRD is 152KB (`clusterpolicies`), still under the 256KB threshold, so no server-side-apply note is needed in the README.