### PR TITLE
chore(node-feature-discovery-crds): update CRDs to v0.19.0

### DIFF
--- a/charts/node-feature-discovery-crds/Chart.yaml
+++ b/charts/node-feature-discovery-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: node-feature-discovery-crds
-version: 0.17.3
-appVersion: "v0.17.3"
+version: 0.19.0
+appVersion: "v0.19.0"
 description: Manage node-feature-discovery CRDs
 keywords:
   - node-feature-discovery

--- a/charts/node-feature-discovery-crds/README.md
+++ b/charts/node-feature-discovery-crds/README.md
@@ -11,5 +11,5 @@ CRDs are retrieved from [here](https://github.com/kubernetes-sigs/node-feature-d
 
 To download them, you can use the following script at root : 
 ```
-./scripts/update_crds.sh -r kubernetes-sigs/node-feature-discovery -b v0.17.2 --folder deployment/helm/node-feature-discovery/crds -o charts/node-feature-discovery-crds/templates/
+./scripts/update_crds.sh -r kubernetes-sigs/node-feature-discovery -b v0.19.0 --folder deployment/helm/node-feature-discovery/crds -o charts/node-feature-discovery-crds/templates/
 ```

--- a/charts/node-feature-discovery-crds/templates/nodefeaturegroups.yaml
+++ b/charts/node-feature-discovery-crds/templates/nodefeaturegroups.yaml
@@ -77,10 +77,18 @@ spec:
                                             - Exists
                                             - DoesNotExist
                                             - Gt
+                                            - Ge
                                             - Lt
+                                            - Le
                                             - GtLt
+                                            - GeLe
                                             - IsTrue
                                             - IsFalse
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the value type for specific operators.
+                                            The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                           type: string
                                         value:
                                           description: |-
@@ -113,10 +121,18 @@ spec:
                                           - Exists
                                           - DoesNotExist
                                           - Gt
+                                          - Ge
                                           - Lt
+                                          - Le
                                           - GtLt
+                                          - GeLe
                                           - IsTrue
                                           - IsFalse
+                                        type: string
+                                      type:
+                                        description: |-
+                                          Type defines the value type for specific operators.
+                                          The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                         type: string
                                       value:
                                         description: |-
@@ -166,10 +182,18 @@ spec:
                                       - Exists
                                       - DoesNotExist
                                       - Gt
+                                      - Ge
                                       - Lt
+                                      - Le
                                       - GtLt
+                                      - GeLe
                                       - IsTrue
                                       - IsFalse
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the value type for specific operators.
+                                      The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                     type: string
                                   value:
                                     description: |-
@@ -202,10 +226,18 @@ spec:
                                     - Exists
                                     - DoesNotExist
                                     - Gt
+                                    - Ge
                                     - Lt
+                                    - Le
                                     - GtLt
+                                    - GeLe
                                     - IsTrue
                                     - IsFalse
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type defines the value type for specific operators.
+                                    The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                   type: string
                                 value:
                                   description: |-
@@ -226,6 +258,19 @@ spec:
                         type: array
                       name:
                         description: Name of the rule.
+                        type: string
+                      vars:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Vars is the variables to store if the rule matches. Variables can be
+                          referenced from other rules enabling more complex rule hierarchies.
+                        type: object
+                      varsTemplate:
+                        description: |-
+                          VarsTemplate specifies a template to expand for dynamically generating
+                          multiple variables. Data (after template expansion) must be keys with an
+                          optional value (<key>[=<value>]) separated by newlines.
                         type: string
                     required:
                       - name

--- a/charts/node-feature-discovery-crds/templates/nodefeaturerules.yaml
+++ b/charts/node-feature-discovery-crds/templates/nodefeaturerules.yaml
@@ -100,10 +100,18 @@ spec:
                                             - Exists
                                             - DoesNotExist
                                             - Gt
+                                            - Ge
                                             - Lt
+                                            - Le
                                             - GtLt
+                                            - GeLe
                                             - IsTrue
                                             - IsFalse
+                                          type: string
+                                        type:
+                                          description: |-
+                                            Type defines the value type for specific operators.
+                                            The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                           type: string
                                         value:
                                           description: |-
@@ -136,10 +144,18 @@ spec:
                                           - Exists
                                           - DoesNotExist
                                           - Gt
+                                          - Ge
                                           - Lt
+                                          - Le
                                           - GtLt
+                                          - GeLe
                                           - IsTrue
                                           - IsFalse
+                                        type: string
+                                      type:
+                                        description: |-
+                                          Type defines the value type for specific operators.
+                                          The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                         type: string
                                       value:
                                         description: |-
@@ -189,10 +205,18 @@ spec:
                                       - Exists
                                       - DoesNotExist
                                       - Gt
+                                      - Ge
                                       - Lt
+                                      - Le
                                       - GtLt
+                                      - GeLe
                                       - IsTrue
                                       - IsFalse
+                                    type: string
+                                  type:
+                                    description: |-
+                                      Type defines the value type for specific operators.
+                                      The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                     type: string
                                   value:
                                     description: |-
@@ -225,10 +249,18 @@ spec:
                                     - Exists
                                     - DoesNotExist
                                     - Gt
+                                    - Ge
                                     - Lt
+                                    - Le
                                     - GtLt
+                                    - GeLe
                                     - IsTrue
                                     - IsFalse
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type defines the value type for specific operators.
+                                    The currently supported type is 'version' for Gt,Ge,Lt,Le,GtLt,GeLe operators.
                                   type: string
                                 value:
                                   description: |-


### PR DESCRIPTION
Brings the chart from v0.17.3 to v0.19.0.

## Why now

`gpu-operator` v26.7.0 bundles **node-feature-discovery v0.19.0** (its subchart moves the NFD image from `v0.18.3` to `v0.19.0`), while this chart still vendored v0.17.3. The NFD workload would run three minors ahead of its own schemas.

NFD v0.19 adds the `Ge`, `Le` and `GeLe` match operators, plus a `type` field documented as *"Type defines the value type for specific operators. The currently supported type is `version` for Gt,Ge,Lt,Le,GtLt,GeLe operators."* Against the v0.17.3 CRD, a `NodeFeatureRule` using either is accepted and then silently stripped by the API server.

## Additive only

`+77 lines, 0 removed`:

| CRD | change |
|---|---|
| `nodefeatures.nfd.k8s-sigs.io` | **byte-identical** |
| `nodefeaturegroups.nfd.k8s-sigs.io` | +45 |
| `nodefeaturerules.nfd.k8s-sigs.io` | +32 |

Checked structurally rather than by reading the diff — parsing both revisions and comparing, the delta is 67 added keys and **zero removed**. Served versions (`v1alpha1`, served + storage) and shortNames (`nfg`, `nfr`) are unchanged, and the chart still renders 3 CRDs.

## Note on the split

Upstream now ships a single `deployment/helm/node-feature-discovery/crds/nfd-api-crds.yaml`, where it used to ship one file per CRD. It is split back into the three per-CRD files this chart uses via `scripts/cut_crds.sh`, so the layout and formatting are unchanged.

Worth knowing: `cut_crds.sh` requires **mikefarah `yq`**. With the Python `yq` (kislyuk) on `PATH` it does not fail loudly — it writes a file literally named `{.yaml` and leaves the real templates untouched.