### PR TITLE
chore(trivy-operator-crds): update CRDs to trivy-operator v0.34.0

### DIFF
--- a/charts/trivy-operator-crds/Chart.yaml
+++ b/charts/trivy-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: trivy-operator-crds
-version: 0.25.0
-appVersion: "v0.25.0"
+version: 0.34.0
+appVersion: "v0.34.0"
 description: Manage trivy-operator CRDs
 keywords:
   - trivy-operator

--- a/charts/trivy-operator-crds/README.md
+++ b/charts/trivy-operator-crds/README.md
@@ -11,5 +11,5 @@ CRDs are retrieved from [here](https://github.com/aquasecurity/trivy-operator/tr
 
 To download them, you can use the following script at root : 
 ```
-./scripts/update_crds.sh -r aquasecurity/trivy-operator -b v0.25.0 --folder deploy/helm/crds -o charts/trivy-operator-crds/templates/
+./scripts/update_crds.sh -r aquasecurity/trivy-operator -b v0.34.0 --folder deploy/helm/crds -o charts/trivy-operator-crds/templates/
 ```

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_clustercompliancereports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_clustercompliancereports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clustercompliancereports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_clusterconfigauditreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_clusterconfigauditreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterconfigauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_clusterinfraassessmentreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_clusterinfraassessmentreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterinfraassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_clusterrbacassessmentreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_clusterrbacassessmentreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clusterrbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_clustersbomreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_clustersbomreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clustersbomreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_clustervulnerabilityreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_clustervulnerabilityreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clustervulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_configauditreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_configauditreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: configauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_exposedsecretreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_exposedsecretreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: exposedsecretreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_infraassessmentreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_infraassessmentreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: infraassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_rbacassessmentreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_rbacassessmentreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: rbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_sbomreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_sbomreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: sbomreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io

--- a/charts/trivy-operator-crds/templates/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/charts/trivy-operator-crds/templates/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: vulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io


### PR DESCRIPTION
Re-vendors the CRDs from `trivy-operator` v0.34.0, up from v0.25.0.

## This is bookkeeping, not a fix

The version gap looked alarming — the chart said v0.25.0 while the deployed operator is v0.31.2, heading to v0.34.0 — but the schemas have not moved. Across all twelve CRDs the only difference is one annotation:

```diff
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.18.0
```

Comparing the **parsed** CRDs rather than the files, the delta is `+12 / -12` — that single key, once per CRD. No property added, removed or retyped anywhere.

## Unchanged

- Same twelve CRDs, same filenames; the chart still renders 12.
- No `creationTimestamp: null` in the upstream output, so the cleanup step was a no-op.
- Chart version mirrors the operator appVersion, per this chart README.

So nothing was silently broken by the old pin; this just makes the version number honest and keeps the chart in step with the operator bump.