### PR TITLE
chore(agentgateway-crds): upgrade to 1.5.0

### DIFF
--- a/charts/agentgateway-crds/Chart.yaml
+++ b/charts/agentgateway-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 annotations:
   category: DeveloperTools
 name: agentgateway-crds
-version: 1.4.1
-appVersion: "v1.4.1"
+version: 1.5.0
+appVersion: "v1.5.0"
 description: Manage agentgateway CRDs
 keywords:
   - agentgateway
@@ -11,7 +11,7 @@ keywords:
   - crds
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/agentgateway-crds
-  - https://github.com/agentgateway/agentgateway/tree/v1.4.1/controller/install/helm/agentgateway-crds
+  - https://github.com/agentgateway/agentgateway/tree/v1.5.0/controller/install/helm/agentgateway-crds
 icon: https://raw.githubusercontent.com/agentgateway/website/refs/heads/main/static/favicon.svg
 maintainers:
   - name: Wiremind

--- a/charts/agentgateway-crds/README.md
+++ b/charts/agentgateway-crds/README.md
@@ -8,12 +8,12 @@ The Chart has the same version as the `agentgateway` release, try to keep them e
 
 CRDs are located [here](https://github.com/agentgateway/agentgateway/tree/main/controller/install/helm/agentgateway-crds/templates).
 
-Use the release tag that matches `appVersion`, for example [v1.4.1](https://github.com/agentgateway/agentgateway/tree/v1.4.1/controller/install/helm/agentgateway-crds/templates).
+Use the release tag that matches `appVersion`, for example [v1.5.0](https://github.com/agentgateway/agentgateway/tree/v1.5.0/controller/install/helm/agentgateway-crds/templates).
 
 **Do not forget to change APP_VERSION**
 
 ```bash
-export APP_VERSION=v1.4.1
+export APP_VERSION=v1.5.0
 ./scripts/update_crds.sh -r agentgateway/agentgateway -b "$APP_VERSION" --folder controller/install/helm/agentgateway-crds/templates -o charts/agentgateway-crds/templates/
 ```
 

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -330,6 +330,13 @@ spec:
                                     maxLength: 256
                                     minLength: 1
                                     type: string
+                                  providerOverride:
+                                    description: |-
+                                      Provider identity used for cost-catalog lookup and telemetry.
+                                      Defaults to "custom" when unset.
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
                                 required:
                                 - formats
                                 type: object
@@ -378,6 +385,56 @@ spec:
                                     maxLength: 256
                                     minLength: 1
                                     type: string
+                                  moderation:
+                                    description: |-
+                                      Inline moderation configuration to inject into OpenAI chat completions
+                                      and responses requests.
+                                      If unset, the OpenAI inline moderation parameter is not injected.
+                                    properties:
+                                      model:
+                                        default: omni-moderation-latest
+                                        description: |-
+                                          The moderation model to use, such as `omni-moderation-latest`.
+                                          Defaults to `omni-moderation-latest` if not specified.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      policy:
+                                        description: Policies to apply to request
+                                          input and generated output.
+                                        properties:
+                                          input:
+                                            description: Policy for request input
+                                              moderation.
+                                            properties:
+                                              mode:
+                                                description: Mode controls whether
+                                                  moderation only returns scores or
+                                                  blocks flagged content.
+                                                enum:
+                                                - Block
+                                                - Score
+                                                type: string
+                                            required:
+                                            - mode
+                                            type: object
+                                          output:
+                                            description: Policy for generated output
+                                              moderation.
+                                            properties:
+                                              mode:
+                                                description: Mode controls whether
+                                                  moderation only returns scores or
+                                                  blocks flagged content.
+                                                enum:
+                                                - Block
+                                                - Score
+                                                type: string
+                                            required:
+                                            - mode
+                                            type: object
+                                        type: object
+                                    type: object
                                 type: object
                               path:
                                 description: |-
@@ -455,6 +512,37 @@ spec:
                                           required:
                                           - field
                                           - value
+                                          type: object
+                                        maxItems: 64
+                                        minItems: 1
+                                        type: array
+                                      finalTransformations:
+                                        description: |-
+                                          CEL transformations to compute and set fields in the request body.
+                                          The expression result overwrites any existing value for that field.
+                                          This has a higher priority than `overrides` if both are set for the same
+                                          key.
+                                          Those transformations are applied after the request is converted to the provider's format, so they can be used to set provider-specific fields.
+                                        items:
+                                          description: |-
+                                            Maps a request JSON field to a CEL expression.
+                                            The expression is evaluated against the current request body and its result
+                                            is assigned to the configured field.
+                                          properties:
+                                            expression:
+                                              description: CEL expression used to
+                                                compute the field value.
+                                              maxLength: 16384
+                                              minLength: 1
+                                              type: string
+                                            field:
+                                              description: Name of the field to set.
+                                              maxLength: 256
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - expression
+                                          - field
                                           type: object
                                         maxItems: 64
                                         minItems: 1
@@ -625,6 +713,19 @@ spec:
                                                     AWS Bedrock Guardrails settings for prompt
                                                     guarding.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether the guardrail's verdict is enforced or only
+                                                        observed. `Reject` (the default) enforces the guardrail: a blocked
+                                                        assessment rejects the request/response and an anonymized assessment masks
+                                                        the matched content. `Audit` runs the guardrail in observe mode: it is
+                                                        invoked and its assessment recorded (metrics + structured log), but the
+                                                        request/response is never blocked or masked.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     identifier:
                                                       description: Identifier of the
                                                         Guardrail policy to use for
@@ -940,12 +1041,9 @@ spec:
                                                                 for receiving a response
                                                                 from the backend.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: requestTimeout
                                                                   must be at least
                                                                   1ms
@@ -972,12 +1070,9 @@ spec:
                                                                 Deadline for establishing a connection to
                                                                 the destination.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: connectTimeout
                                                                   must be at least
                                                                   100ms
@@ -993,12 +1088,9 @@ spec:
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: interval
                                                                       must be at least
                                                                       1 second
@@ -1017,12 +1109,9 @@ spec:
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: time
                                                                       must be at least
                                                                       1 second
@@ -1052,24 +1141,52 @@ spec:
                                                               type: array
                                                             caCertificateRefs:
                                                               description: |-
-                                                                CA certificate `ConfigMap` to use to
-                                                                verify the server certificate.
-                                                                If unset, the system's trusted certificates are used.
+                                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                                key is required. If unset, the system's trusted certificates are used.
                                                               items:
                                                                 description: |-
-                                                                  LocalObjectReference contains enough information to let you locate the
-                                                                  referenced object inside the same namespace.
+                                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                                  An omitted kind defaults to ConfigMap.
                                                                 properties:
-                                                                  name:
-                                                                    default: ""
-                                                                    description: Name
-                                                                      of the referent
+                                                                  kind:
+                                                                    default: ConfigMap
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source. Omitted
+                                                                      defaults to
+                                                                      ConfigMap.
+                                                                    enum:
+                                                                    - ConfigMap
+                                                                    - Secret
                                                                     type: string
+                                                                  name:
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    type: string
+                                                                required:
+                                                                - name
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
                                                               maxItems: 1
                                                               type: array
                                                               x-kubernetes-list-type: atomic
+                                                            certificateSource:
+                                                              default: Inline
+                                                              description: Source
+                                                                for the gateway's
+                                                                client identity and
+                                                                trust roots (`Inline`
+                                                                default, or `SPIFFE`).
+                                                              enum:
+                                                              - Inline
+                                                              - SPIFFE
+                                                              type: string
                                                             insecureSkipVerify:
                                                               description: |-
                                                                 Originates TLS but skips verification of the backend's certificate
@@ -1186,6 +1303,16 @@ spec:
                                                             rule: 'has(self.insecureSkipVerify)
                                                               ? !has(self.verifySubjectAltNames)
                                                               : true'
+                                                          - message: certificateSource
+                                                              SPIFFE may not be combined
+                                                              with mtlsCertificateRef,
+                                                              caCertificateRefs, or
+                                                              insecureSkipVerify
+                                                            rule: '!has(self.certificateSource)
+                                                              || self.certificateSource
+                                                              != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                                              && !has(self.caCertificateRefs)
+                                                              && !has(self.insecureSkipVerify))'
                                                           - message: at most one of
                                                               the fields in [verifySubjectAltNames
                                                               insecureSkipVerify]
@@ -1199,8 +1326,8 @@ spec:
                                                           properties:
                                                             backendRef:
                                                               description: |-
-                                                                Proxy server to reach.
-                                                                Supported types: `Service` and `Backend`.
+                                                                `backendRef` selects a backend for this policy.
+                                                                Mutually exclusive with `url`.
                                                               properties:
                                                                 group:
                                                                   default: ""
@@ -1266,9 +1393,38 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                          required:
-                                                          - backendRef
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
+                                                            url:
+                                                              description: |-
+                                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                                Mutually exclusive with `backendRef`.
+                                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                                will not apply Service policies or load balancing.
+                                                              maxLength: 1024
+                                                              minLength: 1
+                                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                              type: string
                                                           type: object
+                                                          x-kubernetes-validations:
+                                                          - message: exactly one of
+                                                              the fields in [backendRef
+                                                              url] must be set
+                                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                              == 1'
+                                                          - message: url must not
+                                                              include a path for backend
+                                                              tunnel
+                                                            rule: '!has(self.url)
+                                                              || self.url.matches(''^https?://[^/?#]+$'')'
                                                       type: object
                                                       x-kubernetes-validations:
                                                       - message: at least one of the
@@ -1299,6 +1455,16 @@ spec:
                                                   description: Google Model Armor
                                                     settings for prompt guarding.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether flagged content is rejected or only observed.
+                                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                                        would-be rejection without blocking.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     location:
                                                       default: us-central1
                                                       description: |-
@@ -1422,12 +1588,9 @@ spec:
                                                                 for receiving a response
                                                                 from the backend.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: requestTimeout
                                                                   must be at least
                                                                   1ms
@@ -1454,12 +1617,9 @@ spec:
                                                                 Deadline for establishing a connection to
                                                                 the destination.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: connectTimeout
                                                                   must be at least
                                                                   100ms
@@ -1475,12 +1635,9 @@ spec:
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: interval
                                                                       must be at least
                                                                       1 second
@@ -1499,12 +1656,9 @@ spec:
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: time
                                                                       must be at least
                                                                       1 second
@@ -1534,24 +1688,52 @@ spec:
                                                               type: array
                                                             caCertificateRefs:
                                                               description: |-
-                                                                CA certificate `ConfigMap` to use to
-                                                                verify the server certificate.
-                                                                If unset, the system's trusted certificates are used.
+                                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                                key is required. If unset, the system's trusted certificates are used.
                                                               items:
                                                                 description: |-
-                                                                  LocalObjectReference contains enough information to let you locate the
-                                                                  referenced object inside the same namespace.
+                                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                                  An omitted kind defaults to ConfigMap.
                                                                 properties:
-                                                                  name:
-                                                                    default: ""
-                                                                    description: Name
-                                                                      of the referent
+                                                                  kind:
+                                                                    default: ConfigMap
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source. Omitted
+                                                                      defaults to
+                                                                      ConfigMap.
+                                                                    enum:
+                                                                    - ConfigMap
+                                                                    - Secret
                                                                     type: string
+                                                                  name:
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    type: string
+                                                                required:
+                                                                - name
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
                                                               maxItems: 1
                                                               type: array
                                                               x-kubernetes-list-type: atomic
+                                                            certificateSource:
+                                                              default: Inline
+                                                              description: Source
+                                                                for the gateway's
+                                                                client identity and
+                                                                trust roots (`Inline`
+                                                                default, or `SPIFFE`).
+                                                              enum:
+                                                              - Inline
+                                                              - SPIFFE
+                                                              type: string
                                                             insecureSkipVerify:
                                                               description: |-
                                                                 Originates TLS but skips verification of the backend's certificate
@@ -1668,6 +1850,16 @@ spec:
                                                             rule: 'has(self.insecureSkipVerify)
                                                               ? !has(self.verifySubjectAltNames)
                                                               : true'
+                                                          - message: certificateSource
+                                                              SPIFFE may not be combined
+                                                              with mtlsCertificateRef,
+                                                              caCertificateRefs, or
+                                                              insecureSkipVerify
+                                                            rule: '!has(self.certificateSource)
+                                                              || self.certificateSource
+                                                              != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                                              && !has(self.caCertificateRefs)
+                                                              && !has(self.insecureSkipVerify))'
                                                           - message: at most one of
                                                               the fields in [verifySubjectAltNames
                                                               insecureSkipVerify]
@@ -1681,8 +1873,8 @@ spec:
                                                           properties:
                                                             backendRef:
                                                               description: |-
-                                                                Proxy server to reach.
-                                                                Supported types: `Service` and `Backend`.
+                                                                `backendRef` selects a backend for this policy.
+                                                                Mutually exclusive with `url`.
                                                               properties:
                                                                 group:
                                                                   default: ""
@@ -1748,9 +1940,38 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                          required:
-                                                          - backendRef
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
+                                                            url:
+                                                              description: |-
+                                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                                Mutually exclusive with `backendRef`.
+                                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                                will not apply Service policies or load balancing.
+                                                              maxLength: 1024
+                                                              minLength: 1
+                                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                              type: string
                                                           type: object
+                                                          x-kubernetes-validations:
+                                                          - message: exactly one of
+                                                              the fields in [backendRef
+                                                              url] must be set
+                                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                              == 1'
+                                                          - message: url must not
+                                                              include a path for backend
+                                                              tunnel
+                                                            rule: '!has(self.url)
+                                                              || self.url.matches(''^https?://[^/?#]+$'')'
                                                       type: object
                                                       x-kubernetes-validations:
                                                       - message: at least one of the
@@ -1780,6 +2001,16 @@ spec:
                                                     endpoint.
                                                     See https://developers.openai.com/api/reference/resources/moderations for more information.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether flagged content is rejected or only observed.
+                                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                                        would-be rejection without blocking.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     model:
                                                       description: |-
                                                         Moderation model to use. For example,
@@ -1923,12 +2154,9 @@ spec:
                                                                 for receiving a response
                                                                 from the backend.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: requestTimeout
                                                                   must be at least
                                                                   1ms
@@ -1955,12 +2183,9 @@ spec:
                                                                 Deadline for establishing a connection to
                                                                 the destination.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: connectTimeout
                                                                   must be at least
                                                                   100ms
@@ -1976,12 +2201,9 @@ spec:
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: interval
                                                                       must be at least
                                                                       1 second
@@ -2000,12 +2222,9 @@ spec:
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: time
                                                                       must be at least
                                                                       1 second
@@ -2035,24 +2254,52 @@ spec:
                                                               type: array
                                                             caCertificateRefs:
                                                               description: |-
-                                                                CA certificate `ConfigMap` to use to
-                                                                verify the server certificate.
-                                                                If unset, the system's trusted certificates are used.
+                                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                                key is required. If unset, the system's trusted certificates are used.
                                                               items:
                                                                 description: |-
-                                                                  LocalObjectReference contains enough information to let you locate the
-                                                                  referenced object inside the same namespace.
+                                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                                  An omitted kind defaults to ConfigMap.
                                                                 properties:
-                                                                  name:
-                                                                    default: ""
-                                                                    description: Name
-                                                                      of the referent
+                                                                  kind:
+                                                                    default: ConfigMap
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source. Omitted
+                                                                      defaults to
+                                                                      ConfigMap.
+                                                                    enum:
+                                                                    - ConfigMap
+                                                                    - Secret
                                                                     type: string
+                                                                  name:
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    type: string
+                                                                required:
+                                                                - name
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
                                                               maxItems: 1
                                                               type: array
                                                               x-kubernetes-list-type: atomic
+                                                            certificateSource:
+                                                              default: Inline
+                                                              description: Source
+                                                                for the gateway's
+                                                                client identity and
+                                                                trust roots (`Inline`
+                                                                default, or `SPIFFE`).
+                                                              enum:
+                                                              - Inline
+                                                              - SPIFFE
+                                                              type: string
                                                             insecureSkipVerify:
                                                               description: |-
                                                                 Originates TLS but skips verification of the backend's certificate
@@ -2169,6 +2416,16 @@ spec:
                                                             rule: 'has(self.insecureSkipVerify)
                                                               ? !has(self.verifySubjectAltNames)
                                                               : true'
+                                                          - message: certificateSource
+                                                              SPIFFE may not be combined
+                                                              with mtlsCertificateRef,
+                                                              caCertificateRefs, or
+                                                              insecureSkipVerify
+                                                            rule: '!has(self.certificateSource)
+                                                              || self.certificateSource
+                                                              != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                                              && !has(self.caCertificateRefs)
+                                                              && !has(self.insecureSkipVerify))'
                                                           - message: at most one of
                                                               the fields in [verifySubjectAltNames
                                                               insecureSkipVerify]
@@ -2182,8 +2439,8 @@ spec:
                                                           properties:
                                                             backendRef:
                                                               description: |-
-                                                                Proxy server to reach.
-                                                                Supported types: `Service` and `Backend`.
+                                                                `backendRef` selects a backend for this policy.
+                                                                Mutually exclusive with `url`.
                                                               properties:
                                                                 group:
                                                                   default: ""
@@ -2249,9 +2506,38 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                          required:
-                                                          - backendRef
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
+                                                            url:
+                                                              description: |-
+                                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                                Mutually exclusive with `backendRef`.
+                                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                                will not apply Service policies or load balancing.
+                                                              maxLength: 1024
+                                                              minLength: 1
+                                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                              type: string
                                                           type: object
+                                                          x-kubernetes-validations:
+                                                          - message: exactly one of
+                                                              the fields in [backendRef
+                                                              url] must be set
+                                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                              == 1'
+                                                          - message: url must not
+                                                              include a path for backend
+                                                              tunnel
+                                                            rule: '!has(self.url)
+                                                              || self.url.matches(''^https?://[^/?#]+$'')'
                                                       type: object
                                                       x-kubernetes-validations:
                                                       - message: at least one of the
@@ -2269,10 +2555,12 @@ spec:
                                                       default: Mask
                                                       description: |-
                                                         The action to take if a regex pattern is matched in a request or response.
-                                                        This setting applies only to request matches. `PromptguardResponse`
-                                                        matches are always masked by default.
+                                                        The action applies to request and response matches alike. Note that
+                                                        `Mask` is not applied to streamed responses: matched content in a
+                                                        streamed response is passed through unmodified.
                                                         Defaults to `Mask`.
                                                       enum:
+                                                      - Audit
                                                       - Mask
                                                       - Reject
                                                       type: string
@@ -2331,10 +2619,42 @@ spec:
                                                       be set
                                                     rule: '[has(self.message),has(self.statusCode)].filter(x,x==true).size()
                                                       >= 1'
+                                                scope:
+                                                  description: |-
+                                                    Which parts of the request this guard inspects. When unset, defaults to
+                                                    `SystemPrompt` and `Messages`. Tool call inputs and outputs are not
+                                                    inspected unless `ToolInput`/`ToolOutput` are listed explicitly.
+                                                    In APIs that send tool arguments as opaque JSON, such as Completions, the
+                                                    arguments are masked as a single string, meaning a prompt guard has the
+                                                    potential to rewrite the arguments into invalid JSON.
+                                                  items:
+                                                    description: Which category of
+                                                      request content a prompt guard
+                                                      inspects.
+                                                    enum:
+                                                    - Messages
+                                                    - SystemPrompt
+                                                    - ToolInput
+                                                    - ToolOutput
+                                                    type: string
+                                                  maxItems: 4
+                                                  minItems: 1
+                                                  type: array
+                                                  x-kubernetes-list-type: set
                                                 webhook:
                                                   description: Webhook that receives
                                                     requests for prompt guarding.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether the webhook's verdict is enforced or only observed.
+                                                        `Reject` (the default) enforces it; `Audit` records the would-be action
+                                                        without blocking or masking.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     backendRef:
                                                       description: |-
                                                         Webhook server to reach.
@@ -2466,6 +2786,15 @@ spec:
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
+                                              - message: 'scope: only regex and bedrockGuardrails
+                                                  guards support a non-default scope;
+                                                  other guard kinds always inspect
+                                                  the default (SystemPrompt + Messages)'
+                                                rule: '!has(self.scope) || has(self.regex)
+                                                  || has(self.bedrockGuardrails) ||
+                                                  (self.scope.size() == 2 && ''SystemPrompt''
+                                                  in self.scope && ''Messages'' in
+                                                  self.scope)'
                                               - message: exactly one of the fields
                                                   in [regex webhook openAIModeration
                                                   bedrockGuardrails googleModelArmor]
@@ -2487,6 +2816,19 @@ spec:
                                                     AWS Bedrock Guardrails settings for prompt
                                                     guarding.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether the guardrail's verdict is enforced or only
+                                                        observed. `Reject` (the default) enforces the guardrail: a blocked
+                                                        assessment rejects the request/response and an anonymized assessment masks
+                                                        the matched content. `Audit` runs the guardrail in observe mode: it is
+                                                        invoked and its assessment recorded (metrics + structured log), but the
+                                                        request/response is never blocked or masked.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     identifier:
                                                       description: Identifier of the
                                                         Guardrail policy to use for
@@ -2802,12 +3144,9 @@ spec:
                                                                 for receiving a response
                                                                 from the backend.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: requestTimeout
                                                                   must be at least
                                                                   1ms
@@ -2834,12 +3173,9 @@ spec:
                                                                 Deadline for establishing a connection to
                                                                 the destination.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: connectTimeout
                                                                   must be at least
                                                                   100ms
@@ -2855,12 +3191,9 @@ spec:
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: interval
                                                                       must be at least
                                                                       1 second
@@ -2879,12 +3212,9 @@ spec:
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: time
                                                                       must be at least
                                                                       1 second
@@ -2914,24 +3244,52 @@ spec:
                                                               type: array
                                                             caCertificateRefs:
                                                               description: |-
-                                                                CA certificate `ConfigMap` to use to
-                                                                verify the server certificate.
-                                                                If unset, the system's trusted certificates are used.
+                                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                                key is required. If unset, the system's trusted certificates are used.
                                                               items:
                                                                 description: |-
-                                                                  LocalObjectReference contains enough information to let you locate the
-                                                                  referenced object inside the same namespace.
+                                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                                  An omitted kind defaults to ConfigMap.
                                                                 properties:
-                                                                  name:
-                                                                    default: ""
-                                                                    description: Name
-                                                                      of the referent
+                                                                  kind:
+                                                                    default: ConfigMap
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source. Omitted
+                                                                      defaults to
+                                                                      ConfigMap.
+                                                                    enum:
+                                                                    - ConfigMap
+                                                                    - Secret
                                                                     type: string
+                                                                  name:
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    type: string
+                                                                required:
+                                                                - name
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
                                                               maxItems: 1
                                                               type: array
                                                               x-kubernetes-list-type: atomic
+                                                            certificateSource:
+                                                              default: Inline
+                                                              description: Source
+                                                                for the gateway's
+                                                                client identity and
+                                                                trust roots (`Inline`
+                                                                default, or `SPIFFE`).
+                                                              enum:
+                                                              - Inline
+                                                              - SPIFFE
+                                                              type: string
                                                             insecureSkipVerify:
                                                               description: |-
                                                                 Originates TLS but skips verification of the backend's certificate
@@ -3048,6 +3406,16 @@ spec:
                                                             rule: 'has(self.insecureSkipVerify)
                                                               ? !has(self.verifySubjectAltNames)
                                                               : true'
+                                                          - message: certificateSource
+                                                              SPIFFE may not be combined
+                                                              with mtlsCertificateRef,
+                                                              caCertificateRefs, or
+                                                              insecureSkipVerify
+                                                            rule: '!has(self.certificateSource)
+                                                              || self.certificateSource
+                                                              != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                                              && !has(self.caCertificateRefs)
+                                                              && !has(self.insecureSkipVerify))'
                                                           - message: at most one of
                                                               the fields in [verifySubjectAltNames
                                                               insecureSkipVerify]
@@ -3061,8 +3429,8 @@ spec:
                                                           properties:
                                                             backendRef:
                                                               description: |-
-                                                                Proxy server to reach.
-                                                                Supported types: `Service` and `Backend`.
+                                                                `backendRef` selects a backend for this policy.
+                                                                Mutually exclusive with `url`.
                                                               properties:
                                                                 group:
                                                                   default: ""
@@ -3128,9 +3496,38 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                          required:
-                                                          - backendRef
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
+                                                            url:
+                                                              description: |-
+                                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                                Mutually exclusive with `backendRef`.
+                                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                                will not apply Service policies or load balancing.
+                                                              maxLength: 1024
+                                                              minLength: 1
+                                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                              type: string
                                                           type: object
+                                                          x-kubernetes-validations:
+                                                          - message: exactly one of
+                                                              the fields in [backendRef
+                                                              url] must be set
+                                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                              == 1'
+                                                          - message: url must not
+                                                              include a path for backend
+                                                              tunnel
+                                                            rule: '!has(self.url)
+                                                              || self.url.matches(''^https?://[^/?#]+$'')'
                                                       type: object
                                                       x-kubernetes-validations:
                                                       - message: at least one of the
@@ -3161,6 +3558,16 @@ spec:
                                                   description: Google Model Armor
                                                     settings for prompt guarding.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether flagged content is rejected or only observed.
+                                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                                        would-be rejection without blocking.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     location:
                                                       default: us-central1
                                                       description: |-
@@ -3284,12 +3691,9 @@ spec:
                                                                 for receiving a response
                                                                 from the backend.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: requestTimeout
                                                                   must be at least
                                                                   1ms
@@ -3316,12 +3720,9 @@ spec:
                                                                 Deadline for establishing a connection to
                                                                 the destination.
                                                               maxLength: 32
+                                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                               type: string
                                                               x-kubernetes-validations:
-                                                              - message: invalid duration
-                                                                  value
-                                                                rule: matches(self,
-                                                                  '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                               - message: connectTimeout
                                                                   must be at least
                                                                   100ms
@@ -3337,12 +3738,9 @@ spec:
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: interval
                                                                       must be at least
                                                                       1 second
@@ -3361,12 +3759,9 @@ spec:
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
                                                                   maxLength: 32
+                                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                                   type: string
                                                                   x-kubernetes-validations:
-                                                                  - message: invalid
-                                                                      duration value
-                                                                    rule: matches(self,
-                                                                      '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                                   - message: time
                                                                       must be at least
                                                                       1 second
@@ -3396,24 +3791,52 @@ spec:
                                                               type: array
                                                             caCertificateRefs:
                                                               description: |-
-                                                                CA certificate `ConfigMap` to use to
-                                                                verify the server certificate.
-                                                                If unset, the system's trusted certificates are used.
+                                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                                key is required. If unset, the system's trusted certificates are used.
                                                               items:
                                                                 description: |-
-                                                                  LocalObjectReference contains enough information to let you locate the
-                                                                  referenced object inside the same namespace.
+                                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                                  An omitted kind defaults to ConfigMap.
                                                                 properties:
-                                                                  name:
-                                                                    default: ""
-                                                                    description: Name
-                                                                      of the referent
+                                                                  kind:
+                                                                    default: ConfigMap
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source. Omitted
+                                                                      defaults to
+                                                                      ConfigMap.
+                                                                    enum:
+                                                                    - ConfigMap
+                                                                    - Secret
                                                                     type: string
+                                                                  name:
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      CA certificate
+                                                                      source.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    type: string
+                                                                required:
+                                                                - name
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
                                                               maxItems: 1
                                                               type: array
                                                               x-kubernetes-list-type: atomic
+                                                            certificateSource:
+                                                              default: Inline
+                                                              description: Source
+                                                                for the gateway's
+                                                                client identity and
+                                                                trust roots (`Inline`
+                                                                default, or `SPIFFE`).
+                                                              enum:
+                                                              - Inline
+                                                              - SPIFFE
+                                                              type: string
                                                             insecureSkipVerify:
                                                               description: |-
                                                                 Originates TLS but skips verification of the backend's certificate
@@ -3530,6 +3953,16 @@ spec:
                                                             rule: 'has(self.insecureSkipVerify)
                                                               ? !has(self.verifySubjectAltNames)
                                                               : true'
+                                                          - message: certificateSource
+                                                              SPIFFE may not be combined
+                                                              with mtlsCertificateRef,
+                                                              caCertificateRefs, or
+                                                              insecureSkipVerify
+                                                            rule: '!has(self.certificateSource)
+                                                              || self.certificateSource
+                                                              != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                                              && !has(self.caCertificateRefs)
+                                                              && !has(self.insecureSkipVerify))'
                                                           - message: at most one of
                                                               the fields in [verifySubjectAltNames
                                                               insecureSkipVerify]
@@ -3543,8 +3976,8 @@ spec:
                                                           properties:
                                                             backendRef:
                                                               description: |-
-                                                                Proxy server to reach.
-                                                                Supported types: `Service` and `Backend`.
+                                                                `backendRef` selects a backend for this policy.
+                                                                Mutually exclusive with `url`.
                                                               properties:
                                                                 group:
                                                                   default: ""
@@ -3610,9 +4043,38 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                          required:
-                                                          - backendRef
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
+                                                            url:
+                                                              description: |-
+                                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                                Mutually exclusive with `backendRef`.
+                                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                                will not apply Service policies or load balancing.
+                                                              maxLength: 1024
+                                                              minLength: 1
+                                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                              type: string
                                                           type: object
+                                                          x-kubernetes-validations:
+                                                          - message: exactly one of
+                                                              the fields in [backendRef
+                                                              url] must be set
+                                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                              == 1'
+                                                          - message: url must not
+                                                              include a path for backend
+                                                              tunnel
+                                                            rule: '!has(self.url)
+                                                              || self.url.matches(''^https?://[^/?#]+$'')'
                                                       type: object
                                                       x-kubernetes-validations:
                                                       - message: at least one of the
@@ -3645,10 +4107,12 @@ spec:
                                                       default: Mask
                                                       description: |-
                                                         The action to take if a regex pattern is matched in a request or response.
-                                                        This setting applies only to request matches. `PromptguardResponse`
-                                                        matches are always masked by default.
+                                                        The action applies to request and response matches alike. Note that
+                                                        `Mask` is not applied to streamed responses: matched content in a
+                                                        streamed response is passed through unmodified.
                                                         Defaults to `Mask`.
                                                       enum:
+                                                      - Audit
                                                       - Mask
                                                       - Reject
                                                       type: string
@@ -3711,6 +4175,16 @@ spec:
                                                   description: Webhook that receives
                                                     responses for prompt guarding.
                                                   properties:
+                                                    action:
+                                                      default: Reject
+                                                      description: |-
+                                                        Action controls whether the webhook's verdict is enforced or only observed.
+                                                        `Reject` (the default) enforces it; `Audit` records the would-be action
+                                                        without blocking or masking.
+                                                      enum:
+                                                      - Audit
+                                                      - Reject
+                                                      type: string
                                                     backendRef:
                                                       description: |-
                                                         Webhook server to reach.
@@ -3873,6 +4347,8 @@ spec:
                                           - Completions
                                           - Detect
                                           - Embeddings
+                                          - GeminiCountTokens
+                                          - GenerateContent
                                           - Messages
                                           - Models
                                           - Passthrough
@@ -3920,10 +4396,10 @@ spec:
                                     type: object
                                     x-kubernetes-validations:
                                     - message: at least one of the fields in [defaults
-                                        modelAliases overrides prompt promptCaching
-                                        promptGuard routes transformations] must be
-                                        set
-                                      rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
+                                        finalTransformations modelAliases overrides
+                                        prompt promptCaching promptGuard routes transformations]
+                                        must be set
+                                      rule: '[has(self.defaults),has(self.finalTransformations),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                                         >= 1'
                                   auth:
                                     description: Settings for managing authentication
@@ -4068,20 +4544,30 @@ spec:
                                           the backend.
                                         properties:
                                           managedIdentity:
-                                            description: Managed identity authentication
-                                              settings.
+                                            description: |-
+                                              Managed identity authentication settings. Leave this object empty to use
+                                              the system-assigned identity. To use a user-assigned identity, set one of
+                                              `clientId`, `objectId`, or `resourceId`.
                                             properties:
                                               clientId:
+                                                description: Client ID of the user-assigned
+                                                  managed identity.
                                                 type: string
                                               objectId:
+                                                description: Object ID of the user-assigned
+                                                  managed identity.
                                                 type: string
                                               resourceId:
+                                                description: Resource ID of the user-assigned
+                                                  managed identity.
                                                 type: string
-                                            required:
-                                            - clientId
-                                            - objectId
-                                            - resourceId
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: at most one of the fields in
+                                                [clientId objectId resourceId] may
+                                                be set
+                                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                                <= 1'
                                           secretRef:
                                             description: |-
                                               Credential source for Azure credentials, defaulting to a Kubernetes
@@ -4240,6 +4726,14 @@ spec:
                                         description: Cross App Access (Identity Assertion
                                           / ID-JAG) authentication.
                                         properties:
+                                          accessTokenScopes:
+                                            description: |-
+                                              Scopes requested when exchanging the ID-JAG for an access token.
+                                              When omitted, defaults to Scopes. Set to an empty list to omit scope.
+                                            items:
+                                              type: string
+                                            maxItems: 64
+                                            type: array
                                           audience:
                                             description: Identifier of the resource
                                               authorization server. The issued ID-JAG
@@ -4256,7 +4750,13 @@ spec:
                                                     description: TTL used when the
                                                       token endpoint omits expires_in.
                                                       Default 300s.
+                                                    maxLength: 32
+                                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                     type: string
+                                                    x-kubernetes-validations:
+                                                    - message: defaultTtl must be
+                                                        at least 1 second
+                                                      rule: duration(self) >= duration('1s')
                                                   maxEntries:
                                                     description: Default 8192; 0 disables
                                                       the cache.
@@ -4270,7 +4770,9 @@ spec:
                                               exchange.
                                             properties:
                                               backendRef:
-                                                description: Token endpoint backend.
+                                                description: |-
+                                                  `backendRef` selects a backend for this policy.
+                                                  Mutually exclusive with `url`.
                                                 properties:
                                                   group:
                                                     default: ""
@@ -4543,16 +5045,37 @@ spec:
                                                   "/".
                                                 pattern: ^/
                                                 type: string
+                                              url:
+                                                description: |-
+                                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                                  Mutually exclusive with `backendRef`.
+                                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                  will not apply Service policies or load balancing.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                type: string
                                             required:
-                                            - backendRef
                                             - clientAuth
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: path may not be set when url
+                                                is set
+                                              rule: 'has(self.url) ? !has(self.path)
+                                                : true'
+                                            - message: exactly one of the fields in
+                                                [backendRef url] must be set
+                                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                == 1'
                                           resourceAuthorizationServer:
                                             description: Resource authorization server,
                                               used for the RFC 7523 jwt-bearer exchange.
                                             properties:
                                               backendRef:
-                                                description: Token endpoint backend.
+                                                description: |-
+                                                  `backendRef` selects a backend for this policy.
+                                                  Mutually exclusive with `url`.
                                                 properties:
                                                   group:
                                                     default: ""
@@ -4825,10 +5348,29 @@ spec:
                                                   "/".
                                                 pattern: ^/
                                                 type: string
+                                              url:
+                                                description: |-
+                                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                                  Mutually exclusive with `backendRef`.
+                                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                  will not apply Service policies or load balancing.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                                type: string
                                             required:
-                                            - backendRef
                                             - clientAuth
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: path may not be set when url
+                                                is set
+                                              rule: 'has(self.url) ? !has(self.path)
+                                                : true'
+                                            - message: exactly one of the fields in
+                                                [backendRef url] must be set
+                                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                                == 1'
                                           resources:
                                             description: Resources sent to the token
                                               endpoint.
@@ -4838,8 +5380,8 @@ spec:
                                             minItems: 1
                                             type: array
                                           scopes:
-                                            description: Scopes sent to the token
-                                              endpoint.
+                                            description: Scopes requested when obtaining
+                                              the ID-JAG from the identity provider.
                                             items:
                                               type: string
                                             maxItems: 64
@@ -4905,7 +5447,17 @@ spec:
                                                     expression] must be set
                                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                     == 1'
+                                              tokenType:
+                                                description: OAuth RFC 8693 subject
+                                                  token type. Defaults to IdToken
+                                                type: string
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: tokenType IdJag is not supported
+                                                by crossAppAccess
+                                              rule: '!has(self.tokenType) || (self.tokenType
+                                                != ''IdJag'' && self.tokenType !=
+                                                ''urn:ietf:params:oauth:token-type:id-jag'')'
                                         required:
                                         - audience
                                         - identityProvider
@@ -4979,6 +5531,127 @@ spec:
                                         - message: audience is only valid with IdToken
                                           rule: 'has(self.audience) ? self.type ==
                                             ''IdToken'' : true'
+                                      jwtSign:
+                                        description: |-
+                                          Signs a short-lived JWT with a private key on each request and sends it
+                                          to the backend, for upstreams that require per-request keypair JWTs
+                                          (e.g. the Snowflake SQL API) rather than a static credential.
+                                        properties:
+                                          alg:
+                                            description: JWS signing algorithm. Defaults
+                                              to RS256.
+                                            enum:
+                                            - ES256
+                                            - ES384
+                                            - PS256
+                                            - RS256
+                                            - RS384
+                                            - RS512
+                                            type: string
+                                          claims:
+                                            additionalProperties:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            description: |-
+                                              Static claims added to every token (e.g. iss, sub, aud). Values may be
+                                              any JSON value (e.g. a string, number, bool, or array). iat, exp, and
+                                              nbf are reserved for the signer and cannot be configured here; the
+                                              controller rejects them at translation time.
+                                            type: object
+                                          kid:
+                                            description: Optional JWS key ID header.
+                                            type: string
+                                          location:
+                                            description: |-
+                                              Where the signed token is written on the backend request.
+                                              Defaults to the Authorization header with a "Bearer " prefix.
+                                            properties:
+                                              cookie:
+                                                properties:
+                                                  name:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              header:
+                                                properties:
+                                                  name:
+                                                    description: Name of an HTTP header.
+                                                      HTTP/2 pseudo-headers (names
+                                                      beginning with `:`) are not
+                                                      supported
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                    type: string
+                                                  prefix:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              queryParameter:
+                                                properties:
+                                                  name:
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: exactly one of the fields in
+                                                [header queryParameter cookie] must
+                                                be set
+                                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                                == 1'
+                                          signingKeyRef:
+                                            description: Secret providing the `signingKey`
+                                              key with a PEM-encoded RSA or EC private
+                                              key.
+                                            properties:
+                                              group:
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
+                                                type: string
+                                              kind:
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
+                                                type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  credential
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                            x-kubernetes-validations:
+                                            - message: custom credential refs must
+                                                set both group and kind
+                                              rule: '(!has(self.group) || size(self.group)
+                                                == 0) ? (!has(self.kind) || size(self.kind)
+                                                == 0 || self.kind == ''Secret'') :
+                                                (has(self.kind) && size(self.kind)
+                                                > 0)'
+                                          ttl:
+                                            description: Token lifetime used for exp.
+                                              Defaults to 300s.
+                                            maxLength: 32
+                                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: ttl must be at least 1 second
+                                              rule: duration(self) >= duration('1s')
+                                        required:
+                                        - signingKeyRef
+                                        type: object
                                       key:
                                         description: |-
                                           Inline key to use as the value of the
@@ -5140,7 +5813,9 @@ spec:
                                             minItems: 1
                                             type: array
                                           backendRef:
-                                            description: RFC 8693 token endpoint backend.
+                                            description: |-
+                                              `backendRef` selects a backend for this policy.
+                                              Mutually exclusive with `url`.
                                             properties:
                                               group:
                                                 default: ""
@@ -5201,7 +5876,13 @@ spec:
                                                     description: TTL used when the
                                                       token endpoint omits expires_in.
                                                       Default 300s.
+                                                    maxLength: 32
+                                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                     type: string
+                                                    x-kubernetes-validations:
+                                                    - message: defaultTtl must be
+                                                        at least 1 second
+                                                      rule: duration(self) >= duration('1s')
                                                   maxEntries:
                                                     description: Default 8192; 0 disables
                                                       the cache.
@@ -5566,8 +6247,17 @@ spec:
                                                   are supported for subject tokens.
                                                 type: string
                                             type: object
-                                        required:
-                                        - backendRef
+                                          url:
+                                            description: |-
+                                              `url` directly specifies the HTTP(S) endpoint for this policy.
+                                              When the scheme is `https`, backend TLS is enabled automatically.
+                                              Mutually exclusive with `backendRef`.
+                                              URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                              will not apply Service policies or load balancing.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                            type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: actorToken is only valid with TokenExchange
@@ -5583,6 +6273,14 @@ spec:
                                             supported by crossAppAccess
                                           rule: '!has(self.requestedTokenType) ||
                                             self.requestedTokenType != ''IdJag'''
+                                        - message: path may not be set when url is
+                                            set
+                                          rule: 'has(self.url) ? !has(self.path) :
+                                            true'
+                                        - message: exactly one of the fields in [backendRef
+                                            url] must be set
+                                          rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                            == 1'
                                       passthrough:
                                         description: |-
                                           Reuses a client token already validated by another policy. Those policies
@@ -5631,13 +6329,14 @@ spec:
                                     type: object
                                     x-kubernetes-validations:
                                     - message: must specify credentials, or at most
-                                        one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                                        one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess/jwtSign
                                         (credentials may be combined with a primary
                                         auth kind)
                                       rule: has(self.credentials) || has(self.key)
                                         || has(self.secretRef) || has(self.passthrough)
                                         || has(self.aws) || has(self.azure) || has(self.gcp)
                                         || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                                        || has(self.jwtSign)
                                     - message: location may only be set for key, secretRef,
                                         or passthrough auth
                                       rule: 'has(self.location) ? has(self.key) ||
@@ -5645,8 +6344,8 @@ spec:
                                         : true'
                                     - message: at most one of the fields in [key secretRef
                                         passthrough aws azure gcp oauthTokenExchange
-                                        crossAppAccess] may be set
-                                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                                        crossAppAccess jwtSign] may be set
+                                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess),has(self.jwtSign)].filter(x,x==true).size()
                                         <= 1'
                                   health:
                                     description: Settings for passive and active health
@@ -5674,12 +6373,11 @@ spec:
                                               rather than failing entirely.
                                               If unset, defaults to `3s`.
                                             maxLength: 32
+                                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: invalid duration value
-                                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
-                                            - message: evictionDuration must be at
-                                                least 1 second
+                                            - message: duration must be at least 1
+                                                second
                                               rule: duration(self) >= duration('1s')
                                           healthThreshold:
                                             description: |-
@@ -5724,10 +6422,9 @@ spec:
                                         description: Deadline for receiving a response
                                           from the backend.
                                         maxLength: 32
+                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: invalid duration value
-                                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                         - message: requestTimeout must be at least
                                             1ms
                                           rule: duration(self) >= duration('1ms')
@@ -5751,10 +6448,9 @@ spec:
                                           Deadline for establishing a connection to
                                           the destination.
                                         maxLength: 32
+                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: invalid duration value
-                                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                         - message: connectTimeout must be at least
                                             100ms
                                           rule: duration(self) >= duration('100ms')
@@ -5768,10 +6464,9 @@ spec:
                                               Time between keepalive probes.
                                               If unset, this defaults to 180s.
                                             maxLength: 32
+                                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: invalid duration value
-                                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                             - message: interval must be at least 1
                                                 second
                                               rule: duration(self) >= duration('1s')
@@ -5788,10 +6483,9 @@ spec:
                                               Time a connection needs to be idle before keepalive probes start being sent.
                                               If unset, this defaults to 180s.
                                             maxLength: 32
+                                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                             type: string
                                             x-kubernetes-validations:
-                                            - message: invalid duration value
-                                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                             - message: time must be at least 1 second
                                               rule: duration(self) >= duration('1s')
                                         type: object
@@ -5818,23 +6512,45 @@ spec:
                                         type: array
                                       caCertificateRefs:
                                         description: |-
-                                          CA certificate `ConfigMap` to use to
-                                          verify the server certificate.
-                                          If unset, the system's trusted certificates are used.
+                                          CA certificate source to use to verify the server certificate. Omitted kind
+                                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                          key is required. If unset, the system's trusted certificates are used.
                                         items:
                                           description: |-
-                                            LocalObjectReference contains enough information to let you locate the
-                                            referenced object inside the same namespace.
+                                            LocalCACertificateRef references a same-namespace CA certificate source.
+                                            An omitted kind defaults to ConfigMap.
                                           properties:
-                                            name:
-                                              default: ""
-                                              description: Name of the referent
+                                            kind:
+                                              default: ConfigMap
+                                              description: Kind of the referenced
+                                                CA certificate source. Omitted defaults
+                                                to ConfigMap.
+                                              enum:
+                                              - ConfigMap
+                                              - Secret
                                               type: string
+                                            name:
+                                              description: Name of the referenced
+                                                CA certificate source.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         maxItems: 1
                                         type: array
                                         x-kubernetes-list-type: atomic
+                                      certificateSource:
+                                        default: Inline
+                                        description: Source for the gateway's client
+                                          identity and trust roots (`Inline` default,
+                                          or `SPIFFE`).
+                                        enum:
+                                        - Inline
+                                        - SPIFFE
+                                        type: string
                                       insecureSkipVerify:
                                         description: |-
                                           Originates TLS but skips verification of the backend's certificate
@@ -5933,6 +6649,12 @@ spec:
                                         may not be set together
                                       rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                         : true'
+                                    - message: certificateSource SPIFFE may not be
+                                        combined with mtlsCertificateRef, caCertificateRefs,
+                                        or insecureSkipVerify
+                                      rule: '!has(self.certificateSource) || self.certificateSource
+                                        != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                        && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                     - message: at most one of the fields in [verifySubjectAltNames
                                         insecureSkipVerify] may be set
                                       rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -6203,8 +6925,8 @@ spec:
                                     properties:
                                       backendRef:
                                         description: |-
-                                          Proxy server to reach.
-                                          Supported types: `Service` and `Backend`.
+                                          `backendRef` selects a backend for this policy.
+                                          Mutually exclusive with `url`.
                                         properties:
                                           group:
                                             default: ""
@@ -6252,9 +6974,35 @@ spec:
                                         - message: Must have port for Service reference
                                           rule: '(size(self.group) == 0 && self.kind
                                             == ''Service'') ? has(self.port) : true'
-                                    required:
-                                    - backendRef
+                                      mode:
+                                        default: Auto
+                                        description: |-
+                                          How requests are sent through the proxy.
+                                          Defaults to `Auto`.
+                                        enum:
+                                        - Auto
+                                        - Connect
+                                        type: string
+                                      url:
+                                        description: |-
+                                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                                          When the scheme is `https`, backend TLS is enabled automatically.
+                                          Mutually exclusive with `backendRef`.
+                                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                          will not apply Service policies or load balancing.
+                                        maxLength: 1024
+                                        minLength: 1
+                                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                        type: string
                                     type: object
+                                    x-kubernetes-validations:
+                                    - message: exactly one of the fields in [backendRef
+                                        url] must be set
+                                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                        == 1'
+                                    - message: url must not include a path for backend
+                                        tunnel
+                                      rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                 type: object
                                 x-kubernetes-validations:
                                 - message: at least one of the fields in [ai auth
@@ -6570,6 +7318,13 @@ spec:
                             maxLength: 256
                             minLength: 1
                             type: string
+                          providerOverride:
+                            description: |-
+                              Provider identity used for cost-catalog lookup and telemetry.
+                              Defaults to "custom" when unset.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
                         required:
                         - formats
                         type: object
@@ -6611,6 +7366,52 @@ spec:
                             maxLength: 256
                             minLength: 1
                             type: string
+                          moderation:
+                            description: |-
+                              Inline moderation configuration to inject into OpenAI chat completions
+                              and responses requests.
+                              If unset, the OpenAI inline moderation parameter is not injected.
+                            properties:
+                              model:
+                                default: omni-moderation-latest
+                                description: |-
+                                  The moderation model to use, such as `omni-moderation-latest`.
+                                  Defaults to `omni-moderation-latest` if not specified.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              policy:
+                                description: Policies to apply to request input and
+                                  generated output.
+                                properties:
+                                  input:
+                                    description: Policy for request input moderation.
+                                    properties:
+                                      mode:
+                                        description: Mode controls whether moderation
+                                          only returns scores or blocks flagged content.
+                                        enum:
+                                        - Block
+                                        - Score
+                                        type: string
+                                    required:
+                                    - mode
+                                    type: object
+                                  output:
+                                    description: Policy for generated output moderation.
+                                    properties:
+                                      mode:
+                                        description: Mode controls whether moderation
+                                          only returns scores or blocks flagged content.
+                                        enum:
+                                        - Block
+                                        - Score
+                                        type: string
+                                    required:
+                                    - mode
+                                    type: object
+                                type: object
+                            type: object
                         type: object
                       path:
                         description: |-
@@ -7056,20 +7857,30 @@ spec:
                                         the backend.
                                       properties:
                                         managedIdentity:
-                                          description: Managed identity authentication
-                                            settings.
+                                          description: |-
+                                            Managed identity authentication settings. Leave this object empty to use
+                                            the system-assigned identity. To use a user-assigned identity, set one of
+                                            `clientId`, `objectId`, or `resourceId`.
                                           properties:
                                             clientId:
+                                              description: Client ID of the user-assigned
+                                                managed identity.
                                               type: string
                                             objectId:
+                                              description: Object ID of the user-assigned
+                                                managed identity.
                                               type: string
                                             resourceId:
+                                              description: Resource ID of the user-assigned
+                                                managed identity.
                                               type: string
-                                          required:
-                                          - clientId
-                                          - objectId
-                                          - resourceId
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: at most one of the fields in
+                                              [clientId objectId resourceId] may be
+                                              set
+                                            rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                              <= 1'
                                         secretRef:
                                           description: |-
                                             Credential source for Azure credentials, defaulting to a Kubernetes
@@ -7226,6 +8037,14 @@ spec:
                                       description: Cross App Access (Identity Assertion
                                         / ID-JAG) authentication.
                                       properties:
+                                        accessTokenScopes:
+                                          description: |-
+                                            Scopes requested when exchanging the ID-JAG for an access token.
+                                            When omitted, defaults to Scopes. Set to an empty list to omit scope.
+                                          items:
+                                            type: string
+                                          maxItems: 64
+                                          type: array
                                         audience:
                                           description: Identifier of the resource
                                             authorization server. The issued ID-JAG
@@ -7242,7 +8061,13 @@ spec:
                                                   description: TTL used when the token
                                                     endpoint omits expires_in. Default
                                                     300s.
+                                                  maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
+                                                  x-kubernetes-validations:
+                                                  - message: defaultTtl must be at
+                                                      least 1 second
+                                                    rule: duration(self) >= duration('1s')
                                                 maxEntries:
                                                   description: Default 8192; 0 disables
                                                     the cache.
@@ -7255,7 +8080,9 @@ spec:
                                             server, used for the RFC 8693 ID-JAG exchange.
                                           properties:
                                             backendRef:
-                                              description: Token endpoint backend.
+                                              description: |-
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -7520,16 +8347,37 @@ spec:
                                                 to "/". Must start with "/".
                                               pattern: ^/
                                               type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           required:
-                                          - backendRef
                                           - clientAuth
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: path may not be set when url
+                                              is set
+                                            rule: 'has(self.url) ? !has(self.path)
+                                              : true'
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
                                         resourceAuthorizationServer:
                                           description: Resource authorization server,
                                             used for the RFC 7523 jwt-bearer exchange.
                                           properties:
                                             backendRef:
-                                              description: Token endpoint backend.
+                                              description: |-
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -7794,10 +8642,29 @@ spec:
                                                 to "/". Must start with "/".
                                               pattern: ^/
                                               type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           required:
-                                          - backendRef
                                           - clientAuth
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: path may not be set when url
+                                              is set
+                                            rule: 'has(self.url) ? !has(self.path)
+                                              : true'
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
                                         resources:
                                           description: Resources sent to the token
                                             endpoint.
@@ -7807,7 +8674,8 @@ spec:
                                           minItems: 1
                                           type: array
                                         scopes:
-                                          description: Scopes sent to the token endpoint.
+                                          description: Scopes requested when obtaining
+                                            the ID-JAG from the identity provider.
                                           items:
                                             type: string
                                           maxItems: 64
@@ -7873,7 +8741,16 @@ spec:
                                                   expression] must be set
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                   == 1'
+                                            tokenType:
+                                              description: OAuth RFC 8693 subject
+                                                token type. Defaults to IdToken
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: tokenType IdJag is not supported
+                                              by crossAppAccess
+                                            rule: '!has(self.tokenType) || (self.tokenType
+                                              != ''IdJag'' && self.tokenType != ''urn:ietf:params:oauth:token-type:id-jag'')'
                                       required:
                                       - audience
                                       - identityProvider
@@ -7946,6 +8823,125 @@ spec:
                                       - message: audience is only valid with IdToken
                                         rule: 'has(self.audience) ? self.type == ''IdToken''
                                           : true'
+                                    jwtSign:
+                                      description: |-
+                                        Signs a short-lived JWT with a private key on each request and sends it
+                                        to the backend, for upstreams that require per-request keypair JWTs
+                                        (e.g. the Snowflake SQL API) rather than a static credential.
+                                      properties:
+                                        alg:
+                                          description: JWS signing algorithm. Defaults
+                                            to RS256.
+                                          enum:
+                                          - ES256
+                                          - ES384
+                                          - PS256
+                                          - RS256
+                                          - RS384
+                                          - RS512
+                                          type: string
+                                        claims:
+                                          additionalProperties:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          description: |-
+                                            Static claims added to every token (e.g. iss, sub, aud). Values may be
+                                            any JSON value (e.g. a string, number, bool, or array). iat, exp, and
+                                            nbf are reserved for the signer and cannot be configured here; the
+                                            controller rejects them at translation time.
+                                          type: object
+                                        kid:
+                                          description: Optional JWS key ID header.
+                                          type: string
+                                        location:
+                                          description: |-
+                                            Where the signed token is written on the backend request.
+                                            Defaults to the Authorization header with a "Bearer " prefix.
+                                          properties:
+                                            cookie:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            header:
+                                              properties:
+                                                name:
+                                                  description: Name of an HTTP header.
+                                                    HTTP/2 pseudo-headers (names beginning
+                                                    with `:`) are not supported
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                  type: string
+                                                prefix:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            queryParameter:
+                                              properties:
+                                                name:
+                                                  maxLength: 256
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [header queryParameter cookie] must
+                                              be set
+                                            rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                              == 1'
+                                        signingKeyRef:
+                                          description: Secret providing the `signingKey`
+                                            key with a PEM-encoded RSA or EC private
+                                            key.
+                                          properties:
+                                            group:
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
+                                              type: string
+                                            kind:
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
+                                              type: string
+                                            name:
+                                              description: Name of the referenced
+                                                credential
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                          x-kubernetes-validations:
+                                          - message: custom credential refs must set
+                                              both group and kind
+                                            rule: '(!has(self.group) || size(self.group)
+                                              == 0) ? (!has(self.kind) || size(self.kind)
+                                              == 0 || self.kind == ''Secret'') : (has(self.kind)
+                                              && size(self.kind) > 0)'
+                                        ttl:
+                                          description: Token lifetime used for exp.
+                                            Defaults to 300s.
+                                          maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: ttl must be at least 1 second
+                                            rule: duration(self) >= duration('1s')
+                                      required:
+                                      - signingKeyRef
+                                      type: object
                                     key:
                                       description: |-
                                         Inline key to use as the value of the
@@ -8106,7 +9102,9 @@ spec:
                                           minItems: 1
                                           type: array
                                         backendRef:
-                                          description: RFC 8693 token endpoint backend.
+                                          description: |-
+                                            `backendRef` selects a backend for this policy.
+                                            Mutually exclusive with `url`.
                                           properties:
                                             group:
                                               default: ""
@@ -8164,7 +9162,13 @@ spec:
                                                   description: TTL used when the token
                                                     endpoint omits expires_in. Default
                                                     300s.
+                                                  maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
+                                                  x-kubernetes-validations:
+                                                  - message: defaultTtl must be at
+                                                      least 1 second
+                                                    rule: duration(self) >= duration('1s')
                                                 maxEntries:
                                                   description: Default 8192; 0 disables
                                                     the cache.
@@ -8522,8 +9526,17 @@ spec:
                                                 are supported for subject tokens.
                                               type: string
                                           type: object
-                                      required:
-                                      - backendRef
+                                        url:
+                                          description: |-
+                                            `url` directly specifies the HTTP(S) endpoint for this policy.
+                                            When the scheme is `https`, backend TLS is enabled automatically.
+                                            Mutually exclusive with `backendRef`.
+                                            URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                            will not apply Service policies or load balancing.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                          type: string
                                       type: object
                                       x-kubernetes-validations:
                                       - message: actorToken is only valid with TokenExchange
@@ -8538,6 +9551,12 @@ spec:
                                           supported by crossAppAccess
                                         rule: '!has(self.requestedTokenType) || self.requestedTokenType
                                           != ''IdJag'''
+                                      - message: path may not be set when url is set
+                                        rule: 'has(self.url) ? !has(self.path) : true'
+                                      - message: exactly one of the fields in [backendRef
+                                          url] must be set
+                                        rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                          == 1'
                                     passthrough:
                                       description: |-
                                         Reuses a client token already validated by another policy. Those policies
@@ -8586,21 +9605,22 @@ spec:
                                   type: object
                                   x-kubernetes-validations:
                                   - message: must specify credentials, or at most
-                                      one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                                      one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess/jwtSign
                                       (credentials may be combined with a primary
                                       auth kind)
                                     rule: has(self.credentials) || has(self.key) ||
                                       has(self.secretRef) || has(self.passthrough)
                                       || has(self.aws) || has(self.azure) || has(self.gcp)
                                       || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                                      || has(self.jwtSign)
                                   - message: location may only be set for key, secretRef,
                                       or passthrough auth
                                     rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
                                       || has(self.passthrough) : true'
                                   - message: at most one of the fields in [key secretRef
                                       passthrough aws azure gcp oauthTokenExchange
-                                      crossAppAccess] may be set
-                                    rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                                      crossAppAccess jwtSign] may be set
+                                    rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess),has(self.jwtSign)].filter(x,x==true).size()
                                       <= 1'
                                 http:
                                   description: Settings for managing HTTP requests
@@ -8610,10 +9630,9 @@ spec:
                                       description: Deadline for receiving a response
                                         from the backend.
                                       maxLength: 32
+                                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: invalid duration value
-                                        rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                       - message: requestTimeout must be at least 1ms
                                         rule: duration(self) >= duration('1ms')
                                     version:
@@ -8636,10 +9655,9 @@ spec:
                                         Deadline for establishing a connection to
                                         the destination.
                                       maxLength: 32
+                                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: invalid duration value
-                                        rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                       - message: connectTimeout must be at least 100ms
                                         rule: duration(self) >= duration('100ms')
                                     keepalive:
@@ -8652,10 +9670,9 @@ spec:
                                             Time between keepalive probes.
                                             If unset, this defaults to 180s.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: interval must be at least 1 second
                                             rule: duration(self) >= duration('1s')
                                         retries:
@@ -8671,10 +9688,9 @@ spec:
                                             Time a connection needs to be idle before keepalive probes start being sent.
                                             If unset, this defaults to 180s.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: time must be at least 1 second
                                             rule: duration(self) >= duration('1s')
                                       type: object
@@ -8701,23 +9717,45 @@ spec:
                                       type: array
                                     caCertificateRefs:
                                       description: |-
-                                        CA certificate `ConfigMap` to use to
-                                        verify the server certificate.
-                                        If unset, the system's trusted certificates are used.
+                                        CA certificate source to use to verify the server certificate. Omitted kind
+                                        and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                        key is required. If unset, the system's trusted certificates are used.
                                       items:
                                         description: |-
-                                          LocalObjectReference contains enough information to let you locate the
-                                          referenced object inside the same namespace.
+                                          LocalCACertificateRef references a same-namespace CA certificate source.
+                                          An omitted kind defaults to ConfigMap.
                                         properties:
-                                          name:
-                                            default: ""
-                                            description: Name of the referent
+                                          kind:
+                                            default: ConfigMap
+                                            description: Kind of the referenced CA
+                                              certificate source. Omitted defaults
+                                              to ConfigMap.
+                                            enum:
+                                            - ConfigMap
+                                            - Secret
                                             type: string
+                                          name:
+                                            description: Name of the referenced CA
+                                              certificate source.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       maxItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                    certificateSource:
+                                      default: Inline
+                                      description: Source for the gateway's client
+                                        identity and trust roots (`Inline` default,
+                                        or `SPIFFE`).
+                                      enum:
+                                      - Inline
+                                      - SPIFFE
+                                      type: string
                                     insecureSkipVerify:
                                       description: |-
                                         Originates TLS but skips verification of the backend's certificate
@@ -8815,6 +9853,12 @@ spec:
                                       may not be set together
                                     rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                       : true'
+                                  - message: certificateSource SPIFFE may not be combined
+                                      with mtlsCertificateRef, caCertificateRefs,
+                                      or insecureSkipVerify
+                                    rule: '!has(self.certificateSource) || self.certificateSource
+                                      != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                      && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                   - message: at most one of the fields in [verifySubjectAltNames
                                       insecureSkipVerify] may be set
                                     rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -8825,8 +9869,8 @@ spec:
                                   properties:
                                     backendRef:
                                       description: |-
-                                        Proxy server to reach.
-                                        Supported types: `Service` and `Backend`.
+                                        `backendRef` selects a backend for this policy.
+                                        Mutually exclusive with `url`.
                                       properties:
                                         group:
                                           default: ""
@@ -8873,9 +9917,35 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
-                                  required:
-                                  - backendRef
+                                    mode:
+                                      default: Auto
+                                      description: |-
+                                        How requests are sent through the proxy.
+                                        Defaults to `Auto`.
+                                      enum:
+                                      - Auto
+                                      - Connect
+                                      type: string
+                                    url:
+                                      description: |-
+                                        `url` directly specifies the HTTP(S) endpoint for this policy.
+                                        When the scheme is `https`, backend TLS is enabled automatically.
+                                        Mutually exclusive with `backendRef`.
+                                        URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                        will not apply Service policies or load balancing.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                      type: string
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: exactly one of the fields in [backendRef
+                                      url] must be set
+                                    rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                      == 1'
+                                  - message: url must not include a path for backend
+                                      tunnel
+                                    rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                               type: object
                             port:
                               description: Port number of the MCP target.
@@ -8909,15 +9979,12 @@ spec:
                           be set
                         rule: '[has(self.selector),has(self.static)].filter(x,x==true).size()
                           == 1'
-                    maxItems: 32
+                    maxItems: 128
                     minItems: 1
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
-                    x-kubernetes-validations:
-                    - message: target names must be unique
-                      rule: self.all(t1, self.exists_one(t2, t1.name == t2.name))
                 required:
                 - targets
                 type: object
@@ -8968,6 +10035,37 @@ spec:
                           required:
                           - field
                           - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                      finalTransformations:
+                        description: |-
+                          CEL transformations to compute and set fields in the request body.
+                          The expression result overwrites any existing value for that field.
+                          This has a higher priority than `overrides` if both are set for the same
+                          key.
+                          Those transformations are applied after the request is converted to the provider's format, so they can be used to set provider-specific fields.
+                        items:
+                          description: |-
+                            Maps a request JSON field to a CEL expression.
+                            The expression is evaluated against the current request body and its result
+                            is assigned to the configured field.
+                          properties:
+                            expression:
+                              description: CEL expression used to compute the field
+                                value.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                            field:
+                              description: Name of the field to set.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                          required:
+                          - expression
+                          - field
                           type: object
                         maxItems: 64
                         minItems: 1
@@ -9125,6 +10223,19 @@ spec:
                                     AWS Bedrock Guardrails settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the guardrail's verdict is enforced or only
+                                        observed. `Reject` (the default) enforces the guardrail: a blocked
+                                        assessment rejects the request/response and an anonymized assessment masks
+                                        the matched content. `Audit` runs the guardrail in observe mode: it is
+                                        invoked and its assessment recorded (metrics + structured log), but the
+                                        request/response is never blocked or masked.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     identifier:
                                       description: Identifier of the Guardrail policy
                                         to use for the backend.
@@ -9391,10 +10502,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -9418,10 +10528,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -9435,10 +10544,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -9455,10 +10563,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -9486,23 +10593,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -9603,6 +10732,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -9614,8 +10750,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -9667,9 +10803,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -9698,6 +10860,16 @@ spec:
                                   description: Google Model Armor settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether flagged content is rejected or only observed.
+                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                        would-be rejection without blocking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     location:
                                       default: us-central1
                                       description: |-
@@ -9798,10 +10970,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -9825,10 +10996,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -9842,10 +11012,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -9862,10 +11031,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -9893,23 +11061,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -10010,6 +11200,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -10021,8 +11218,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -10074,9 +11271,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -10103,6 +11326,16 @@ spec:
                                     endpoint.
                                     See https://developers.openai.com/api/reference/resources/moderations for more information.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether flagged content is rejected or only observed.
+                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                        would-be rejection without blocking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     model:
                                       description: |-
                                         Moderation model to use. For example,
@@ -10227,10 +11460,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -10254,10 +11486,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -10271,10 +11502,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -10291,10 +11521,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -10322,23 +11551,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -10439,6 +11690,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -10450,8 +11708,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -10503,9 +11761,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -10521,10 +11805,12 @@ spec:
                                       default: Mask
                                       description: |-
                                         The action to take if a regex pattern is matched in a request or response.
-                                        This setting applies only to request matches. `PromptguardResponse`
-                                        matches are always masked by default.
+                                        The action applies to request and response matches alike. Note that
+                                        `Mask` is not applied to streamed responses: matched content in a
+                                        streamed response is passed through unmodified.
                                         Defaults to `Mask`.
                                       enum:
+                                      - Audit
                                       - Mask
                                       - Reject
                                       type: string
@@ -10581,10 +11867,41 @@ spec:
                                       statusCode] must be set
                                     rule: '[has(self.message),has(self.statusCode)].filter(x,x==true).size()
                                       >= 1'
+                                scope:
+                                  description: |-
+                                    Which parts of the request this guard inspects. When unset, defaults to
+                                    `SystemPrompt` and `Messages`. Tool call inputs and outputs are not
+                                    inspected unless `ToolInput`/`ToolOutput` are listed explicitly.
+                                    In APIs that send tool arguments as opaque JSON, such as Completions, the
+                                    arguments are masked as a single string, meaning a prompt guard has the
+                                    potential to rewrite the arguments into invalid JSON.
+                                  items:
+                                    description: Which category of request content
+                                      a prompt guard inspects.
+                                    enum:
+                                    - Messages
+                                    - SystemPrompt
+                                    - ToolInput
+                                    - ToolOutput
+                                    type: string
+                                  maxItems: 4
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: set
                                 webhook:
                                   description: Webhook that receives requests for
                                     prompt guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the webhook's verdict is enforced or only observed.
+                                        `Reject` (the default) enforces it; `Audit` records the would-be action
+                                        without blocking or masking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     backendRef:
                                       description: |-
                                         Webhook server to reach.
@@ -10701,6 +12018,13 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
+                              - message: 'scope: only regex and bedrockGuardrails
+                                  guards support a non-default scope; other guard
+                                  kinds always inspect the default (SystemPrompt +
+                                  Messages)'
+                                rule: '!has(self.scope) || has(self.regex) || has(self.bedrockGuardrails)
+                                  || (self.scope.size() == 2 && ''SystemPrompt'' in
+                                  self.scope && ''Messages'' in self.scope)'
                               - message: exactly one of the fields in [regex webhook
                                   openAIModeration bedrockGuardrails googleModelArmor]
                                   must be set
@@ -10721,6 +12045,19 @@ spec:
                                     AWS Bedrock Guardrails settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the guardrail's verdict is enforced or only
+                                        observed. `Reject` (the default) enforces the guardrail: a blocked
+                                        assessment rejects the request/response and an anonymized assessment masks
+                                        the matched content. `Audit` runs the guardrail in observe mode: it is
+                                        invoked and its assessment recorded (metrics + structured log), but the
+                                        request/response is never blocked or masked.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     identifier:
                                       description: Identifier of the Guardrail policy
                                         to use for the backend.
@@ -10987,10 +12324,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -11014,10 +12350,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -11031,10 +12366,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -11051,10 +12385,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -11082,23 +12415,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -11199,6 +12554,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -11210,8 +12572,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -11263,9 +12625,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -11294,6 +12682,16 @@ spec:
                                   description: Google Model Armor settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether flagged content is rejected or only observed.
+                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                        would-be rejection without blocking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     location:
                                       default: us-central1
                                       description: |-
@@ -11394,10 +12792,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -11421,10 +12818,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -11438,10 +12834,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -11458,10 +12853,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -11489,23 +12883,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -11606,6 +13022,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -11617,8 +13040,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -11670,9 +13093,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -11701,10 +13150,12 @@ spec:
                                       default: Mask
                                       description: |-
                                         The action to take if a regex pattern is matched in a request or response.
-                                        This setting applies only to request matches. `PromptguardResponse`
-                                        matches are always masked by default.
+                                        The action applies to request and response matches alike. Note that
+                                        `Mask` is not applied to streamed responses: matched content in a
+                                        streamed response is passed through unmodified.
                                         Defaults to `Mask`.
                                       enum:
+                                      - Audit
                                       - Mask
                                       - Reject
                                       type: string
@@ -11765,6 +13216,16 @@ spec:
                                   description: Webhook that receives responses for
                                     prompt guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the webhook's verdict is enforced or only observed.
+                                        `Reject` (the default) enforces it; `Audit` records the would-be action
+                                        without blocking or masking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     backendRef:
                                       description: |-
                                         Webhook server to reach.
@@ -11911,6 +13372,8 @@ spec:
                           - Completions
                           - Detect
                           - Embeddings
+                          - GeminiCountTokens
+                          - GenerateContent
                           - Messages
                           - Models
                           - Passthrough
@@ -11957,10 +13420,10 @@ spec:
                         type: array
                     type: object
                     x-kubernetes-validations:
-                    - message: at least one of the fields in [defaults modelAliases
-                        overrides prompt promptCaching promptGuard routes transformations]
-                        must be set
-                      rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
+                    - message: at least one of the fields in [defaults finalTransformations
+                        modelAliases overrides prompt promptCaching promptGuard routes
+                        transformations] must be set
+                      rule: '[has(self.defaults),has(self.finalTransformations),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                         >= 1'
                   auth:
                     description: Settings for managing authentication to the backend
@@ -12096,19 +13559,29 @@ spec:
                         description: Azure authentication method for the backend.
                         properties:
                           managedIdentity:
-                            description: Managed identity authentication settings.
+                            description: |-
+                              Managed identity authentication settings. Leave this object empty to use
+                              the system-assigned identity. To use a user-assigned identity, set one of
+                              `clientId`, `objectId`, or `resourceId`.
                             properties:
                               clientId:
+                                description: Client ID of the user-assigned managed
+                                  identity.
                                 type: string
                               objectId:
+                                description: Object ID of the user-assigned managed
+                                  identity.
                                 type: string
                               resourceId:
+                                description: Resource ID of the user-assigned managed
+                                  identity.
                                 type: string
-                            required:
-                            - clientId
-                            - objectId
-                            - resourceId
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [clientId objectId
+                                resourceId] may be set
+                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source for Azure credentials, defaulting to a Kubernetes
@@ -12256,6 +13729,14 @@ spec:
                         description: Cross App Access (Identity Assertion / ID-JAG)
                           authentication.
                         properties:
+                          accessTokenScopes:
+                            description: |-
+                              Scopes requested when exchanging the ID-JAG for an access token.
+                              When omitted, defaults to Scopes. Set to an empty list to omit scope.
+                            items:
+                              type: string
+                            maxItems: 64
+                            type: array
                           audience:
                             description: Identifier of the resource authorization
                               server. The issued ID-JAG is bound to this audience.
@@ -12270,7 +13751,12 @@ spec:
                                   defaultTtl:
                                     description: TTL used when the token endpoint
                                       omits expires_in. Default 300s.
+                                    maxLength: 32
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                    x-kubernetes-validations:
+                                    - message: defaultTtl must be at least 1 second
+                                      rule: duration(self) >= duration('1s')
                                   maxEntries:
                                     description: Default 8192; 0 disables the cache.
                                     format: int32
@@ -12282,7 +13768,9 @@ spec:
                               used for the RFC 8693 ID-JAG exchange.
                             properties:
                               backendRef:
-                                description: Token endpoint backend.
+                                description: |-
+                                  `backendRef` selects a backend for this policy.
+                                  Mutually exclusive with `url`.
                                 properties:
                                   group:
                                     default: ""
@@ -12511,16 +13999,35 @@ spec:
                                   Must start with "/".
                                 pattern: ^/
                                 type: string
+                              url:
+                                description: |-
+                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                  Mutually exclusive with `backendRef`.
+                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                  will not apply Service policies or load balancing.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                type: string
                             required:
-                            - backendRef
                             - clientAuth
                             type: object
+                            x-kubernetes-validations:
+                            - message: path may not be set when url is set
+                              rule: 'has(self.url) ? !has(self.path) : true'
+                            - message: exactly one of the fields in [backendRef url]
+                                must be set
+                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                == 1'
                           resourceAuthorizationServer:
                             description: Resource authorization server, used for the
                               RFC 7523 jwt-bearer exchange.
                             properties:
                               backendRef:
-                                description: Token endpoint backend.
+                                description: |-
+                                  `backendRef` selects a backend for this policy.
+                                  Mutually exclusive with `url`.
                                 properties:
                                   group:
                                     default: ""
@@ -12749,10 +14256,27 @@ spec:
                                   Must start with "/".
                                 pattern: ^/
                                 type: string
+                              url:
+                                description: |-
+                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                  Mutually exclusive with `backendRef`.
+                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                  will not apply Service policies or load balancing.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                type: string
                             required:
-                            - backendRef
                             - clientAuth
                             type: object
+                            x-kubernetes-validations:
+                            - message: path may not be set when url is set
+                              rule: 'has(self.url) ? !has(self.path) : true'
+                            - message: exactly one of the fields in [backendRef url]
+                                must be set
+                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                == 1'
                           resources:
                             description: Resources sent to the token endpoint.
                             items:
@@ -12761,7 +14285,8 @@ spec:
                             minItems: 1
                             type: array
                           scopes:
-                            description: Scopes sent to the token endpoint.
+                            description: Scopes requested when obtaining the ID-JAG
+                              from the identity provider.
                             items:
                               type: string
                             maxItems: 64
@@ -12823,7 +14348,15 @@ spec:
                                     cookie expression] must be set
                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                     == 1'
+                              tokenType:
+                                description: OAuth RFC 8693 subject token type. Defaults
+                                  to IdToken
+                                type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: tokenType IdJag is not supported by crossAppAccess
+                              rule: '!has(self.tokenType) || (self.tokenType != ''IdJag''
+                                && self.tokenType != ''urn:ietf:params:oauth:token-type:id-jag'')'
                         required:
                         - audience
                         - identityProvider
@@ -12892,6 +14425,119 @@ spec:
                         x-kubernetes-validations:
                         - message: audience is only valid with IdToken
                           rule: 'has(self.audience) ? self.type == ''IdToken'' : true'
+                      jwtSign:
+                        description: |-
+                          Signs a short-lived JWT with a private key on each request and sends it
+                          to the backend, for upstreams that require per-request keypair JWTs
+                          (e.g. the Snowflake SQL API) rather than a static credential.
+                        properties:
+                          alg:
+                            description: JWS signing algorithm. Defaults to RS256.
+                            enum:
+                            - ES256
+                            - ES384
+                            - PS256
+                            - RS256
+                            - RS384
+                            - RS512
+                            type: string
+                          claims:
+                            additionalProperties:
+                              x-kubernetes-preserve-unknown-fields: true
+                            description: |-
+                              Static claims added to every token (e.g. iss, sub, aud). Values may be
+                              any JSON value (e.g. a string, number, bool, or array). iat, exp, and
+                              nbf are reserved for the signer and cannot be configured here; the
+                              controller rejects them at translation time.
+                            type: object
+                          kid:
+                            description: Optional JWS key ID header.
+                            type: string
+                          location:
+                            description: |-
+                              Where the signed token is written on the backend request.
+                              Defaults to the Authorization header with a "Bearer " prefix.
+                            properties:
+                              cookie:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              header:
+                                properties:
+                                  name:
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  prefix:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              queryParameter:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of the fields in [header queryParameter
+                                cookie] must be set
+                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                == 1'
+                          signingKeyRef:
+                            description: Secret providing the `signingKey` key with
+                              a PEM-encoded RSA or EC private key.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
+                          ttl:
+                            description: Token lifetime used for exp. Defaults to
+                              300s.
+                            maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                            x-kubernetes-validations:
+                            - message: ttl must be at least 1 second
+                              rule: duration(self) >= duration('1s')
+                        required:
+                        - signingKeyRef
+                        type: object
                       key:
                         description: |-
                           Inline key to use as the value of the
@@ -13042,7 +14688,9 @@ spec:
                             minItems: 1
                             type: array
                           backendRef:
-                            description: RFC 8693 token endpoint backend.
+                            description: |-
+                              `backendRef` selects a backend for this policy.
+                              Mutually exclusive with `url`.
                             properties:
                               group:
                                 default: ""
@@ -13094,7 +14742,12 @@ spec:
                                   defaultTtl:
                                     description: TTL used when the token endpoint
                                       omits expires_in. Default 300s.
+                                    maxLength: 32
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                    x-kubernetes-validations:
+                                    - message: defaultTtl must be at least 1 second
+                                      rule: duration(self) >= duration('1s')
                                   maxEntries:
                                     description: Default 8192; 0 disables the cache.
                                     format: int32
@@ -13422,8 +15075,17 @@ spec:
                                   are supported for subject tokens.
                                 type: string
                             type: object
-                        required:
-                        - backendRef
+                          url:
+                            description: |-
+                              `url` directly specifies the HTTP(S) endpoint for this policy.
+                              When the scheme is `https`, backend TLS is enabled automatically.
+                              Mutually exclusive with `backendRef`.
+                              URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                              will not apply Service policies or load balancing.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: actorToken is only valid with TokenExchange grantType
@@ -13436,6 +15098,12 @@ spec:
                         - message: requestedTokenType IdJag is only supported by crossAppAccess
                           rule: '!has(self.requestedTokenType) || self.requestedTokenType
                             != ''IdJag'''
+                        - message: path may not be set when url is set
+                          rule: 'has(self.url) ? !has(self.path) : true'
+                        - message: exactly one of the fields in [backendRef url] must
+                            be set
+                          rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                            == 1'
                       passthrough:
                         description: |-
                           Reuses a client token already validated by another policy. Those policies
@@ -13480,18 +15148,20 @@ spec:
                             (has(self.kind) && size(self.kind) > 0)'
                     type: object
                     x-kubernetes-validations:
-                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess/jwtSign
                         (credentials may be combined with a primary auth kind)
                       rule: has(self.credentials) || has(self.key) || has(self.secretRef)
                         || has(self.passthrough) || has(self.aws) || has(self.azure)
                         || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                        || has(self.jwtSign)
                     - message: location may only be set for key, secretRef, or passthrough
                         auth
                       rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
                         || has(self.passthrough) : true'
                     - message: at most one of the fields in [key secretRef passthrough
-                        aws azure gcp oauthTokenExchange crossAppAccess] may be set
-                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                        aws azure gcp oauthTokenExchange crossAppAccess jwtSign] may
+                        be set
+                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess),has(self.jwtSign)].filter(x,x==true).size()
                         <= 1'
                   extAuth:
                     description: |-
@@ -13500,9 +15170,8 @@ spec:
                     properties:
                       backendRef:
                         description: |-
-                          External Authorization server to reach.
-
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -13737,10 +15406,30 @@ spec:
                             maxProperties: 64
                             type: object
                         type: object
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
                     x-kubernetes-validations:
+                    - message: exactly one of backendRef or url must be set
+                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
                     - message: forwardBody cannot be used with http.body
                       rule: '!(has(self.forwardBody) && has(self.http) && has(self.http.body))'
+                    - message: url path is only valid with http
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || has(self.http)'
+                    - message: http.path may not be set when url includes a path
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || !has(self.http) || !has(self.http.path)'
                   health:
                     description: Settings for passive and active health checking.
                     properties:
@@ -13765,11 +15454,10 @@ spec:
                               rather than failing entirely.
                               If unset, defaults to `3s`.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
-                            - message: evictionDuration must be at least 1 second
+                            - message: duration must be at least 1 second
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
@@ -13812,10 +15500,9 @@ spec:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: requestTimeout must be at least 1ms
                           rule: duration(self) >= duration('1ms')
                       version:
@@ -13909,11 +15596,8 @@ spec:
                             properties:
                               backendRef:
                                 description: |-
-                                  Remote JWKS server to reach.
-                                  Supported types are `Service` and static `Backend`. An
-                                  `AgentgatewayPolicy` containing backend TLS config can then be attached
-                                  to the `Service` or `Backend` in order to set TLS options for a
-                                  connection to the remote `jwks` source.
+                                  `backendRef` selects a backend for this policy.
+                                  Mutually exclusive with `url`.
                                 properties:
                                   group:
                                     default: ""
@@ -13960,24 +15644,42 @@ spec:
                                     ? has(self.port) : true'
                               cacheDuration:
                                 default: 5m
+                                description: How long a fetched `jwks` document is
+                                  used before it is re-fetched from the IdP.
                                 maxLength: 32
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid duration value
-                                  rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                 - message: cacheDuration must be at least 5m.
                                   rule: duration(self) >= duration('5m')
                               jwksPath:
                                 description: |-
                                   Path to the IdP `jwks` endpoint, relative to the root, commonly
                                   `".well-known/jwks.json"`.
-                                maxLength: 2000
+                                maxLength: 1024
                                 minLength: 1
                                 type: string
-                            required:
-                            - backendRef
-                            - jwksPath
+                              url:
+                                description: |-
+                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                  Mutually exclusive with `backendRef`.
+                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                  will not apply Service policies or load balancing.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: jwksPath is required when backendRef is set
+                              rule: 'has(self.backendRef) ? has(self.jwksPath) : true'
+                            - message: jwksPath may not be set when url is set
+                              rule: 'has(self.url) ? !has(self.jwksPath) : true'
+                            - message: exactly one of the fields in [backendRef url]
+                                must be set
+                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                == 1'
                           mode:
                             default: Strict
                             description: Validation mode for JWT authentication.
@@ -14124,8 +15826,8 @@ spec:
                                       x-kubernetes-list-type: set
                                     backendRef:
                                       description: |-
-                                        `backendRef` references the remote guardrails policy server.
-                                        Supported types: `Service` and `Backend`.
+                                        `backendRef` selects a backend for this policy.
+                                        Mutually exclusive with `url`.
                                       properties:
                                         group:
                                           default: ""
@@ -14214,9 +15916,25 @@ spec:
                                         keyed by config key. Values are CEL expressions.
                                       maxProperties: 64
                                       type: object
-                                  required:
-                                  - backendRef
+                                    url:
+                                      description: |-
+                                        `url` directly specifies the HTTP(S) endpoint for this policy.
+                                        When the scheme is `https`, backend TLS is enabled automatically.
+                                        Mutually exclusive with `backendRef`.
+                                        URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                        will not apply Service policies or load balancing.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                      type: string
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: url must not include a path
+                                    rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
+                                  - message: exactly one of the fields in [backendRef
+                                      url] must be set
+                                    rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                      == 1'
                               required:
                               - methods
                               type: object
@@ -14245,10 +15963,9 @@ spec:
                           Deadline for establishing a connection to
                           the destination.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: connectTimeout must be at least 100ms
                           rule: duration(self) >= duration('100ms')
                       keepalive:
@@ -14261,10 +15978,9 @@ spec:
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                             - message: interval must be at least 1 second
                               rule: duration(self) >= duration('1s')
                           retries:
@@ -14280,10 +15996,9 @@ spec:
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                             - message: time must be at least 1 second
                               rule: duration(self) >= duration('1s')
                         type: object
@@ -14310,23 +16025,42 @@ spec:
                         type: array
                       caCertificateRefs:
                         description: |-
-                          CA certificate `ConfigMap` to use to
-                          verify the server certificate.
-                          If unset, the system's trusted certificates are used.
+                          CA certificate source to use to verify the server certificate. Omitted kind
+                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                          key is required. If unset, the system's trusted certificates are used.
                         items:
                           description: |-
-                            LocalObjectReference contains enough information to let you locate the
-                            referenced object inside the same namespace.
+                            LocalCACertificateRef references a same-namespace CA certificate source.
+                            An omitted kind defaults to ConfigMap.
                           properties:
-                            name:
-                              default: ""
-                              description: Name of the referent
+                            kind:
+                              default: ConfigMap
+                              description: Kind of the referenced CA certificate source.
+                                Omitted defaults to ConfigMap.
+                              enum:
+                              - ConfigMap
+                              - Secret
                               type: string
+                            name:
+                              description: Name of the referenced CA certificate source.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
                           type: object
                           x-kubernetes-map-type: atomic
                         maxItems: 1
                         type: array
                         x-kubernetes-list-type: atomic
+                      certificateSource:
+                        default: Inline
+                        description: Source for the gateway's client identity and
+                          trust roots (`Inline` default, or `SPIFFE`).
+                        enum:
+                        - Inline
+                        - SPIFFE
+                        type: string
                       insecureSkipVerify:
                         description: |-
                           Originates TLS but skips verification of the backend's certificate
@@ -14421,6 +16155,11 @@ spec:
                         be set together
                       rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                         : true'
+                    - message: certificateSource SPIFFE may not be combined with mtlsCertificateRef,
+                        caCertificateRefs, or insecureSkipVerify
+                      rule: '!has(self.certificateSource) || self.certificateSource
+                        != ''SPIFFE'' || (!has(self.mtlsCertificateRef) && !has(self.caCertificateRefs)
+                        && !has(self.insecureSkipVerify))'
                     - message: at most one of the fields in [verifySubjectAltNames
                         insecureSkipVerify] may be set
                       rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -14667,8 +16406,8 @@ spec:
                     properties:
                       backendRef:
                         description: |-
-                          Proxy server to reach.
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -14712,9 +16451,34 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
-                    required:
-                    - backendRef
+                      mode:
+                        default: Auto
+                        description: |-
+                          How requests are sent through the proxy.
+                          Defaults to `Auto`.
+                        enum:
+                        - Auto
+                        - Connect
+                        type: string
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [backendRef url] must
+                        be set
+                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
+                    - message: url must not include a path for backend tunnel
+                      rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                 type: object
                 x-kubernetes-validations:
                 - message: at least one of the fields in [ai auth extAuth health http

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -221,6 +221,13 @@ spec:
                     x-kubernetes-list-map-keys:
                     - type
                     x-kubernetes-list-type: map
+                  providerOverride:
+                    description: |-
+                      Provider identity used for cost-catalog lookup and telemetry.
+                      Defaults to "custom" when unset.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
                 required:
                 - formats
                 type: object
@@ -250,7 +257,16 @@ spec:
                         - 1))'
                 type: object
               parentRefs:
-                description: Gateways and listeners to which this model attaches.
+                description: |-
+                  Parent resources to which this model attaches. Supported parent kinds are
+                  Gateway, ListenerSet, and HTTPRoute.
+
+                  A Gateway or ListenerSet parent attaches the model directly to its
+                  listeners. An HTTPRoute parent attaches the model to the referenced rule;
+                  sectionName selects a named rule, or the HTTPRoute must contain exactly
+                  one rule when sectionName is omitted. The selected rule must use exactly
+                  one AgentgatewayModel backend with name "*". If the rule has path matches,
+                  they must use PathPrefix matching.
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -469,19 +485,29 @@ spec:
                         description: Azure authentication method for the model provider.
                         properties:
                           managedIdentity:
-                            description: Managed identity authentication settings.
+                            description: |-
+                              Managed identity authentication settings. Leave this object empty to use
+                              the system-assigned identity. To use a user-assigned identity, set one of
+                              `clientId`, `objectId`, or `resourceId`.
                             properties:
                               clientId:
+                                description: Client ID of the user-assigned managed
+                                  identity.
                                 type: string
                               objectId:
+                                description: Object ID of the user-assigned managed
+                                  identity.
                                 type: string
                               resourceId:
+                                description: Resource ID of the user-assigned managed
+                                  identity.
                                 type: string
-                            required:
-                            - clientId
-                            - objectId
-                            - resourceId
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [clientId objectId
+                                resourceId] may be set
+                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source for Azure credentials, defaulting to a Kubernetes
@@ -839,7 +865,9 @@ spec:
                             minItems: 1
                             type: array
                           backendRef:
-                            description: RFC 8693 token endpoint backend.
+                            description: |-
+                              `backendRef` selects a backend for this policy.
+                              Mutually exclusive with `url`.
                             properties:
                               group:
                                 default: ""
@@ -891,7 +919,12 @@ spec:
                                   defaultTtl:
                                     description: TTL used when the token endpoint
                                       omits expires_in. Default 300s.
+                                    maxLength: 32
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                    x-kubernetes-validations:
+                                    - message: defaultTtl must be at least 1 second
+                                      rule: duration(self) >= duration('1s')
                                   maxEntries:
                                     description: Default 8192; 0 disables the cache.
                                     format: int32
@@ -1219,8 +1252,17 @@ spec:
                                   are supported for subject tokens.
                                 type: string
                             type: object
-                        required:
-                        - backendRef
+                          url:
+                            description: |-
+                              `url` directly specifies the HTTP(S) endpoint for this policy.
+                              When the scheme is `https`, backend TLS is enabled automatically.
+                              Mutually exclusive with `backendRef`.
+                              URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                              will not apply Service policies or load balancing.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: actorToken is only valid with TokenExchange grantType
@@ -1233,6 +1275,12 @@ spec:
                         - message: requestedTokenType IdJag is only supported by crossAppAccess
                           rule: '!has(self.requestedTokenType) || self.requestedTokenType
                             != ''IdJag'''
+                        - message: path may not be set when url is set
+                          rule: 'has(self.url) ? !has(self.path) : true'
+                        - message: exactly one of the fields in [backendRef url] must
+                            be set
+                          rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                            == 1'
                       passthrough:
                         description: |-
                           Reuses a client token already validated by another policy. Those policies
@@ -1336,6 +1384,36 @@ spec:
                     required:
                     - policy
                     type: object
+                  finalTransformations:
+                    description: |-
+                      CEL transformations applied to fields in the provider request body.
+                      After conversion from one provider format to another, these transformations are applied to the converted request body.
+                    items:
+                      description: |-
+                        Maps a request JSON field to a CEL expression.
+                        The expression is evaluated against the current request body and its result
+                        is assigned to the configured field.
+                      properties:
+                        expression:
+                          description: CEL expression used to compute the field value.
+                          maxLength: 16384
+                          minLength: 1
+                          type: string
+                        field:
+                          description: Name of the field to set.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                      required:
+                      - expression
+                      - field
+                      type: object
+                    maxItems: 64
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - field
+                    x-kubernetes-list-type: map
                   headers:
                     description: Request and response header changes applied to provider
                       traffic.
@@ -1593,11 +1671,10 @@ spec:
                               rather than failing entirely.
                               If unset, defaults to `3s`.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
-                            - message: evictionDuration must be at least 1 second
+                            - message: duration must be at least 1 second
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
@@ -1650,6 +1727,19 @@ spec:
                                 AWS Bedrock Guardrails settings for prompt
                                 guarding.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether the guardrail's verdict is enforced or only
+                                    observed. `Reject` (the default) enforces the guardrail: a blocked
+                                    assessment rejects the request/response and an anonymized assessment masks
+                                    the matched content. `Audit` runs the guardrail in observe mode: it is
+                                    invoked and its assessment recorded (metrics + structured log), but the
+                                    request/response is never blocked or masked.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 identifier:
                                   description: Identifier of the Guardrail policy
                                     to use for the backend.
@@ -1911,10 +2001,9 @@ spec:
                                           description: Deadline for receiving a response
                                             from the backend.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: requestTimeout must be at least
                                               1ms
                                             rule: duration(self) >= duration('1ms')
@@ -1938,10 +2027,9 @@ spec:
                                             Deadline for establishing a connection to
                                             the destination.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: connectTimeout must be at least
                                               100ms
                                             rule: duration(self) >= duration('100ms')
@@ -1955,10 +2043,9 @@ spec:
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: interval must be at least
                                                   1 second
                                                 rule: duration(self) >= duration('1s')
@@ -1975,10 +2062,9 @@ spec:
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: time must be at least 1 second
                                                 rule: duration(self) >= duration('1s')
                                           type: object
@@ -2005,23 +2091,45 @@ spec:
                                           type: array
                                         caCertificateRefs:
                                           description: |-
-                                            CA certificate `ConfigMap` to use to
-                                            verify the server certificate.
-                                            If unset, the system's trusted certificates are used.
+                                            CA certificate source to use to verify the server certificate. Omitted kind
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                            key is required. If unset, the system's trusted certificates are used.
                                           items:
                                             description: |-
-                                              LocalObjectReference contains enough information to let you locate the
-                                              referenced object inside the same namespace.
+                                              LocalCACertificateRef references a same-namespace CA certificate source.
+                                              An omitted kind defaults to ConfigMap.
                                             properties:
-                                              name:
-                                                default: ""
-                                                description: Name of the referent
+                                              kind:
+                                                default: ConfigMap
+                                                description: Kind of the referenced
+                                                  CA certificate source. Omitted defaults
+                                                  to ConfigMap.
+                                                enum:
+                                                - ConfigMap
+                                                - Secret
                                                 type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  CA certificate source.
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           maxItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
+                                        certificateSource:
+                                          default: Inline
+                                          description: Source for the gateway's client
+                                            identity and trust roots (`Inline` default,
+                                            or `SPIFFE`).
+                                          enum:
+                                          - Inline
+                                          - SPIFFE
+                                          type: string
                                         insecureSkipVerify:
                                           description: |-
                                             Originates TLS but skips verification of the backend's certificate
@@ -2121,6 +2229,12 @@ spec:
                                           may not be set together
                                         rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                           : true'
+                                      - message: certificateSource SPIFFE may not
+                                          be combined with mtlsCertificateRef, caCertificateRefs,
+                                          or insecureSkipVerify
+                                        rule: '!has(self.certificateSource) || self.certificateSource
+                                          != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                          && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                       - message: at most one of the fields in [verifySubjectAltNames
                                           insecureSkipVerify] may be set
                                         rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -2131,8 +2245,8 @@ spec:
                                       properties:
                                         backendRef:
                                           description: |-
-                                            Proxy server to reach.
-                                            Supported types: `Service` and `Backend`.
+                                            `backendRef` selects a backend for this policy.
+                                            Mutually exclusive with `url`.
                                           properties:
                                             group:
                                               default: ""
@@ -2181,9 +2295,35 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                      required:
-                                      - backendRef
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
+                                        url:
+                                          description: |-
+                                            `url` directly specifies the HTTP(S) endpoint for this policy.
+                                            When the scheme is `https`, backend TLS is enabled automatically.
+                                            Mutually exclusive with `backendRef`.
+                                            URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                            will not apply Service policies or load balancing.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                          type: string
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [backendRef
+                                          url] must be set
+                                        rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                          == 1'
+                                      - message: url must not include a path for backend
+                                          tunnel
+                                        rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                   type: object
                                   x-kubernetes-validations:
                                   - message: at least one of the fields in [auth http
@@ -2212,6 +2352,16 @@ spec:
                               description: Google Model Armor settings for prompt
                                 guarding.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether flagged content is rejected or only observed.
+                                    `Reject` (the default) rejects flagged content; `Audit` records the
+                                    would-be rejection without blocking.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 location:
                                   default: us-central1
                                   description: |-
@@ -2311,10 +2461,9 @@ spec:
                                           description: Deadline for receiving a response
                                             from the backend.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: requestTimeout must be at least
                                               1ms
                                             rule: duration(self) >= duration('1ms')
@@ -2338,10 +2487,9 @@ spec:
                                             Deadline for establishing a connection to
                                             the destination.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: connectTimeout must be at least
                                               100ms
                                             rule: duration(self) >= duration('100ms')
@@ -2355,10 +2503,9 @@ spec:
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: interval must be at least
                                                   1 second
                                                 rule: duration(self) >= duration('1s')
@@ -2375,10 +2522,9 @@ spec:
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: time must be at least 1 second
                                                 rule: duration(self) >= duration('1s')
                                           type: object
@@ -2405,23 +2551,45 @@ spec:
                                           type: array
                                         caCertificateRefs:
                                           description: |-
-                                            CA certificate `ConfigMap` to use to
-                                            verify the server certificate.
-                                            If unset, the system's trusted certificates are used.
+                                            CA certificate source to use to verify the server certificate. Omitted kind
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                            key is required. If unset, the system's trusted certificates are used.
                                           items:
                                             description: |-
-                                              LocalObjectReference contains enough information to let you locate the
-                                              referenced object inside the same namespace.
+                                              LocalCACertificateRef references a same-namespace CA certificate source.
+                                              An omitted kind defaults to ConfigMap.
                                             properties:
-                                              name:
-                                                default: ""
-                                                description: Name of the referent
+                                              kind:
+                                                default: ConfigMap
+                                                description: Kind of the referenced
+                                                  CA certificate source. Omitted defaults
+                                                  to ConfigMap.
+                                                enum:
+                                                - ConfigMap
+                                                - Secret
                                                 type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  CA certificate source.
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           maxItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
+                                        certificateSource:
+                                          default: Inline
+                                          description: Source for the gateway's client
+                                            identity and trust roots (`Inline` default,
+                                            or `SPIFFE`).
+                                          enum:
+                                          - Inline
+                                          - SPIFFE
+                                          type: string
                                         insecureSkipVerify:
                                           description: |-
                                             Originates TLS but skips verification of the backend's certificate
@@ -2521,6 +2689,12 @@ spec:
                                           may not be set together
                                         rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                           : true'
+                                      - message: certificateSource SPIFFE may not
+                                          be combined with mtlsCertificateRef, caCertificateRefs,
+                                          or insecureSkipVerify
+                                        rule: '!has(self.certificateSource) || self.certificateSource
+                                          != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                          && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                       - message: at most one of the fields in [verifySubjectAltNames
                                           insecureSkipVerify] may be set
                                         rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -2531,8 +2705,8 @@ spec:
                                       properties:
                                         backendRef:
                                           description: |-
-                                            Proxy server to reach.
-                                            Supported types: `Service` and `Backend`.
+                                            `backendRef` selects a backend for this policy.
+                                            Mutually exclusive with `url`.
                                           properties:
                                             group:
                                               default: ""
@@ -2581,9 +2755,35 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                      required:
-                                      - backendRef
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
+                                        url:
+                                          description: |-
+                                            `url` directly specifies the HTTP(S) endpoint for this policy.
+                                            When the scheme is `https`, backend TLS is enabled automatically.
+                                            Mutually exclusive with `backendRef`.
+                                            URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                            will not apply Service policies or load balancing.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                          type: string
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [backendRef
+                                          url] must be set
+                                        rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                          == 1'
+                                      - message: url must not include a path for backend
+                                          tunnel
+                                        rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                   type: object
                                   x-kubernetes-validations:
                                   - message: at least one of the fields in [auth http
@@ -2610,6 +2810,16 @@ spec:
                                 endpoint.
                                 See https://developers.openai.com/api/reference/resources/moderations for more information.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether flagged content is rejected or only observed.
+                                    `Reject` (the default) rejects flagged content; `Audit` records the
+                                    would-be rejection without blocking.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 model:
                                   description: |-
                                     Moderation model to use. For example,
@@ -2730,10 +2940,9 @@ spec:
                                           description: Deadline for receiving a response
                                             from the backend.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: requestTimeout must be at least
                                               1ms
                                             rule: duration(self) >= duration('1ms')
@@ -2757,10 +2966,9 @@ spec:
                                             Deadline for establishing a connection to
                                             the destination.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: connectTimeout must be at least
                                               100ms
                                             rule: duration(self) >= duration('100ms')
@@ -2774,10 +2982,9 @@ spec:
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: interval must be at least
                                                   1 second
                                                 rule: duration(self) >= duration('1s')
@@ -2794,10 +3001,9 @@ spec:
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: time must be at least 1 second
                                                 rule: duration(self) >= duration('1s')
                                           type: object
@@ -2824,23 +3030,45 @@ spec:
                                           type: array
                                         caCertificateRefs:
                                           description: |-
-                                            CA certificate `ConfigMap` to use to
-                                            verify the server certificate.
-                                            If unset, the system's trusted certificates are used.
+                                            CA certificate source to use to verify the server certificate. Omitted kind
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                            key is required. If unset, the system's trusted certificates are used.
                                           items:
                                             description: |-
-                                              LocalObjectReference contains enough information to let you locate the
-                                              referenced object inside the same namespace.
+                                              LocalCACertificateRef references a same-namespace CA certificate source.
+                                              An omitted kind defaults to ConfigMap.
                                             properties:
-                                              name:
-                                                default: ""
-                                                description: Name of the referent
+                                              kind:
+                                                default: ConfigMap
+                                                description: Kind of the referenced
+                                                  CA certificate source. Omitted defaults
+                                                  to ConfigMap.
+                                                enum:
+                                                - ConfigMap
+                                                - Secret
                                                 type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  CA certificate source.
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           maxItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
+                                        certificateSource:
+                                          default: Inline
+                                          description: Source for the gateway's client
+                                            identity and trust roots (`Inline` default,
+                                            or `SPIFFE`).
+                                          enum:
+                                          - Inline
+                                          - SPIFFE
+                                          type: string
                                         insecureSkipVerify:
                                           description: |-
                                             Originates TLS but skips verification of the backend's certificate
@@ -2940,6 +3168,12 @@ spec:
                                           may not be set together
                                         rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                           : true'
+                                      - message: certificateSource SPIFFE may not
+                                          be combined with mtlsCertificateRef, caCertificateRefs,
+                                          or insecureSkipVerify
+                                        rule: '!has(self.certificateSource) || self.certificateSource
+                                          != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                          && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                       - message: at most one of the fields in [verifySubjectAltNames
                                           insecureSkipVerify] may be set
                                         rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -2950,8 +3184,8 @@ spec:
                                       properties:
                                         backendRef:
                                           description: |-
-                                            Proxy server to reach.
-                                            Supported types: `Service` and `Backend`.
+                                            `backendRef` selects a backend for this policy.
+                                            Mutually exclusive with `url`.
                                           properties:
                                             group:
                                               default: ""
@@ -3000,9 +3234,35 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                      required:
-                                      - backendRef
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
+                                        url:
+                                          description: |-
+                                            `url` directly specifies the HTTP(S) endpoint for this policy.
+                                            When the scheme is `https`, backend TLS is enabled automatically.
+                                            Mutually exclusive with `backendRef`.
+                                            URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                            will not apply Service policies or load balancing.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                          type: string
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [backendRef
+                                          url] must be set
+                                        rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                          == 1'
+                                      - message: url must not include a path for backend
+                                          tunnel
+                                        rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                   type: object
                                   x-kubernetes-validations:
                                   - message: at least one of the fields in [auth http
@@ -3018,10 +3278,12 @@ spec:
                                   default: Mask
                                   description: |-
                                     The action to take if a regex pattern is matched in a request or response.
-                                    This setting applies only to request matches. `PromptguardResponse`
-                                    matches are always masked by default.
+                                    The action applies to request and response matches alike. Note that
+                                    `Mask` is not applied to streamed responses: matched content in a
+                                    streamed response is passed through unmodified.
                                     Defaults to `Mask`.
                                   enum:
+                                  - Audit
                                   - Mask
                                   - Reject
                                   type: string
@@ -3078,10 +3340,41 @@ spec:
                                   must be set
                                 rule: '[has(self.message),has(self.statusCode)].filter(x,x==true).size()
                                   >= 1'
+                            scope:
+                              description: |-
+                                Which parts of the request this guard inspects. When unset, defaults to
+                                `SystemPrompt` and `Messages`. Tool call inputs and outputs are not
+                                inspected unless `ToolInput`/`ToolOutput` are listed explicitly.
+                                In APIs that send tool arguments as opaque JSON, such as Completions, the
+                                arguments are masked as a single string, meaning a prompt guard has the
+                                potential to rewrite the arguments into invalid JSON.
+                              items:
+                                description: Which category of request content a prompt
+                                  guard inspects.
+                                enum:
+                                - Messages
+                                - SystemPrompt
+                                - ToolInput
+                                - ToolOutput
+                                type: string
+                              maxItems: 4
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: set
                             webhook:
                               description: Webhook that receives requests for prompt
                                 guarding.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether the webhook's verdict is enforced or only observed.
+                                    `Reject` (the default) enforces it; `Audit` records the would-be action
+                                    without blocking or masking.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 backendRef:
                                   description: |-
                                     Webhook server to reach.
@@ -3196,6 +3489,12 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
+                          - message: 'scope: only regex and bedrockGuardrails guards
+                              support a non-default scope; other guard kinds always
+                              inspect the default (SystemPrompt + Messages)'
+                            rule: '!has(self.scope) || has(self.regex) || has(self.bedrockGuardrails)
+                              || (self.scope.size() == 2 && ''SystemPrompt'' in self.scope
+                              && ''Messages'' in self.scope)'
                           - message: exactly one of the fields in [regex webhook openAIModeration
                               bedrockGuardrails googleModelArmor] must be set
                             rule: '[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size()
@@ -3215,6 +3514,19 @@ spec:
                                 AWS Bedrock Guardrails settings for prompt
                                 guarding.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether the guardrail's verdict is enforced or only
+                                    observed. `Reject` (the default) enforces the guardrail: a blocked
+                                    assessment rejects the request/response and an anonymized assessment masks
+                                    the matched content. `Audit` runs the guardrail in observe mode: it is
+                                    invoked and its assessment recorded (metrics + structured log), but the
+                                    request/response is never blocked or masked.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 identifier:
                                   description: Identifier of the Guardrail policy
                                     to use for the backend.
@@ -3476,10 +3788,9 @@ spec:
                                           description: Deadline for receiving a response
                                             from the backend.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: requestTimeout must be at least
                                               1ms
                                             rule: duration(self) >= duration('1ms')
@@ -3503,10 +3814,9 @@ spec:
                                             Deadline for establishing a connection to
                                             the destination.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: connectTimeout must be at least
                                               100ms
                                             rule: duration(self) >= duration('100ms')
@@ -3520,10 +3830,9 @@ spec:
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: interval must be at least
                                                   1 second
                                                 rule: duration(self) >= duration('1s')
@@ -3540,10 +3849,9 @@ spec:
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: time must be at least 1 second
                                                 rule: duration(self) >= duration('1s')
                                           type: object
@@ -3570,23 +3878,45 @@ spec:
                                           type: array
                                         caCertificateRefs:
                                           description: |-
-                                            CA certificate `ConfigMap` to use to
-                                            verify the server certificate.
-                                            If unset, the system's trusted certificates are used.
+                                            CA certificate source to use to verify the server certificate. Omitted kind
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                            key is required. If unset, the system's trusted certificates are used.
                                           items:
                                             description: |-
-                                              LocalObjectReference contains enough information to let you locate the
-                                              referenced object inside the same namespace.
+                                              LocalCACertificateRef references a same-namespace CA certificate source.
+                                              An omitted kind defaults to ConfigMap.
                                             properties:
-                                              name:
-                                                default: ""
-                                                description: Name of the referent
+                                              kind:
+                                                default: ConfigMap
+                                                description: Kind of the referenced
+                                                  CA certificate source. Omitted defaults
+                                                  to ConfigMap.
+                                                enum:
+                                                - ConfigMap
+                                                - Secret
                                                 type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  CA certificate source.
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           maxItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
+                                        certificateSource:
+                                          default: Inline
+                                          description: Source for the gateway's client
+                                            identity and trust roots (`Inline` default,
+                                            or `SPIFFE`).
+                                          enum:
+                                          - Inline
+                                          - SPIFFE
+                                          type: string
                                         insecureSkipVerify:
                                           description: |-
                                             Originates TLS but skips verification of the backend's certificate
@@ -3686,6 +4016,12 @@ spec:
                                           may not be set together
                                         rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                           : true'
+                                      - message: certificateSource SPIFFE may not
+                                          be combined with mtlsCertificateRef, caCertificateRefs,
+                                          or insecureSkipVerify
+                                        rule: '!has(self.certificateSource) || self.certificateSource
+                                          != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                          && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                       - message: at most one of the fields in [verifySubjectAltNames
                                           insecureSkipVerify] may be set
                                         rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -3696,8 +4032,8 @@ spec:
                                       properties:
                                         backendRef:
                                           description: |-
-                                            Proxy server to reach.
-                                            Supported types: `Service` and `Backend`.
+                                            `backendRef` selects a backend for this policy.
+                                            Mutually exclusive with `url`.
                                           properties:
                                             group:
                                               default: ""
@@ -3746,9 +4082,35 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                      required:
-                                      - backendRef
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
+                                        url:
+                                          description: |-
+                                            `url` directly specifies the HTTP(S) endpoint for this policy.
+                                            When the scheme is `https`, backend TLS is enabled automatically.
+                                            Mutually exclusive with `backendRef`.
+                                            URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                            will not apply Service policies or load balancing.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                          type: string
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [backendRef
+                                          url] must be set
+                                        rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                          == 1'
+                                      - message: url must not include a path for backend
+                                          tunnel
+                                        rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                   type: object
                                   x-kubernetes-validations:
                                   - message: at least one of the fields in [auth http
@@ -3777,6 +4139,16 @@ spec:
                               description: Google Model Armor settings for prompt
                                 guarding.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether flagged content is rejected or only observed.
+                                    `Reject` (the default) rejects flagged content; `Audit` records the
+                                    would-be rejection without blocking.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 location:
                                   default: us-central1
                                   description: |-
@@ -3876,10 +4248,9 @@ spec:
                                           description: Deadline for receiving a response
                                             from the backend.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: requestTimeout must be at least
                                               1ms
                                             rule: duration(self) >= duration('1ms')
@@ -3903,10 +4274,9 @@ spec:
                                             Deadline for establishing a connection to
                                             the destination.
                                           maxLength: 32
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
                                           x-kubernetes-validations:
-                                          - message: invalid duration value
-                                            rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                           - message: connectTimeout must be at least
                                               100ms
                                             rule: duration(self) >= duration('100ms')
@@ -3920,10 +4290,9 @@ spec:
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: interval must be at least
                                                   1 second
                                                 rule: duration(self) >= duration('1s')
@@ -3940,10 +4309,9 @@ spec:
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: time must be at least 1 second
                                                 rule: duration(self) >= duration('1s')
                                           type: object
@@ -3970,23 +4338,45 @@ spec:
                                           type: array
                                         caCertificateRefs:
                                           description: |-
-                                            CA certificate `ConfigMap` to use to
-                                            verify the server certificate.
-                                            If unset, the system's trusted certificates are used.
+                                            CA certificate source to use to verify the server certificate. Omitted kind
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                            key is required. If unset, the system's trusted certificates are used.
                                           items:
                                             description: |-
-                                              LocalObjectReference contains enough information to let you locate the
-                                              referenced object inside the same namespace.
+                                              LocalCACertificateRef references a same-namespace CA certificate source.
+                                              An omitted kind defaults to ConfigMap.
                                             properties:
-                                              name:
-                                                default: ""
-                                                description: Name of the referent
+                                              kind:
+                                                default: ConfigMap
+                                                description: Kind of the referenced
+                                                  CA certificate source. Omitted defaults
+                                                  to ConfigMap.
+                                                enum:
+                                                - ConfigMap
+                                                - Secret
                                                 type: string
+                                              name:
+                                                description: Name of the referenced
+                                                  CA certificate source.
+                                                maxLength: 253
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           maxItems: 1
                                           type: array
                                           x-kubernetes-list-type: atomic
+                                        certificateSource:
+                                          default: Inline
+                                          description: Source for the gateway's client
+                                            identity and trust roots (`Inline` default,
+                                            or `SPIFFE`).
+                                          enum:
+                                          - Inline
+                                          - SPIFFE
+                                          type: string
                                         insecureSkipVerify:
                                           description: |-
                                             Originates TLS but skips verification of the backend's certificate
@@ -4086,6 +4476,12 @@ spec:
                                           may not be set together
                                         rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                                           : true'
+                                      - message: certificateSource SPIFFE may not
+                                          be combined with mtlsCertificateRef, caCertificateRefs,
+                                          or insecureSkipVerify
+                                        rule: '!has(self.certificateSource) || self.certificateSource
+                                          != ''SPIFFE'' || (!has(self.mtlsCertificateRef)
+                                          && !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                       - message: at most one of the fields in [verifySubjectAltNames
                                           insecureSkipVerify] may be set
                                         rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -4096,8 +4492,8 @@ spec:
                                       properties:
                                         backendRef:
                                           description: |-
-                                            Proxy server to reach.
-                                            Supported types: `Service` and `Backend`.
+                                            `backendRef` selects a backend for this policy.
+                                            Mutually exclusive with `url`.
                                           properties:
                                             group:
                                               default: ""
@@ -4146,9 +4542,35 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                      required:
-                                      - backendRef
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
+                                        url:
+                                          description: |-
+                                            `url` directly specifies the HTTP(S) endpoint for this policy.
+                                            When the scheme is `https`, backend TLS is enabled automatically.
+                                            Mutually exclusive with `backendRef`.
+                                            URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                            will not apply Service policies or load balancing.
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                          type: string
                                       type: object
+                                      x-kubernetes-validations:
+                                      - message: exactly one of the fields in [backendRef
+                                          url] must be set
+                                        rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                          == 1'
+                                      - message: url must not include a path for backend
+                                          tunnel
+                                        rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                   type: object
                                   x-kubernetes-validations:
                                   - message: at least one of the fields in [auth http
@@ -4177,10 +4599,12 @@ spec:
                                   default: Mask
                                   description: |-
                                     The action to take if a regex pattern is matched in a request or response.
-                                    This setting applies only to request matches. `PromptguardResponse`
-                                    matches are always masked by default.
+                                    The action applies to request and response matches alike. Note that
+                                    `Mask` is not applied to streamed responses: matched content in a
+                                    streamed response is passed through unmodified.
                                     Defaults to `Mask`.
                                   enum:
+                                  - Audit
                                   - Mask
                                   - Reject
                                   type: string
@@ -4241,6 +4665,16 @@ spec:
                               description: Webhook that receives responses for prompt
                                 guarding.
                               properties:
+                                action:
+                                  default: Reject
+                                  description: |-
+                                    Action controls whether the webhook's verdict is enforced or only observed.
+                                    `Reject` (the default) enforces it; `Audit` records the would-be action
+                                    without blocking or masking.
+                                  enum:
+                                  - Audit
+                                  - Reject
+                                  type: string
                                 backendRef:
                                   description: |-
                                     Webhook server to reach.
@@ -4393,23 +4827,42 @@ spec:
                         type: array
                       caCertificateRefs:
                         description: |-
-                          CA certificate `ConfigMap` to use to
-                          verify the server certificate.
-                          If unset, the system's trusted certificates are used.
+                          CA certificate source to use to verify the server certificate. Omitted kind
+                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                          key is required. If unset, the system's trusted certificates are used.
                         items:
                           description: |-
-                            LocalObjectReference contains enough information to let you locate the
-                            referenced object inside the same namespace.
+                            LocalCACertificateRef references a same-namespace CA certificate source.
+                            An omitted kind defaults to ConfigMap.
                           properties:
-                            name:
-                              default: ""
-                              description: Name of the referent
+                            kind:
+                              default: ConfigMap
+                              description: Kind of the referenced CA certificate source.
+                                Omitted defaults to ConfigMap.
+                              enum:
+                              - ConfigMap
+                              - Secret
                               type: string
+                            name:
+                              description: Name of the referenced CA certificate source.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
                           type: object
                           x-kubernetes-map-type: atomic
                         maxItems: 1
                         type: array
                         x-kubernetes-list-type: atomic
+                      certificateSource:
+                        default: Inline
+                        description: Source for the gateway's client identity and
+                          trust roots (`Inline` default, or `SPIFFE`).
+                        enum:
+                        - Inline
+                        - SPIFFE
+                        type: string
                       insecureSkipVerify:
                         description: |-
                           Originates TLS but skips verification of the backend's certificate
@@ -4504,6 +4957,11 @@ spec:
                         be set together
                       rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                         : true'
+                    - message: certificateSource SPIFFE may not be combined with mtlsCertificateRef,
+                        caCertificateRefs, or insecureSkipVerify
+                      rule: '!has(self.certificateSource) || self.certificateSource
+                        != ''SPIFFE'' || (!has(self.mtlsCertificateRef) && !has(self.caCertificateRefs)
+                        && !has(self.insecureSkipVerify))'
                     - message: at most one of the fields in [verifySubjectAltNames
                         insecureSkipVerify] may be set
                       rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -4542,8 +5000,8 @@ spec:
                     properties:
                       backendRef:
                         description: |-
-                          Proxy server to reach.
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -4587,14 +5045,40 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
-                    required:
-                    - backendRef
+                      mode:
+                        default: Auto
+                        description: |-
+                          How requests are sent through the proxy.
+                          Defaults to `Auto`.
+                        enum:
+                        - Auto
+                        - Connect
+                        type: string
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [backendRef url] must
+                        be set
+                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
+                    - message: url must not include a path for backend tunnel
+                      rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                 type: object
                 x-kubernetes-validations:
-                - message: at least one of the fields in [auth authorization headers
-                    health promptGuard tls transformations tunnel] must be set
-                  rule: '[has(self.auth),has(self.authorization),has(self.headers),has(self.health),has(self.promptGuard),has(self.tls),has(self.transformations),has(self.tunnel)].filter(x,x==true).size()
+                - message: at least one of the fields in [auth authorization finalTransformations
+                    headers health promptGuard tls transformations tunnel] must be
+                    set
+                  rule: '[has(self.auth),has(self.authorization),has(self.finalTransformations),has(self.headers),has(self.health),has(self.promptGuard),has(self.tls),has(self.transformations),has(self.tunnel)].filter(x,x==true).size()
                     >= 1'
               provider:
                 description: |-

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
@@ -946,6 +946,61 @@ spec:
                 - message: The 'min' value must be less than or equal to the 'max'
                     value.
                   rule: self.min <= self.max
+              spiffe:
+                description: |-
+                  SPIFFE integration settings. When set, the gateway sources its TLS identity (X.509-SVID)
+                  and trust bundle from the local SPIFFE Workload API, and the controller
+                  mounts the Workload API socket into the pod. Listeners and backends opt in to SPIFFE individually
+                  (via the `agentgateway.dev/tls-certificate-source: SPIFFE` listener option and the
+                  AgentgatewayPolicy `backend.tls.certificateSource: SPIFFE` field respectively).
+                properties:
+                  enabled:
+                    description: |-
+                      Explicitly turns SPIFFE integration on or off for this gateway. When unset, the presence
+                      of the spiffe block opts in. Set to false on a Gateway-level AgentgatewayParameters to opt
+                      a gateway out of SPIFFE enabled at the GatewayClass level.
+                    type: boolean
+                  source:
+                    description: |-
+                      Volume source for the SPIFFE Workload API socket. When omitted (i.e. `spiffe: {}`),
+                      the socket is sourced from the SPIFFE CSI driver with default settings.
+                    properties:
+                      csi:
+                        description: Source the Workload API socket from the SPIFFE
+                          CSI driver (the default).
+                        properties:
+                          driver:
+                            description: CSI driver name. Defaults to `csi.spiffe.io`.
+                            type: string
+                        type: object
+                      hostPath:
+                        description: Source the Workload API socket from a host directory.
+                        properties:
+                          path:
+                            description: Host directory containing the SPIFFE Workload
+                              API socket, e.g. `/run/spire/agent-sockets`.
+                            minLength: 1
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      mountPath:
+                        description: |-
+                          Mount path inside the container for the Workload API socket directory.
+                          Must be an absolute path. Defaults to `/spiffe-workload-api`.
+                        pattern: ^/
+                        type: string
+                      socketName:
+                        description: Socket filename within the mount directory. Defaults
+                          to `spire-agent.sock`.
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at most one of the fields in [csi hostPath] may be
+                        set
+                      rule: '[has(self.csi),has(self.hostPath)].filter(x,x==true).size()
+                        <= 1'
+                type: object
               workload:
                 description: |-
                   `workload` selects the Kubernetes workload kind for the managed Gateway

--- a/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/charts/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -66,7 +66,7 @@ spec:
                   `sectionName` indicating the listener), `ListenerSet`, `Route`
                   (optionally, with a `sectionName` indicating the route rule), or a
                   `Service` or `Backend` (optionally, with a `sectionName` indicating the
-                  port for `Service`, or sub-backend for `Backend`).
+                  numeric port for `Service`, or sub-backend for `Backend`).
 
                   Note that a backend policy applies when connecting to a specific destination backend. Targeting a higher level
                   resource, like `Gateway`, is just a way to easily apply a policy to a
@@ -120,6 +120,37 @@ spec:
                           required:
                           - field
                           - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                      finalTransformations:
+                        description: |-
+                          CEL transformations to compute and set fields in the request body.
+                          The expression result overwrites any existing value for that field.
+                          This has a higher priority than `overrides` if both are set for the same
+                          key.
+                          Those transformations are applied after the request is converted to the provider's format, so they can be used to set provider-specific fields.
+                        items:
+                          description: |-
+                            Maps a request JSON field to a CEL expression.
+                            The expression is evaluated against the current request body and its result
+                            is assigned to the configured field.
+                          properties:
+                            expression:
+                              description: CEL expression used to compute the field
+                                value.
+                              maxLength: 16384
+                              minLength: 1
+                              type: string
+                            field:
+                              description: Name of the field to set.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                          required:
+                          - expression
+                          - field
                           type: object
                         maxItems: 64
                         minItems: 1
@@ -277,6 +308,19 @@ spec:
                                     AWS Bedrock Guardrails settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the guardrail's verdict is enforced or only
+                                        observed. `Reject` (the default) enforces the guardrail: a blocked
+                                        assessment rejects the request/response and an anonymized assessment masks
+                                        the matched content. `Audit` runs the guardrail in observe mode: it is
+                                        invoked and its assessment recorded (metrics + structured log), but the
+                                        request/response is never blocked or masked.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     identifier:
                                       description: Identifier of the Guardrail policy
                                         to use for the backend.
@@ -543,10 +587,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -570,10 +613,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -587,10 +629,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -607,10 +648,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -638,23 +678,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -755,6 +817,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -766,8 +835,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -819,9 +888,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -850,6 +945,16 @@ spec:
                                   description: Google Model Armor settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether flagged content is rejected or only observed.
+                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                        would-be rejection without blocking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     location:
                                       default: us-central1
                                       description: |-
@@ -950,10 +1055,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -977,10 +1081,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -994,10 +1097,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -1014,10 +1116,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -1045,23 +1146,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -1162,6 +1285,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -1173,8 +1303,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -1226,9 +1356,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -1255,6 +1411,16 @@ spec:
                                     endpoint.
                                     See https://developers.openai.com/api/reference/resources/moderations for more information.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether flagged content is rejected or only observed.
+                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                        would-be rejection without blocking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     model:
                                       description: |-
                                         Moderation model to use. For example,
@@ -1379,10 +1545,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -1406,10 +1571,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -1423,10 +1587,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -1443,10 +1606,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -1474,23 +1636,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -1591,6 +1775,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -1602,8 +1793,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -1655,9 +1846,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -1673,10 +1890,12 @@ spec:
                                       default: Mask
                                       description: |-
                                         The action to take if a regex pattern is matched in a request or response.
-                                        This setting applies only to request matches. `PromptguardResponse`
-                                        matches are always masked by default.
+                                        The action applies to request and response matches alike. Note that
+                                        `Mask` is not applied to streamed responses: matched content in a
+                                        streamed response is passed through unmodified.
                                         Defaults to `Mask`.
                                       enum:
+                                      - Audit
                                       - Mask
                                       - Reject
                                       type: string
@@ -1733,10 +1952,41 @@ spec:
                                       statusCode] must be set
                                     rule: '[has(self.message),has(self.statusCode)].filter(x,x==true).size()
                                       >= 1'
+                                scope:
+                                  description: |-
+                                    Which parts of the request this guard inspects. When unset, defaults to
+                                    `SystemPrompt` and `Messages`. Tool call inputs and outputs are not
+                                    inspected unless `ToolInput`/`ToolOutput` are listed explicitly.
+                                    In APIs that send tool arguments as opaque JSON, such as Completions, the
+                                    arguments are masked as a single string, meaning a prompt guard has the
+                                    potential to rewrite the arguments into invalid JSON.
+                                  items:
+                                    description: Which category of request content
+                                      a prompt guard inspects.
+                                    enum:
+                                    - Messages
+                                    - SystemPrompt
+                                    - ToolInput
+                                    - ToolOutput
+                                    type: string
+                                  maxItems: 4
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: set
                                 webhook:
                                   description: Webhook that receives requests for
                                     prompt guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the webhook's verdict is enforced or only observed.
+                                        `Reject` (the default) enforces it; `Audit` records the would-be action
+                                        without blocking or masking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     backendRef:
                                       description: |-
                                         Webhook server to reach.
@@ -1853,6 +2103,13 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
+                              - message: 'scope: only regex and bedrockGuardrails
+                                  guards support a non-default scope; other guard
+                                  kinds always inspect the default (SystemPrompt +
+                                  Messages)'
+                                rule: '!has(self.scope) || has(self.regex) || has(self.bedrockGuardrails)
+                                  || (self.scope.size() == 2 && ''SystemPrompt'' in
+                                  self.scope && ''Messages'' in self.scope)'
                               - message: exactly one of the fields in [regex webhook
                                   openAIModeration bedrockGuardrails googleModelArmor]
                                   must be set
@@ -1873,6 +2130,19 @@ spec:
                                     AWS Bedrock Guardrails settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the guardrail's verdict is enforced or only
+                                        observed. `Reject` (the default) enforces the guardrail: a blocked
+                                        assessment rejects the request/response and an anonymized assessment masks
+                                        the matched content. `Audit` runs the guardrail in observe mode: it is
+                                        invoked and its assessment recorded (metrics + structured log), but the
+                                        request/response is never blocked or masked.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     identifier:
                                       description: Identifier of the Guardrail policy
                                         to use for the backend.
@@ -2139,10 +2409,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -2166,10 +2435,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -2183,10 +2451,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -2203,10 +2470,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -2234,23 +2500,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -2351,6 +2639,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -2362,8 +2657,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -2415,9 +2710,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -2446,6 +2767,16 @@ spec:
                                   description: Google Model Armor settings for prompt
                                     guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether flagged content is rejected or only observed.
+                                        `Reject` (the default) rejects flagged content; `Audit` records the
+                                        would-be rejection without blocking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     location:
                                       default: us-central1
                                       description: |-
@@ -2546,10 +2877,9 @@ spec:
                                               description: Deadline for receiving
                                                 a response from the backend.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: requestTimeout must be at
                                                   least 1ms
                                                 rule: duration(self) >= duration('1ms')
@@ -2573,10 +2903,9 @@ spec:
                                                 Deadline for establishing a connection to
                                                 the destination.
                                               maxLength: 32
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
                                               x-kubernetes-validations:
-                                              - message: invalid duration value
-                                                rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                               - message: connectTimeout must be at
                                                   least 100ms
                                                 rule: duration(self) >= duration('100ms')
@@ -2590,10 +2919,9 @@ spec:
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: interval must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -2610,10 +2938,9 @@ spec:
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
                                                   maxLength: 32
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                   type: string
                                                   x-kubernetes-validations:
-                                                  - message: invalid duration value
-                                                    rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                                   - message: time must be at least
                                                       1 second
                                                     rule: duration(self) >= duration('1s')
@@ -2641,23 +2968,45 @@ spec:
                                               type: array
                                             caCertificateRefs:
                                               description: |-
-                                                CA certificate `ConfigMap` to use to
-                                                verify the server certificate.
-                                                If unset, the system's trusted certificates are used.
+                                                CA certificate source to use to verify the server certificate. Omitted kind
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                                                key is required. If unset, the system's trusted certificates are used.
                                               items:
                                                 description: |-
-                                                  LocalObjectReference contains enough information to let you locate the
-                                                  referenced object inside the same namespace.
+                                                  LocalCACertificateRef references a same-namespace CA certificate source.
+                                                  An omitted kind defaults to ConfigMap.
                                                 properties:
-                                                  name:
-                                                    default: ""
-                                                    description: Name of the referent
+                                                  kind:
+                                                    default: ConfigMap
+                                                    description: Kind of the referenced
+                                                      CA certificate source. Omitted
+                                                      defaults to ConfigMap.
+                                                    enum:
+                                                    - ConfigMap
+                                                    - Secret
                                                     type: string
+                                                  name:
+                                                    description: Name of the referenced
+                                                      CA certificate source.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               maxItems: 1
                                               type: array
                                               x-kubernetes-list-type: atomic
+                                            certificateSource:
+                                              default: Inline
+                                              description: Source for the gateway's
+                                                client identity and trust roots (`Inline`
+                                                default, or `SPIFFE`).
+                                              enum:
+                                              - Inline
+                                              - SPIFFE
+                                              type: string
                                             insecureSkipVerify:
                                               description: |-
                                                 Originates TLS but skips verification of the backend's certificate
@@ -2758,6 +3107,13 @@ spec:
                                               may not be set together
                                             rule: 'has(self.insecureSkipVerify) ?
                                               !has(self.verifySubjectAltNames) : true'
+                                          - message: certificateSource SPIFFE may
+                                              not be combined with mtlsCertificateRef,
+                                              caCertificateRefs, or insecureSkipVerify
+                                            rule: '!has(self.certificateSource) ||
+                                              self.certificateSource != ''SPIFFE''
+                                              || (!has(self.mtlsCertificateRef) &&
+                                              !has(self.caCertificateRefs) && !has(self.insecureSkipVerify))'
                                           - message: at most one of the fields in
                                               [verifySubjectAltNames insecureSkipVerify]
                                               may be set
@@ -2769,8 +3125,8 @@ spec:
                                           properties:
                                             backendRef:
                                               description: |-
-                                                Proxy server to reach.
-                                                Supported types: `Service` and `Backend`.
+                                                `backendRef` selects a backend for this policy.
+                                                Mutually exclusive with `url`.
                                               properties:
                                                 group:
                                                   default: ""
@@ -2822,9 +3178,35 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                          required:
-                                          - backendRef
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
+                                            url:
+                                              description: |-
+                                                `url` directly specifies the HTTP(S) endpoint for this policy.
+                                                When the scheme is `https`, backend TLS is enabled automatically.
+                                                Mutually exclusive with `backendRef`.
+                                                URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                                will not apply Service policies or load balancing.
+                                              maxLength: 1024
+                                              minLength: 1
+                                              pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                              type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: exactly one of the fields in
+                                              [backendRef url] must be set
+                                            rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                              == 1'
+                                          - message: url must not include a path for
+                                              backend tunnel
+                                            rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                                       type: object
                                       x-kubernetes-validations:
                                       - message: at least one of the fields in [auth
@@ -2853,10 +3235,12 @@ spec:
                                       default: Mask
                                       description: |-
                                         The action to take if a regex pattern is matched in a request or response.
-                                        This setting applies only to request matches. `PromptguardResponse`
-                                        matches are always masked by default.
+                                        The action applies to request and response matches alike. Note that
+                                        `Mask` is not applied to streamed responses: matched content in a
+                                        streamed response is passed through unmodified.
                                         Defaults to `Mask`.
                                       enum:
+                                      - Audit
                                       - Mask
                                       - Reject
                                       type: string
@@ -2917,6 +3301,16 @@ spec:
                                   description: Webhook that receives responses for
                                     prompt guarding.
                                   properties:
+                                    action:
+                                      default: Reject
+                                      description: |-
+                                        Action controls whether the webhook's verdict is enforced or only observed.
+                                        `Reject` (the default) enforces it; `Audit` records the would-be action
+                                        without blocking or masking.
+                                      enum:
+                                      - Audit
+                                      - Reject
+                                      type: string
                                     backendRef:
                                       description: |-
                                         Webhook server to reach.
@@ -3063,6 +3457,8 @@ spec:
                           - Completions
                           - Detect
                           - Embeddings
+                          - GeminiCountTokens
+                          - GenerateContent
                           - Messages
                           - Models
                           - Passthrough
@@ -3109,10 +3505,10 @@ spec:
                         type: array
                     type: object
                     x-kubernetes-validations:
-                    - message: at least one of the fields in [defaults modelAliases
-                        overrides prompt promptCaching promptGuard routes transformations]
-                        must be set
-                      rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
+                    - message: at least one of the fields in [defaults finalTransformations
+                        modelAliases overrides prompt promptCaching promptGuard routes
+                        transformations] must be set
+                      rule: '[has(self.defaults),has(self.finalTransformations),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                         >= 1'
                   auth:
                     description: Settings for managing authentication to the backend
@@ -3248,19 +3644,29 @@ spec:
                         description: Azure authentication method for the backend.
                         properties:
                           managedIdentity:
-                            description: Managed identity authentication settings.
+                            description: |-
+                              Managed identity authentication settings. Leave this object empty to use
+                              the system-assigned identity. To use a user-assigned identity, set one of
+                              `clientId`, `objectId`, or `resourceId`.
                             properties:
                               clientId:
+                                description: Client ID of the user-assigned managed
+                                  identity.
                                 type: string
                               objectId:
+                                description: Object ID of the user-assigned managed
+                                  identity.
                                 type: string
                               resourceId:
+                                description: Resource ID of the user-assigned managed
+                                  identity.
                                 type: string
-                            required:
-                            - clientId
-                            - objectId
-                            - resourceId
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [clientId objectId
+                                resourceId] may be set
+                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source for Azure credentials, defaulting to a Kubernetes
@@ -3408,6 +3814,14 @@ spec:
                         description: Cross App Access (Identity Assertion / ID-JAG)
                           authentication.
                         properties:
+                          accessTokenScopes:
+                            description: |-
+                              Scopes requested when exchanging the ID-JAG for an access token.
+                              When omitted, defaults to Scopes. Set to an empty list to omit scope.
+                            items:
+                              type: string
+                            maxItems: 64
+                            type: array
                           audience:
                             description: Identifier of the resource authorization
                               server. The issued ID-JAG is bound to this audience.
@@ -3422,7 +3836,12 @@ spec:
                                   defaultTtl:
                                     description: TTL used when the token endpoint
                                       omits expires_in. Default 300s.
+                                    maxLength: 32
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                    x-kubernetes-validations:
+                                    - message: defaultTtl must be at least 1 second
+                                      rule: duration(self) >= duration('1s')
                                   maxEntries:
                                     description: Default 8192; 0 disables the cache.
                                     format: int32
@@ -3434,7 +3853,9 @@ spec:
                               used for the RFC 8693 ID-JAG exchange.
                             properties:
                               backendRef:
-                                description: Token endpoint backend.
+                                description: |-
+                                  `backendRef` selects a backend for this policy.
+                                  Mutually exclusive with `url`.
                                 properties:
                                   group:
                                     default: ""
@@ -3663,16 +4084,35 @@ spec:
                                   Must start with "/".
                                 pattern: ^/
                                 type: string
+                              url:
+                                description: |-
+                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                  Mutually exclusive with `backendRef`.
+                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                  will not apply Service policies or load balancing.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                type: string
                             required:
-                            - backendRef
                             - clientAuth
                             type: object
+                            x-kubernetes-validations:
+                            - message: path may not be set when url is set
+                              rule: 'has(self.url) ? !has(self.path) : true'
+                            - message: exactly one of the fields in [backendRef url]
+                                must be set
+                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                == 1'
                           resourceAuthorizationServer:
                             description: Resource authorization server, used for the
                               RFC 7523 jwt-bearer exchange.
                             properties:
                               backendRef:
-                                description: Token endpoint backend.
+                                description: |-
+                                  `backendRef` selects a backend for this policy.
+                                  Mutually exclusive with `url`.
                                 properties:
                                   group:
                                     default: ""
@@ -3901,10 +4341,27 @@ spec:
                                   Must start with "/".
                                 pattern: ^/
                                 type: string
+                              url:
+                                description: |-
+                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                  Mutually exclusive with `backendRef`.
+                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                  will not apply Service policies or load balancing.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                type: string
                             required:
-                            - backendRef
                             - clientAuth
                             type: object
+                            x-kubernetes-validations:
+                            - message: path may not be set when url is set
+                              rule: 'has(self.url) ? !has(self.path) : true'
+                            - message: exactly one of the fields in [backendRef url]
+                                must be set
+                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                == 1'
                           resources:
                             description: Resources sent to the token endpoint.
                             items:
@@ -3913,7 +4370,8 @@ spec:
                             minItems: 1
                             type: array
                           scopes:
-                            description: Scopes sent to the token endpoint.
+                            description: Scopes requested when obtaining the ID-JAG
+                              from the identity provider.
                             items:
                               type: string
                             maxItems: 64
@@ -3975,7 +4433,15 @@ spec:
                                     cookie expression] must be set
                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                     == 1'
+                              tokenType:
+                                description: OAuth RFC 8693 subject token type. Defaults
+                                  to IdToken
+                                type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: tokenType IdJag is not supported by crossAppAccess
+                              rule: '!has(self.tokenType) || (self.tokenType != ''IdJag''
+                                && self.tokenType != ''urn:ietf:params:oauth:token-type:id-jag'')'
                         required:
                         - audience
                         - identityProvider
@@ -4044,6 +4510,119 @@ spec:
                         x-kubernetes-validations:
                         - message: audience is only valid with IdToken
                           rule: 'has(self.audience) ? self.type == ''IdToken'' : true'
+                      jwtSign:
+                        description: |-
+                          Signs a short-lived JWT with a private key on each request and sends it
+                          to the backend, for upstreams that require per-request keypair JWTs
+                          (e.g. the Snowflake SQL API) rather than a static credential.
+                        properties:
+                          alg:
+                            description: JWS signing algorithm. Defaults to RS256.
+                            enum:
+                            - ES256
+                            - ES384
+                            - PS256
+                            - RS256
+                            - RS384
+                            - RS512
+                            type: string
+                          claims:
+                            additionalProperties:
+                              x-kubernetes-preserve-unknown-fields: true
+                            description: |-
+                              Static claims added to every token (e.g. iss, sub, aud). Values may be
+                              any JSON value (e.g. a string, number, bool, or array). iat, exp, and
+                              nbf are reserved for the signer and cannot be configured here; the
+                              controller rejects them at translation time.
+                            type: object
+                          kid:
+                            description: Optional JWS key ID header.
+                            type: string
+                          location:
+                            description: |-
+                              Where the signed token is written on the backend request.
+                              Defaults to the Authorization header with a "Bearer " prefix.
+                            properties:
+                              cookie:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              header:
+                                properties:
+                                  name:
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  prefix:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              queryParameter:
+                                properties:
+                                  name:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            type: object
+                            x-kubernetes-validations:
+                            - message: exactly one of the fields in [header queryParameter
+                                cookie] must be set
+                              rule: '[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size()
+                                == 1'
+                          signingKeyRef:
+                            description: Secret providing the `signingKey` key with
+                              a PEM-encoded RSA or EC private key.
+                            properties:
+                              group:
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
+                                type: string
+                              kind:
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
+                                type: string
+                              name:
+                                description: Name of the referenced credential
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                            - message: custom credential refs must set both group
+                                and kind
+                              rule: '(!has(self.group) || size(self.group) == 0) ?
+                                (!has(self.kind) || size(self.kind) == 0 || self.kind
+                                == ''Secret'') : (has(self.kind) && size(self.kind)
+                                > 0)'
+                          ttl:
+                            description: Token lifetime used for exp. Defaults to
+                              300s.
+                            maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                            x-kubernetes-validations:
+                            - message: ttl must be at least 1 second
+                              rule: duration(self) >= duration('1s')
+                        required:
+                        - signingKeyRef
+                        type: object
                       key:
                         description: |-
                           Inline key to use as the value of the
@@ -4194,7 +4773,9 @@ spec:
                             minItems: 1
                             type: array
                           backendRef:
-                            description: RFC 8693 token endpoint backend.
+                            description: |-
+                              `backendRef` selects a backend for this policy.
+                              Mutually exclusive with `url`.
                             properties:
                               group:
                                 default: ""
@@ -4246,7 +4827,12 @@ spec:
                                   defaultTtl:
                                     description: TTL used when the token endpoint
                                       omits expires_in. Default 300s.
+                                    maxLength: 32
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                    x-kubernetes-validations:
+                                    - message: defaultTtl must be at least 1 second
+                                      rule: duration(self) >= duration('1s')
                                   maxEntries:
                                     description: Default 8192; 0 disables the cache.
                                     format: int32
@@ -4574,8 +5160,17 @@ spec:
                                   are supported for subject tokens.
                                 type: string
                             type: object
-                        required:
-                        - backendRef
+                          url:
+                            description: |-
+                              `url` directly specifies the HTTP(S) endpoint for this policy.
+                              When the scheme is `https`, backend TLS is enabled automatically.
+                              Mutually exclusive with `backendRef`.
+                              URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                              will not apply Service policies or load balancing.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: actorToken is only valid with TokenExchange grantType
@@ -4588,6 +5183,12 @@ spec:
                         - message: requestedTokenType IdJag is only supported by crossAppAccess
                           rule: '!has(self.requestedTokenType) || self.requestedTokenType
                             != ''IdJag'''
+                        - message: path may not be set when url is set
+                          rule: 'has(self.url) ? !has(self.path) : true'
+                        - message: exactly one of the fields in [backendRef url] must
+                            be set
+                          rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                            == 1'
                       passthrough:
                         description: |-
                           Reuses a client token already validated by another policy. Those policies
@@ -4632,18 +5233,20 @@ spec:
                             (has(self.kind) && size(self.kind) > 0)'
                     type: object
                     x-kubernetes-validations:
-                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess
+                    - message: must specify credentials, or at most one of key/secretRef/passthrough/aws/azure/gcp/oauthTokenExchange/crossAppAccess/jwtSign
                         (credentials may be combined with a primary auth kind)
                       rule: has(self.credentials) || has(self.key) || has(self.secretRef)
                         || has(self.passthrough) || has(self.aws) || has(self.azure)
                         || has(self.gcp) || has(self.oauthTokenExchange) || has(self.crossAppAccess)
+                        || has(self.jwtSign)
                     - message: location may only be set for key, secretRef, or passthrough
                         auth
                       rule: 'has(self.location) ? has(self.key) || has(self.secretRef)
                         || has(self.passthrough) : true'
                     - message: at most one of the fields in [key secretRef passthrough
-                        aws azure gcp oauthTokenExchange crossAppAccess] may be set
-                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess)].filter(x,x==true).size()
+                        aws azure gcp oauthTokenExchange crossAppAccess jwtSign] may
+                        be set
+                      rule: '[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp),has(self.oauthTokenExchange),has(self.crossAppAccess),has(self.jwtSign)].filter(x,x==true).size()
                         <= 1'
                   extAuth:
                     description: |-
@@ -4652,9 +5255,8 @@ spec:
                     properties:
                       backendRef:
                         description: |-
-                          External Authorization server to reach.
-
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -4889,10 +5491,30 @@ spec:
                             maxProperties: 64
                             type: object
                         type: object
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
                     x-kubernetes-validations:
+                    - message: exactly one of backendRef or url must be set
+                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
                     - message: forwardBody cannot be used with http.body
                       rule: '!(has(self.forwardBody) && has(self.http) && has(self.http.body))'
+                    - message: url path is only valid with http
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || has(self.http)'
+                    - message: http.path may not be set when url includes a path
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || !has(self.http) || !has(self.http.path)'
                   health:
                     description: Settings for passive and active health checking.
                     properties:
@@ -4917,11 +5539,10 @@ spec:
                               rather than failing entirely.
                               If unset, defaults to `3s`.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
-                            - message: evictionDuration must be at least 1 second
+                            - message: duration must be at least 1 second
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
@@ -4964,10 +5585,9 @@ spec:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: requestTimeout must be at least 1ms
                           rule: duration(self) >= duration('1ms')
                       version:
@@ -5061,11 +5681,8 @@ spec:
                             properties:
                               backendRef:
                                 description: |-
-                                  Remote JWKS server to reach.
-                                  Supported types are `Service` and static `Backend`. An
-                                  `AgentgatewayPolicy` containing backend TLS config can then be attached
-                                  to the `Service` or `Backend` in order to set TLS options for a
-                                  connection to the remote `jwks` source.
+                                  `backendRef` selects a backend for this policy.
+                                  Mutually exclusive with `url`.
                                 properties:
                                   group:
                                     default: ""
@@ -5112,24 +5729,42 @@ spec:
                                     ? has(self.port) : true'
                               cacheDuration:
                                 default: 5m
+                                description: How long a fetched `jwks` document is
+                                  used before it is re-fetched from the IdP.
                                 maxLength: 32
+                                pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid duration value
-                                  rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                 - message: cacheDuration must be at least 5m.
                                   rule: duration(self) >= duration('5m')
                               jwksPath:
                                 description: |-
                                   Path to the IdP `jwks` endpoint, relative to the root, commonly
                                   `".well-known/jwks.json"`.
-                                maxLength: 2000
+                                maxLength: 1024
                                 minLength: 1
                                 type: string
-                            required:
-                            - backendRef
-                            - jwksPath
+                              url:
+                                description: |-
+                                  `url` directly specifies the HTTP(S) endpoint for this policy.
+                                  When the scheme is `https`, backend TLS is enabled automatically.
+                                  Mutually exclusive with `backendRef`.
+                                  URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                  will not apply Service policies or load balancing.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: jwksPath is required when backendRef is set
+                              rule: 'has(self.backendRef) ? has(self.jwksPath) : true'
+                            - message: jwksPath may not be set when url is set
+                              rule: 'has(self.url) ? !has(self.jwksPath) : true'
+                            - message: exactly one of the fields in [backendRef url]
+                                must be set
+                              rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                == 1'
                           mode:
                             default: Strict
                             description: Validation mode for JWT authentication.
@@ -5276,8 +5911,8 @@ spec:
                                       x-kubernetes-list-type: set
                                     backendRef:
                                       description: |-
-                                        `backendRef` references the remote guardrails policy server.
-                                        Supported types: `Service` and `Backend`.
+                                        `backendRef` selects a backend for this policy.
+                                        Mutually exclusive with `url`.
                                       properties:
                                         group:
                                           default: ""
@@ -5366,9 +6001,25 @@ spec:
                                         keyed by config key. Values are CEL expressions.
                                       maxProperties: 64
                                       type: object
-                                  required:
-                                  - backendRef
+                                    url:
+                                      description: |-
+                                        `url` directly specifies the HTTP(S) endpoint for this policy.
+                                        When the scheme is `https`, backend TLS is enabled automatically.
+                                        Mutually exclusive with `backendRef`.
+                                        URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                        will not apply Service policies or load balancing.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                      type: string
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: url must not include a path
+                                    rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
+                                  - message: exactly one of the fields in [backendRef
+                                      url] must be set
+                                    rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                      == 1'
                               required:
                               - methods
                               type: object
@@ -5397,10 +6048,9 @@ spec:
                           Deadline for establishing a connection to
                           the destination.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: connectTimeout must be at least 100ms
                           rule: duration(self) >= duration('100ms')
                       keepalive:
@@ -5413,10 +6063,9 @@ spec:
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                             - message: interval must be at least 1 second
                               rule: duration(self) >= duration('1s')
                           retries:
@@ -5432,10 +6081,9 @@ spec:
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                             - message: time must be at least 1 second
                               rule: duration(self) >= duration('1s')
                         type: object
@@ -5462,23 +6110,42 @@ spec:
                         type: array
                       caCertificateRefs:
                         description: |-
-                          CA certificate `ConfigMap` to use to
-                          verify the server certificate.
-                          If unset, the system's trusted certificates are used.
+                          CA certificate source to use to verify the server certificate. Omitted kind
+                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
+                          key is required. If unset, the system's trusted certificates are used.
                         items:
                           description: |-
-                            LocalObjectReference contains enough information to let you locate the
-                            referenced object inside the same namespace.
+                            LocalCACertificateRef references a same-namespace CA certificate source.
+                            An omitted kind defaults to ConfigMap.
                           properties:
-                            name:
-                              default: ""
-                              description: Name of the referent
+                            kind:
+                              default: ConfigMap
+                              description: Kind of the referenced CA certificate source.
+                                Omitted defaults to ConfigMap.
+                              enum:
+                              - ConfigMap
+                              - Secret
                               type: string
+                            name:
+                              description: Name of the referenced CA certificate source.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
                           type: object
                           x-kubernetes-map-type: atomic
                         maxItems: 1
                         type: array
                         x-kubernetes-list-type: atomic
+                      certificateSource:
+                        default: Inline
+                        description: Source for the gateway's client identity and
+                          trust roots (`Inline` default, or `SPIFFE`).
+                        enum:
+                        - Inline
+                        - SPIFFE
+                        type: string
                       insecureSkipVerify:
                         description: |-
                           Originates TLS but skips verification of the backend's certificate
@@ -5573,6 +6240,11 @@ spec:
                         be set together
                       rule: 'has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames)
                         : true'
+                    - message: certificateSource SPIFFE may not be combined with mtlsCertificateRef,
+                        caCertificateRefs, or insecureSkipVerify
+                      rule: '!has(self.certificateSource) || self.certificateSource
+                        != ''SPIFFE'' || (!has(self.mtlsCertificateRef) && !has(self.caCertificateRefs)
+                        && !has(self.insecureSkipVerify))'
                     - message: at most one of the fields in [verifySubjectAltNames
                         insecureSkipVerify] may be set
                       rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
@@ -5819,8 +6491,8 @@ spec:
                     properties:
                       backendRef:
                         description: |-
-                          Proxy server to reach.
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -5864,9 +6536,34 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
-                    required:
-                    - backendRef
+                      mode:
+                        default: Auto
+                        description: |-
+                          How requests are sent through the proxy.
+                          Defaults to `Auto`.
+                        enum:
+                        - Auto
+                        - Connect
+                        type: string
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [backendRef url] must
+                        be set
+                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
+                    - message: url must not include a path for backend tunnel
+                      rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                 type: object
                 x-kubernetes-validations:
                 - message: at least one of the fields in [ai auth extAuth health http
@@ -5992,8 +6689,8 @@ spec:
                                 >= 1'
                           backendRef:
                             description: |-
-                              OTLP server to send access logs to.
-                              Supported types: `Service` and `AgentgatewayBackend`.
+                              `backendRef` selects a backend for this policy.
+                              Mutually exclusive with `url`.
                             properties:
                               group:
                                 default: ""
@@ -6059,8 +6756,17 @@ spec:
                             - GRPC
                             - HTTP
                             type: string
-                        required:
-                        - backendRef
+                          url:
+                            description: |-
+                              `url` directly specifies the HTTP(S) endpoint for this policy.
+                              When the scheme is `https`, backend TLS is enabled automatically.
+                              Mutually exclusive with `backendRef`.
+                              URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                              will not apply Service policies or load balancing.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: path is only valid with protocol HTTP
@@ -6068,6 +6774,13 @@ spec:
                             == ''HTTP'''
                         - message: path must start with /
                           rule: '!has(self.path) || self.path.startsWith(''/'')'
+                        - message: url path is only valid with protocol HTTP
+                          rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                            || (has(self.protocol) && self.protocol == ''HTTP'')'
+                        - message: exactly one of the fields in [backendRef url] must
+                            be set
+                          rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                            == 1'
                     type: object
                   connect:
                     description: |-
@@ -6105,10 +6818,9 @@ spec:
                           closed.
                           If unset, this defaults to 10 minutes.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: http1IdleTimeout must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http1MaxHeaders:
@@ -6155,19 +6867,23 @@ spec:
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2KeepaliveInterval:
+                        description: |-
+                          Interval between `HTTP/2` keepalive pings.
+                          If unset, keepalive pings are not sent.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: http2KeepaliveInterval must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http2KeepaliveTimeout:
+                        description: |-
+                          Time to wait for a response to an `HTTP/2` keepalive ping before the connection is closed.
+                          Only applies when `http2KeepaliveInterval` is set.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: http2KeepaliveTimeout must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http2MaxHeaderSize:
@@ -6218,16 +6934,23 @@ spec:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
+                      maxConcurrentRequests:
+                        description: |-
+                          Maximum number of in-flight HTTP requests across this gateway/port.
+                          This includes HTTP/1 requests and HTTP/2 streams. Requests over the limit
+                          are rejected immediately with a 503 response. Unset means unlimited.
+                        format: int32
+                        minimum: 1
+                        type: integer
                       maxConnectionDuration:
                         description: |-
                           Maximum time a connection is allowed to remain open.
                           After this duration, the connection is gracefully closed after the current in-flight request completes.
                           Useful for ensuring even traffic distribution behind load balancers during scaling events.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: maxConnectionDuration must be at least 1 second
                           rule: duration(self) >= duration('1s')
                     type: object
@@ -6235,8 +6958,8 @@ spec:
                     - message: at least one of the fields in [http1HeaderCase http1IdleTimeout
                         http1MaxHeaders http2ConnectionWindowSize http2FrameSize http2KeepaliveInterval
                         http2KeepaliveTimeout http2MaxHeaderSize http2WindowSize maxBufferSize
-                        maxConnectionDuration] must be set
-                      rule: '[has(self.http1HeaderCase),has(self.http1IdleTimeout),has(self.http1MaxHeaders),has(self.http2ConnectionWindowSize),has(self.http2FrameSize),has(self.http2KeepaliveInterval),has(self.http2KeepaliveTimeout),has(self.http2MaxHeaderSize),has(self.http2WindowSize),has(self.maxBufferSize),has(self.maxConnectionDuration)].filter(x,x==true).size()
+                        maxConcurrentRequests maxConnectionDuration] must be set
+                      rule: '[has(self.http1HeaderCase),has(self.http1IdleTimeout),has(self.http1MaxHeaders),has(self.http2ConnectionWindowSize),has(self.http2FrameSize),has(self.http2KeepaliveInterval),has(self.http2KeepaliveTimeout),has(self.http2MaxHeaderSize),has(self.http2WindowSize),has(self.maxBufferSize),has(self.maxConcurrentRequests),has(self.maxConnectionDuration)].filter(x,x==true).size()
                         >= 1'
                   metrics:
                     description: |-
@@ -6378,10 +7101,9 @@ spec:
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                             - message: interval must be at least 1 second
                               rule: duration(self) >= duration('1s')
                           retries:
@@ -6397,17 +7119,25 @@ spec:
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
                             maxLength: 32
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid duration value
-                              rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                             - message: time must be at least 1 second
                               rule: duration(self) >= duration('1s')
                         type: object
+                      maxConnections:
+                        description: |-
+                          Maximum number of active downstream connections on this gateway/port.
+                          Connections over the limit are closed immediately. Unset means unlimited.
+                        format: int32
+                        minimum: 1
+                        type: integer
                     type: object
                     x-kubernetes-validations:
-                    - message: at least one of the fields in [keepalive] must be set
-                      rule: '[has(self.keepalive)].filter(x,x==true).size() >= 1'
+                    - message: at least one of the fields in [keepalive maxConnections]
+                        must be set
+                      rule: '[has(self.keepalive),has(self.maxConnections)].filter(x,x==true).size()
+                        >= 1'
                   tls:
                     description: Settings for managing incoming TLS connections.
                     properties:
@@ -6448,10 +7178,9 @@ spec:
                           Deadline for a TLS handshake to
                           complete. If unset, this defaults to `15s`.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: handshakeTimeout must be at least 100ms
                           rule: duration(self) >= duration('100ms')
                       keyExchangeGroups:
@@ -6535,8 +7264,8 @@ spec:
                             >= 1'
                       backendRef:
                         description: |-
-                          OTLP server to reach.
-                          Supported types: `Service` and `AgentgatewayBackend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -6642,8 +7371,17 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - backendRef
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
                     x-kubernetes-validations:
                     - message: path is only valid with protocol HTTP
@@ -6651,6 +7389,13 @@ spec:
                         == ''HTTP'''
                     - message: path must start with /
                       rule: '!has(self.path) || self.path.startsWith(''/'')'
+                    - message: url path is only valid with protocol HTTP
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || (has(self.protocol) && self.protocol == ''HTTP'')'
+                    - message: exactly one of the fields in [backendRef url] must
+                        be set
+                      rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
                 type: object
                 x-kubernetes-validations:
                 - message: at least one of the fields in [accessLog connect http metrics
@@ -7579,9 +8324,8 @@ spec:
                     properties:
                       backendRef:
                         description: |-
-                          External Authorization server to reach.
-
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -7691,9 +8435,8 @@ spec:
                               properties:
                                 backendRef:
                                   description: |-
-                                    External Authorization server to reach.
-
-                                    Supported types: `Service` and `Backend`.
+                                    `backendRef` selects a backend for this policy.
+                                    Mutually exclusive with `url`.
                                   properties:
                                     group:
                                       default: ""
@@ -7935,10 +8678,22 @@ spec:
                                       maxProperties: 64
                                       type: object
                                   type: object
+                                url:
+                                  description: |-
+                                    `url` directly specifies the HTTP(S) endpoint for this policy.
+                                    When the scheme is `https`, backend TLS is enabled automatically.
+                                    Mutually exclusive with `backendRef`.
+                                    URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                    will not apply Service policies or load balancing.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                  type: string
                               type: object
                               x-kubernetes-validations:
-                              - message: backendRef is required
-                                rule: has(self.backendRef)
+                              - message: exactly one of backendRef or url is required
+                                rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                  == 1'
                               - message: exactly one of the fields in [grpc http]
                                   must be set
                                 rule: '[has(self.grpc),has(self.http)].filter(x,x==true).size()
@@ -7946,6 +8701,13 @@ spec:
                               - message: forwardBody cannot be used with http.body
                                 rule: '!(has(self.forwardBody) && has(self.http) &&
                                   has(self.http.body))'
+                              - message: url path is only valid with http
+                                rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                                  || has(self.http)'
+                              - message: http.path may not be set when url includes
+                                  a path
+                                rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                                  || !has(self.http) || !has(self.http.path)'
                           required:
                           - policy
                           type: object
@@ -8100,25 +8862,45 @@ spec:
                             maxProperties: 64
                             type: object
                         type: object
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
                     x-kubernetes-validations:
+                    - message: exactly one of backendRef or url must be set unless
+                        conditional is set
+                      rule: 'has(self.conditional) ? (!has(self.backendRef) && !has(self.url))
+                        : [has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
                     - message: exactly one of the fields in [grpc http] must be set
                       rule: has(self.conditional) || [has(self.grpc),has(self.http)].filter(x,x==true).size()
                         == 1
                     - message: forwardBody cannot be used with http.body
                       rule: '!(has(self.forwardBody) && has(self.http) && has(self.http.body))'
+                    - message: url path is only valid with http
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || has(self.http)'
+                    - message: http.path may not be set when url includes a path
+                      rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
+                        || !has(self.http) || !has(self.http.path)'
                     - message: conditional cannot be set with any other field
-                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.cache),has(self.failureMode),has(self.forwardBody),has(self.grpc),has(self.http)].filter(x,x==true).size()
+                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.cache),has(self.failureMode),has(self.forwardBody),has(self.grpc),has(self.http),has(self.url)].filter(x,x==true).size()
                         == 0 : true'
-                    - message: 'backendRef: Required value'
-                      rule: 'has(self.conditional) ? true : has(self.backendRef)'
                   extProc:
                     description: External processing configuration for the policy.
                     properties:
                       backendRef:
                         description: |-
-                          External Processor server to reach.
-                          Supported types: `Service` and `Backend`.
+                          `backendRef` selects a backend for this policy.
+                          Mutually exclusive with `url`.
                         properties:
                           group:
                             default: ""
@@ -8181,8 +8963,8 @@ spec:
                               properties:
                                 backendRef:
                                   description: |-
-                                    External Processor server to reach.
-                                    Supported types: `Service` and `Backend`.
+                                    `backendRef` selects a backend for this policy.
+                                    Mutually exclusive with `url`.
                                   properties:
                                     group:
                                       default: ""
@@ -8273,9 +9055,7 @@ spec:
                                       default: FullDuplexStreamed
                                       description: |-
                                         How request bodies are sent to the external processor.
-                                        `Buffered` buffers the full body and returns an error if it exceeds 8KB.
-                                        `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
-                                        body exceeds that limit. Defaults to `FullDuplexStreamed`.
+                                        Defaults to `FullDuplexStreamed`.
                                       enum:
                                       - Buffered
                                       - BufferedPartial
@@ -8304,9 +9084,7 @@ spec:
                                       default: FullDuplexStreamed
                                       description: |-
                                         How response bodies are sent to the external processor.
-                                        `Buffered` buffers the full body and returns an error if it exceeds 8KB.
-                                        `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
-                                        body exceeds that limit. Defaults to `FullDuplexStreamed`.
+                                        Defaults to `FullDuplexStreamed`.
                                       enum:
                                       - Buffered
                                       - BufferedPartial
@@ -8358,10 +9136,24 @@ spec:
                                     evaluated per response.
                                   maxProperties: 64
                                   type: object
+                                url:
+                                  description: |-
+                                    `url` directly specifies the HTTP(S) endpoint for this policy.
+                                    When the scheme is `https`, backend TLS is enabled automatically.
+                                    Mutually exclusive with `backendRef`.
+                                    URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                    will not apply Service policies or load balancing.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                  type: string
                               type: object
                               x-kubernetes-validations:
-                              - message: backendRef is required
-                                rule: has(self.backendRef)
+                              - message: exactly one of backendRef or url is required
+                                rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                  == 1'
+                              - message: url must not include a path
+                                rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                           required:
                           - policy
                           type: object
@@ -8414,9 +9206,7 @@ spec:
                             default: FullDuplexStreamed
                             description: |-
                               How request bodies are sent to the external processor.
-                              `Buffered` buffers the full body and returns an error if it exceeds 8KB.
-                              `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
-                              body exceeds that limit. Defaults to `FullDuplexStreamed`.
+                              Defaults to `FullDuplexStreamed`.
                             enum:
                             - Buffered
                             - BufferedPartial
@@ -8445,9 +9235,7 @@ spec:
                             default: FullDuplexStreamed
                             description: |-
                               How response bodies are sent to the external processor.
-                              `Buffered` buffers the full body and returns an error if it exceeds 8KB.
-                              `BufferedPartial` buffers up to 8KB and sends the buffered prefix if the
-                              body exceeds that limit. Defaults to `FullDuplexStreamed`.
+                              Defaults to `FullDuplexStreamed`.
                             enum:
                             - Buffered
                             - BufferedPartial
@@ -8497,13 +9285,29 @@ spec:
                           evaluated per response.
                         maxProperties: 64
                         type: object
+                      url:
+                        description: |-
+                          `url` directly specifies the HTTP(S) endpoint for this policy.
+                          When the scheme is `https`, backend TLS is enabled automatically.
+                          Mutually exclusive with `backendRef`.
+                          URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                          will not apply Service policies or load balancing.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                        type: string
                     type: object
                     x-kubernetes-validations:
+                    - message: exactly one of backendRef or url must be set unless
+                        conditional is set
+                      rule: 'has(self.conditional) ? (!has(self.backendRef) && !has(self.url))
+                        : [has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                        == 1'
+                    - message: url must not include a path
+                      rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
                     - message: conditional cannot be set with any other field
-                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes)].filter(x,x==true).size()
+                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes),has(self.url)].filter(x,x==true).size()
                         == 0 : true'
-                    - message: 'backendRef: Required value'
-                      rule: 'has(self.conditional) ? true : has(self.backendRef)'
                   headerModifiers:
                     description: Request and response header modification policy.
                     properties:
@@ -8853,6 +9657,12 @@ spec:
                         - Permissive
                         - Strict
                         type: string
+                      preserveToken:
+                        description: |-
+                          Keeps a successfully validated JWT in its original location. By default, the gateway removes
+                          the JWT after validation. When the token only needs to be forwarded to the selected backend,
+                          prefer `backendAuth.passthrough` so it is not exposed to other policies in the request path.
+                        type: boolean
                       providers:
                         items:
                           properties:
@@ -8893,11 +9703,8 @@ spec:
                                   properties:
                                     backendRef:
                                       description: |-
-                                        Remote JWKS server to reach.
-                                        Supported types are `Service` and static `Backend`. An
-                                        `AgentgatewayPolicy` containing backend TLS config can then be attached
-                                        to the `Service` or `Backend` in order to set TLS options for a
-                                        connection to the remote `jwks` source.
+                                        `backendRef` selects a backend for this policy.
+                                        Mutually exclusive with `url`.
                                       properties:
                                         group:
                                           default: ""
@@ -8946,24 +9753,44 @@ spec:
                                           == ''Service'') ? has(self.port) : true'
                                     cacheDuration:
                                       default: 5m
+                                      description: How long a fetched `jwks` document
+                                        is used before it is re-fetched from the IdP.
                                       maxLength: 32
+                                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                       type: string
                                       x-kubernetes-validations:
-                                      - message: invalid duration value
-                                        rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                                       - message: cacheDuration must be at least 5m.
                                         rule: duration(self) >= duration('5m')
                                     jwksPath:
                                       description: |-
                                         Path to the IdP `jwks` endpoint, relative to the root, commonly
                                         `".well-known/jwks.json"`.
-                                      maxLength: 2000
+                                      maxLength: 1024
                                       minLength: 1
                                       type: string
-                                  required:
-                                  - backendRef
-                                  - jwksPath
+                                    url:
+                                      description: |-
+                                        `url` directly specifies the HTTP(S) endpoint for this policy.
+                                        When the scheme is `https`, backend TLS is enabled automatically.
+                                        Mutually exclusive with `backendRef`.
+                                        URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                        will not apply Service policies or load balancing.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                      type: string
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: jwksPath is required when backendRef
+                                      is set
+                                    rule: 'has(self.backendRef) ? has(self.jwksPath)
+                                      : true'
+                                  - message: jwksPath may not be set when url is set
+                                    rule: 'has(self.url) ? !has(self.jwksPath) : true'
+                                  - message: exactly one of the fields in [backendRef
+                                      url] must be set
+                                    rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                      == 1'
                               type: object
                               x-kubernetes-validations:
                               - message: exactly one of the fields in [remote inline]
@@ -9034,8 +9861,8 @@ spec:
                                   properties:
                                     backendRef:
                                       description: |-
-                                        Rate limit server to reach.
-                                        Supported types: `Service` and `Backend`.
+                                        `backendRef` selects a backend for this policy.
+                                        Mutually exclusive with `url`.
                                       properties:
                                         group:
                                           default: ""
@@ -9133,6 +9960,17 @@ spec:
                                             maxItems: 16
                                             minItems: 1
                                             type: array
+                                          limitOverride:
+                                            description: |-
+                                              Common Expression Language (`CEL`) expression that returns a dynamic
+                                              limit override for this descriptor. The expression must evaluate to an
+                                              object containing `unit` and `requestsPerUnit`, for example
+                                              `{"unit":"minute","requestsPerUnit":5}`.
+
+                                              See https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.
+                                            maxLength: 16384
+                                            minLength: 1
+                                            type: string
                                           unit:
                                             description: |-
                                               Cost unit. If unspecified,
@@ -9163,11 +10001,28 @@ spec:
                                       - FailClosed
                                       - FailOpen
                                       type: string
+                                    url:
+                                      description: |-
+                                        `url` directly specifies the HTTP(S) endpoint for this policy.
+                                        When the scheme is `https`, backend TLS is enabled automatically.
+                                        Mutually exclusive with `backendRef`.
+                                        URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                                        will not apply Service policies or load balancing.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                                      type: string
                                   required:
-                                  - backendRef
                                   - descriptors
                                   - domain
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: url must not include a path
+                                    rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
+                                  - message: exactly one of the fields in [backendRef
+                                      url] must be set
+                                    rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                                      == 1'
                                 local:
                                   description: Local rate limiting policy.
                                   items:
@@ -9180,6 +10035,7 @@ spec:
                                           Allowance of requests above the request-per-unit
                                           that should be allowed within a short period of time.
                                         format: int32
+                                        minimum: 0
                                         type: integer
                                       requests:
                                         description: |-
@@ -9239,8 +10095,8 @@ spec:
                         properties:
                           backendRef:
                             description: |-
-                              Rate limit server to reach.
-                              Supported types: `Service` and `Backend`.
+                              `backendRef` selects a backend for this policy.
+                              Mutually exclusive with `url`.
                             properties:
                               group:
                                 default: ""
@@ -9335,6 +10191,17 @@ spec:
                                   maxItems: 16
                                   minItems: 1
                                   type: array
+                                limitOverride:
+                                  description: |-
+                                    Common Expression Language (`CEL`) expression that returns a dynamic
+                                    limit override for this descriptor. The expression must evaluate to an
+                                    object containing `unit` and `requestsPerUnit`, for example
+                                    `{"unit":"minute","requestsPerUnit":5}`.
+
+                                    See https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.
+                                  maxLength: 16384
+                                  minLength: 1
+                                  type: string
                                 unit:
                                   description: |-
                                     Cost unit. If unspecified,
@@ -9365,11 +10232,28 @@ spec:
                             - FailClosed
                             - FailOpen
                             type: string
+                          url:
+                            description: |-
+                              `url` directly specifies the HTTP(S) endpoint for this policy.
+                              When the scheme is `https`, backend TLS is enabled automatically.
+                              Mutually exclusive with `backendRef`.
+                              URLs are opaque; referencing a Kubernetes service hostname like `hello.ns.svc.cluster.local`
+                              will not apply Service policies or load balancing.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^https?://[^/?#@]+(/[^?#]*)?$
+                            type: string
                         required:
-                        - backendRef
                         - descriptors
                         - domain
                         type: object
+                        x-kubernetes-validations:
+                        - message: url must not include a path
+                          rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
+                        - message: exactly one of the fields in [backendRef url] must
+                            be set
+                          rule: '[has(self.backendRef),has(self.url)].filter(x,x==true).size()
+                            == 1'
                       local:
                         description: Local rate limiting policy.
                         items:
@@ -9382,6 +10266,7 @@ spec:
                                 Allowance of requests above the request-per-unit
                                 that should be allowed within a short period of time.
                               format: int32
+                              minimum: 0
                               type: integer
                             requests:
                               description: |-
@@ -9513,13 +10398,15 @@ spec:
                           Timeout for an individual request from the gateway to a backend. This covers the time from when
                           the request first starts being sent from the gateway to when the full response has been received from the backend.
                         maxLength: 32
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: invalid duration value
-                          rule: matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')
                         - message: request must be at least 1ms
-                          rule: duration(self) >= duration('100ms')
+                          rule: duration(self) >= duration('1ms')
                     type: object
+                    x-kubernetes-validations:
+                    - message: at least one of the fields in [request] must be set
+                      rule: '[has(self.request)].filter(x,x==true).size() >= 1'
                   transformation:
                     description: |-
                       Mutates and transforms requests and responses
@@ -10118,6 +11005,14 @@ spec:
               rule: 'has(self.targetSelectors) && has(self.traffic) && has(self.traffic.phase)
                 && self.traffic.phase == ''PreRouting'' ? self.targetSelectors.all(t,
                 t.kind in [''Gateway'', ''ListenerSet'']) : true'
+            - message: Service sectionName must be a numeric port from 1 to 65535
+              rule: '!has(self.targetRefs) || self.targetRefs.all(t, t.kind != ''Service''
+                || !has(t.sectionName) || (int(t.sectionName) >= 1 && int(t.sectionName)
+                <= 65535))'
+            - message: Service sectionName must be a numeric port from 1 to 65535
+              rule: '!has(self.targetSelectors) || self.targetSelectors.all(t, t.kind
+                != ''Service'' || !has(t.sectionName) || (int(t.sectionName) >= 1
+                && int(t.sectionName) <= 65535))'
             - message: exactly one of the fields in [targetRefs targetSelectors] must
                 be set
               rule: '[has(self.targetRefs),has(self.targetSelectors)].filter(x,x==true).size()


### PR DESCRIPTION
## What

Regenerate the `agentgateway-crds` chart from agentgateway [v1.5.0](https://github.com/agentgateway/agentgateway/releases/tag/v1.5.0) with `scripts/update_crds.sh` and bump `version`/`appVersion` to 1.5.0.

## Why

Stay on the supported agentgateway line: the `agentgateway` controller chart is bumped to v1.5.0 in wiremind-services-configuration right after this chart is released.

## Schema changes

Additive only. The four CRDs stay on `v1alpha1` (served+storage), none is removed, and a field-path diff of the four schemas shows 279 paths added and none removed:

| CRD | added paths |
|---|---|
| AgentgatewayBackend | 159 |
| AgentgatewayPolicy | 74 |
| AgentgatewayModel | 37 |
| AgentgatewayParameters | 9 |

Notable additions: `spec.spiffe` on AgentgatewayParameters, `connectTimeout` / `moderation` / `jwtSign` on backends and models, `finalTransformations` and multiple local rate limits on policies. The remaining deletions in the diff are reworded descriptions and validation messages.

Gateway API v1.6 is still the requirement, which `gateway-api-crds` already ships.

Ref: https://app.notion.com/p/3d5dcbda9c3581e0b96ad47e30c2d7a6