### PR TITLE
feat(ovh-exporter): fail on a key set in both extraEnv and extraSecretEnv

### DIFF
--- a/charts/ovh-exporter/Chart.yaml
+++ b/charts/ovh-exporter/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - api
   - exporter
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "v2.3.1"
 kubeVersion: ">=1.19.0-0"
 maintainers:

--- a/charts/ovh-exporter/templates/_helpers.tpl
+++ b/charts/ovh-exporter/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Stop rendering when a key is set in both extraEnv and extraSecretEnv.
+
+extraEnv lands in the ConfigMap and extraSecretEnv in the Secret, and the
+Deployment lists the ConfigMap first in envFrom, then the Secret. Kubernetes
+resolves a duplicate key in favour of the last source, so the Secret silently
+wins. Neither Helm nor `helm diff` reports it: both objects render fine, and
+the conflict only exists once they are merged into the container. Failing here
+turns that into a rendering error instead.
+*/}}
+{{- define "ovh-exporter.validateNoDuplicateEnvKey" -}}
+{{- $extraSecretEnv := .Values.extraSecretEnv | default dict }}
+{{- range $key, $_ := .Values.extraEnv | default dict }}
+{{- if hasKey $extraSecretEnv $key }}
+{{- fail (printf "%s is set in both extraEnv and extraSecretEnv. envFrom loads the Secret after the ConfigMap, so the Secret value would silently win. Keep the key in one of them only." $key) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ovh-exporter/templates/configmap.yaml
+++ b/charts/ovh-exporter/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "ovh-exporter.validateNoDuplicateEnvKey" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/ovh-exporter/templates/secret.yaml
+++ b/charts/ovh-exporter/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- include "ovh-exporter.validateNoDuplicateEnvKey" . -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Problem

`extraEnv` renders into the ConfigMap, `extraSecretEnv` into the Secret. The Deployment lists both in `envFrom`, ConfigMap first:

```yaml
envFrom:
  - configMapRef: { name: ovh-exporter }
  - secretRef:    { name: ovh-exporter }
```

Kubernetes resolves a duplicate key in favour of the last source, so the Secret silently wins over the ConfigMap.

This happened in production: `OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS` existed in both objects with different values. The ConfigMap held the current list of 10 OpenStack projects, the Secret an outdated list of 8. The exporter read the Secret, never scanned two projects, and reported every DNS record hosted there as a dangling floating IP.

Nothing reported the conflict. Both objects render as valid YAML, and `helm diff` compares manifests, not the merged container environment.

## Change

A `fail` guard in `_helpers.tpl`, included from `configmap.yaml` and `secret.yaml`, stops rendering when a key is present in both maps.

## Verification

Normal case still renders:

```console
$ helm template t charts/ovh-exporter --set extraEnv.FOO=bar --set extraSecretEnv.TOKEN=secret
...
kind: Secret
  TOKEN: c2VjcmV0
kind: ConfigMap
  FOO: "bar"
```

Duplicate key now fails with exit code 1:

```console
$ helm template t charts/ovh-exporter \
    --set extraEnv.OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS=ten \
    --set extraSecretEnv.OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS=eight
Error: execution error at (ovh-exporter/templates/secret.yaml:1:4): OVH_CLOUD_PROJECT_INVENTORY_PROJECT_IDS is set in both extraEnv and extraSecretEnv. envFrom loads the Secret after the ConfigMap, so the Secret value would silently win. Keep the key in one of them only.
```

`helm lint` passes with both the default values and `ci/default-values.yaml`.

## Note

Chart version bumped to 1.2.0. Existing releases that already set a key in both maps will now fail to render. That is the intended behaviour: such a release is already broken, only silently.